### PR TITLE
Change replace charcter

### DIFF
--- a/cwl_utils/image_puller.py
+++ b/cwl_utils/image_puller.py
@@ -59,8 +59,8 @@ class SingularityImagePuller(ImagePuller):
     """
     Pull docker image with Singularity
     """
-    CHARS_TO_REPLACE = ['/', ':']
-    NEW_CHAR = '-'
+    CHARS_TO_REPLACE = ['/']
+    NEW_CHAR = '_'
 
     def __init__(self, req, save_directory):
         super(SingularityImagePuller, self).__init__(req, save_directory)


### PR DESCRIPTION
cwltool 1.0.20190815141648

It do not convert `:`.
It uses '_' for replaced character

I checked at singularity version 3.x

```
$ singularity version
3.1.0-30.1.ohpc.1.3.7.1
```