### PR TITLE
expr: better escaping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ MODULE=cwl_utils
 # `[[` conditional expressions.
 PYSOURCES=$(filter-out cwl_utils/parser_v%,$(wildcard ${MODULE}/**.py tests/*.py)) setup.py
 DEVPKGS=diff_cover black pylint coverage pep257 pydocstyle flake8 mypy\
-	isort wheel
+	isort wheel autoflake
 DEBDEVPKGS=pep8 python-autopep8 pylint python-coverage pydocstyle sloccount \
 	   python-flake8 python-mock shellcheck
 VERSION=$(shell awk '{print $3}' < cwl_utils/__meta__.py )
@@ -80,6 +80,9 @@ clean: FORCE
 ## sorting imports using isort: https://github.com/timothycrosley/isort
 sort_imports: $(PYSOURCES)
 	isort $^
+
+remove_unused_imports: $(PYSOURCES)
+	autoflake --in-place --remove-all-unused-imports $^
 
 pep257: pydocstyle
 ## pydocstyle      : check Python code style

--- a/cwl_utils/cwl_expression_refactor.py
+++ b/cwl_utils/cwl_expression_refactor.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
 """CWL Expression refactoring tool for CWL."""
 import argparse
-import copy
-import hashlib
 import logging
 import shutil
 import sys
-from collections.abc import Mapping
 from pathlib import Path
 from typing import (
     Any,
@@ -15,23 +12,13 @@ from typing import (
     List,
     MutableSequence,
     Optional,
-    Sequence,
-    Text,
     Tuple,
-    Type,
     Union,
-    cast,
 )
 from typing_extensions import Protocol
 
-from cwltool.errors import WorkflowException
-from cwltool.expression import do_eval
 from cwltool.loghandler import _logger as _cwltoollogger
-from cwltool.sandboxjs import JavascriptException
-from cwltool.utils import CWLObjectType, CWLOutputType
 from ruamel import yaml
-from schema_salad.sourceline import SourceLine
-from schema_salad.utils import json_dumps
 
 from . import (
     cwl_v1_0_expression_refactor,

--- a/cwl_utils/cwl_expression_refactor.py
+++ b/cwl_utils/cwl_expression_refactor.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""CWL Expression refactoring tool for CWL."""
+import argparse
+import copy
+import hashlib
+import logging
+import shutil
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    MutableSequence,
+    Optional,
+    Sequence,
+    Text,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+from typing_extensions import Protocol
+
+from cwltool.errors import WorkflowException
+from cwltool.expression import do_eval
+from cwltool.loghandler import _logger as _cwltoollogger
+from cwltool.sandboxjs import JavascriptException
+from cwltool.utils import CWLObjectType, CWLOutputType
+from ruamel import yaml
+from schema_salad.sourceline import SourceLine
+from schema_salad.utils import json_dumps
+
+from . import (
+    cwl_v1_0_expression_refactor,
+    cwl_v1_1_expression_refactor,
+    cwl_v1_2_expression_refactor,
+    parser_v1_0,
+    parser_v1_1,
+    parser_v1_2,
+)
+
+_logger = logging.getLogger("cwl-expression-refactor")  # pylint: disable=invalid-name
+defaultStreamHandler = logging.StreamHandler()  # pylint: disable=invalid-name
+_logger.addHandler(defaultStreamHandler)
+_logger.setLevel(logging.INFO)
+_cwltoollogger.setLevel(100)
+
+save_type = Union[Dict[str, str], List[Union[Dict[str, str], List[Any], None]], None]
+
+
+class saveCWL(Protocol):
+    """Shortcut type for CWL v1.x parse.save()."""
+
+    def __call__(
+        self,
+        val: Optional[Union[Any, MutableSequence[Any]]],
+        top: bool = True,
+        base_url: str = "",
+        relative_uris: bool = True,
+    ) -> save_type:
+        """Must use this instead of a Callable due to the keyword args."""
+        ...
+
+
+def parse_args(args: List[str]) -> argparse.Namespace:
+    """Argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Tool to refactor CWL documents so that any CWL expression "
+        "are separate steps as either ExpressionTools or CommandLineTools. Exit code 7 "
+        "means a single CWL document was provided but it did not need modification."
+    )
+    parser.add_argument(
+        "--etools",
+        help="Output ExpressionTools, don't go all the way to CommandLineTools.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--skip-some1",
+        help="Don't process CommandLineTool.inputs.inputBinding and CommandLineTool.arguments sections.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--skip-some2",
+        help="Don't process CommandLineTool.outputEval or CommandLineTool.requirements.InitialWorkDirRequirement.",
+        action="store_true",
+    )
+    parser.add_argument("dir", help="Directory in which to save converted files")
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="One or more CWL documents.",
+    )
+    return parser.parse_args(args)
+
+
+def main(args: Optional[List[str]] = None) -> int:
+    """Collect the arguments and run."""
+    if not args:
+        args = sys.argv[1:]
+    return run(parse_args(args))
+
+
+def run(args: argparse.Namespace) -> int:
+    """Primary processing loop."""
+    for document in args.inputs:
+        _logger.info("Processing %s.", document)
+        with open(document, "r") as doc_handle:
+            result = yaml.main.round_trip_load(doc_handle, preserve_quotes=True)
+        version = result["cwlVersion"]
+        if version == "v1.0":
+            top = parser_v1_0.load_document_by_yaml(result, document)
+            traverse: Callable[
+                [Any, bool, bool, bool, bool], Tuple[Any, bool]
+            ] = cwl_v1_0_expression_refactor.traverse
+            save: saveCWL = parser_v1_0.save
+        elif version == "v1.1":
+            top = parser_v1_1.load_document_by_yaml(result, document)
+            traverse = cwl_v1_1_expression_refactor.traverse
+            save = parser_v1_1.save
+        elif version == "v1.2":
+            top = parser_v1_2.load_document_by_yaml(result, document)
+            traverse = cwl_v1_2_expression_refactor.traverse
+            save = parser_v1_2.save
+        else:
+            _logger.error(
+                "Sorry, %s is not a supported CWL version by this tool.", version
+            )
+            return -1
+        result, modified = traverse(
+            top, not args.etools, False, args.skip_some1, args.skip_some2
+        )
+        output = Path(args.dir) / Path(document).name
+        if not modified:
+            if len(args.inputs) > 1:
+                shutil.copyfile(document, output)
+                continue
+            else:
+                return 7
+        if not isinstance(result, MutableSequence):
+            result_json = save(
+                result,
+                base_url=result.loadingOptions.fileuri
+                if result.loadingOptions.fileuri
+                else "",
+            )
+        #   ^^ Setting the base_url and keeping the default value
+        #      for relative_uris=True means that the IDs in the generated
+        #      JSON/YAML are kept clean of the path to the input document
+        else:
+            result_json = [
+                save(result_item, base_url=result_item.loadingOptions.fileuri)
+                for result_item in result
+            ]
+        yaml.scalarstring.walk_tree(result_json)
+        # ^ converts multine line strings to nice multiline YAML
+        with open(output, "w", encoding="utf-8") as output_filehandle:
+            output_filehandle.write(
+                "#!/usr/bin/env cwl-runner\n"
+            )  # TODO: teach the codegen to do this?
+            yaml.round_trip_dump(result_json, output_filehandle)
+    return 0
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/cwl_utils/cwl_v1_0_expression_refactor.py
+++ b/cwl_utils/cwl_v1_0_expression_refactor.py
@@ -20,7 +20,6 @@ from typing import (
 
 from cwltool.errors import WorkflowException
 from cwltool.expression import do_eval, interpolate
-from cwltool.loghandler import _logger as _cwltoollogger
 from cwltool.sandboxjs import JavascriptException
 from cwltool.utils import CWLObjectType, CWLOutputType
 from ruamel import yaml
@@ -28,12 +27,6 @@ from schema_salad.sourceline import SourceLine
 from schema_salad.utils import json_dumps
 
 import cwl_utils.parser_v1_0 as cwl
-
-_logger = logging.getLogger("cwl-expression-refactor")  # pylint: disable=invalid-name
-defaultStreamHandler = logging.StreamHandler()  # pylint: disable=invalid-name
-_logger.addHandler(defaultStreamHandler)
-_logger.setLevel(logging.INFO)
-_cwltoollogger.setLevel(100)
 
 
 def expand_stream_shortcuts(process: cwl.CommandLineTool) -> cwl.CommandLineTool:
@@ -129,7 +122,7 @@ def get_expression(
                     fullJS=True,
                     escaping_behavior=2,
                     convert_to_expression=True,
-                )
+                ),
             )
     return None
 

--- a/cwl_utils/cwl_v1_0_expression_refactor.py
+++ b/cwl_utils/cwl_v1_0_expression_refactor.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 from cwltool.errors import WorkflowException
-from cwltool.expression import do_eval
+from cwltool.expression import do_eval, interpolate
 from cwltool.loghandler import _logger as _cwltoollogger
 from cwltool.sandboxjs import JavascriptException
 from cwltool.utils import CWLObjectType, CWLOutputType
@@ -184,6 +184,14 @@ def get_expression(
     if string.strip().startswith("${"):
         return string
     if "$(" in string:
+        runtime = {
+            "cores": 0,
+            "ram": 0,
+            "outdir": "/root",
+            "tmpdir": "/tmp",
+            "outdirSize": 0,
+            "tmpdirSize": 0,
+        }
         try:
             do_eval(
                 string,
@@ -195,9 +203,16 @@ def get_expression(
                 resources={},
             )
         except (WorkflowException, JavascriptException):
-            # TODO: what if the $() expr is in the middle of the string?
-            # TODO: what if there are multple $() expressions?
-            return "${return " + string.strip()[2:-1] + ";}"
+            return cast(
+                interpolate(
+                    scan=string,
+                    rootvars={"inputs": inputs, "context": self, "runtime": runtime},
+                    fullJS=True,
+                    escaping_behavior=2,
+                    convert_to_expression=True,
+                ),
+                str,
+            )
     return None
 
 
@@ -244,11 +259,10 @@ var runtime=$(runtime);"""
     contents += (
         """
 var ret = function(){"""
-        + etool.expression.strip()[2:-1]
+        + escape_expression_field(etool.expression.strip()[2:-1])
         + """}();
 process.stdout.write(JSON.stringify(ret));"""
     )
-    contents = escape_expression_field(contents)
     listing = [cwl.Dirent(entryname="expression.js", entry=contents, writable=None)]
     iwdr = cwl.InitialWorkDirRequirement(listing)
     containerReq = cwl.DockerRequirement(dockerPull="node:slim")
@@ -348,7 +362,15 @@ def traverse(
         else:
             return process, False
     if isinstance(process, cwl.ExpressionTool) and replace_etool:
-        return etool_to_cltool(process), True
+        expression = get_expression(process.expression, empty_inputs(process), None)
+        # Why call get_expression on an ExpressionTool?
+        # It normalizes the form of $() CWL expressions into the ${} style
+        if expression:
+            process2 = copy.deepcopy(process)
+            process2.expression = expression
+        else:
+            process2 = process
+        return etool_to_cltool(process2), True
     if isinstance(process, cwl.Workflow):
         return traverse_workflow(
             process, replace_etool, skip_command_line1, skip_command_line2
@@ -569,7 +591,9 @@ def replace_wf_input_ref_with_step_output(
 
 
 def empty_inputs(
-    process_or_step: Union[cwl.CommandLineTool, cwl.WorkflowStep, cwl.Workflow],
+    process_or_step: Union[
+        cwl.CommandLineTool, cwl.WorkflowStep, cwl.ExpressionTool, cwl.Workflow
+    ],
     parent: Optional[cwl.Workflow] = None,
 ) -> Dict[str, Any]:
     """Produce a mock input object for the given inputs."""
@@ -700,8 +724,9 @@ EMPTY_FILE: CWLOutputType = {
 
 TOPLEVEL_SF_EXPR_ERROR = (
     "Input '{}'. Sorry, CWL Expressions as part of a secondaryFiles "
-    "specification in a Workflow level input are not able to be refactored "
-    "into separate ExpressionTool/CommandLineTool steps."
+    "specification in a Workflow level input or standalone CommandLine Tool "
+    "are not able to be refactored into separate ExpressionTool or "
+    "CommandLineTool steps."
 )
 
 TOPLEVEL_FORMAT_EXPR_ERROR = (

--- a/cwl_utils/cwl_v1_0_expression_refactor.py
+++ b/cwl_utils/cwl_v1_0_expression_refactor.py
@@ -514,12 +514,18 @@ def empty_inputs(
             result[param.id.split("#")[-1]] = example_input(param.type)
     else:
         for param in process_or_step.in_:
-            try:
-                result[param.id.split("/")[-1]] = example_input(
-                    type_for_source(process_or_step.run, param.source, parent)
-                )
-            except WorkflowException:
-                pass
+            param_id = param.id.split("/")[-1]
+            if param.source is None and param.valueFrom:
+                result[param_id] = example_input("string")
+            elif param.source is None and param.default:
+                result[param_id] = param.default
+            else:
+                try:
+                    result[param_id] = example_input(
+                        type_for_source(process_or_step.run, param.source, parent)
+                    )
+                except WorkflowException:
+                    pass
     return result
 
 

--- a/cwl_utils/cwl_v1_0_expression_refactor.py
+++ b/cwl_utils/cwl_v1_0_expression_refactor.py
@@ -40,84 +40,6 @@ _logger.setLevel(logging.INFO)
 _cwltoollogger.setLevel(100)
 
 
-def parse_args(args: List[str]) -> argparse.Namespace:
-    """Argument parser."""
-    parser = argparse.ArgumentParser(
-        description="Tool to refactor CWL v1.0 documents so that any CWL expression "
-        "are separate steps as either ExpressionTools or CommandLineTools. Exit code 7 "
-        "means a single CWL document was provided but it did not need modification."
-    )
-    parser.add_argument(
-        "--etools",
-        help="Output ExpressionTools, don't go all the way to CommandLineTools.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--skip-some1",
-        help="Don't process CommandLineTool.inputs.inputBinding and CommandLineTool.arguments sections.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--skip-some2",
-        help="Don't process CommandLineTool.outputEval or CommandLineTool.requirements.InitialWorkDirRequirement.",
-        action="store_true",
-    )
-    parser.add_argument("dir", help="Directory in which to save converted files")
-    parser.add_argument(
-        "inputs",
-        nargs="+",
-        help="One or more CWL documents.",
-    )
-    return parser.parse_args(args)
-
-
-def main(args: Optional[List[str]] = None) -> int:
-    """Collect the arguments and run."""
-    if not args:
-        args = sys.argv[1:]
-    return run(parse_args(args))
-
-
-def run(args: argparse.Namespace) -> int:
-    """Load the first command line argument, print the results to stdout."""
-    for document in args.inputs:
-        _logger.info("Processing %s.", document)
-        top = cwl.load_document(document)
-        output = Path(args.dir) / Path(document).name
-        result, modified = traverse(
-            top, not args.etools, False, args.skip_some1, args.skip_some2
-        )
-        if not modified:
-            if len(args.inputs) > 1:
-                shutil.copyfile(document, output)
-                continue
-            else:
-                return 7
-        if not isinstance(result, MutableSequence):
-            result_json = cwl.save(
-                result,
-                base_url=result.loadingOptions.fileuri
-                if result.loadingOptions.fileuri
-                else "",
-            )
-        #   ^^ Setting the base_url and keeping the default value
-        #      for relative_uris=True means that the IDs in the generated
-        #      JSON/YAML are kept clean of the path to the input document
-        else:
-            result_json = [
-                cwl.save(result_item, base_url=result_item.loadingOptions.fileuri)
-                for result_item in result
-            ]
-        yaml.scalarstring.walk_tree(result_json)
-        # ^ converts multine line strings to nice multiline YAML
-        with open(output, "w", encoding="utf-8") as output_filehandle:
-            output_filehandle.write(
-                "#!/usr/bin/env cwl-runner\n"
-            )  # TODO: teach the codegen to do this?
-            yaml.round_trip_dump(result_json, output_filehandle)
-    return 0
-
-
 def expand_stream_shortcuts(process: cwl.CommandLineTool) -> cwl.CommandLineTool:
     """Rewrite the "type: stdout" shortcut to use an explicit random filename."""
     if not process.outputs:
@@ -184,7 +106,7 @@ def get_expression(
     if string.strip().startswith("${"):
         return string
     if "$(" in string:
-        runtime = {
+        runtime: CWLObjectType = {
             "cores": 0,
             "ram": 0,
             "outdir": "/root",
@@ -204,14 +126,14 @@ def get_expression(
             )
         except (WorkflowException, JavascriptException):
             return cast(
+                str,
                 interpolate(
                     scan=string,
                     rootvars={"inputs": inputs, "context": self, "runtime": runtime},
                     fullJS=True,
                     escaping_behavior=2,
                     convert_to_expression=True,
-                ),
-                str,
+                )
             )
     return None
 
@@ -2174,8 +2096,3 @@ def traverse_workflow(
     else:
         workflow.requirements = None
     return workflow, modified
-
-
-if __name__ == "__main__":
-    main()
-    sys.exit(0)

--- a/cwl_utils/cwl_v1_0_expression_refactor.py
+++ b/cwl_utils/cwl_v1_0_expression_refactor.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 """CWL Expression refactoring tool for CWL v1.0 ."""
-import argparse
 import copy
 import hashlib
 import logging
-import shutil
-import sys
 from collections.abc import Mapping
-from pathlib import Path
 from typing import (
     Any,
     Dict,

--- a/cwl_utils/cwl_v1_1_expression_refactor.py
+++ b/cwl_utils/cwl_v1_1_expression_refactor.py
@@ -2,7 +2,6 @@
 """CWL Expression refactoring tool for CWL v1.1 ."""
 import copy
 import hashlib
-import logging
 from collections.abc import Mapping
 from typing import (
     Any,
@@ -114,16 +113,29 @@ def get_expression(
                 resources={},
             )
         except (WorkflowException, JavascriptException):
-            return cast(
-                str,
-                interpolate(
-                    scan=string,
-                    rootvars={"inputs": inputs, "context": self, "runtime": runtime},
-                    fullJS=True,
-                    escaping_behavior=2,
-                    convert_to_expression=True,
-                ),
-            )
+            if (
+                string[0:2] != "$("
+                or not string.endswith(")")
+                or len(string.split("$(")) > 2
+            ):
+                # then it is a string interpolation
+                return cast(
+                    str,
+                    interpolate(
+                        scan=string,
+                        rootvars={
+                            "inputs": inputs,
+                            "context": self,
+                            "runtime": runtime,
+                        },
+                        fullJS=True,
+                        escaping_behavior=2,
+                        convert_to_expression=True,
+                    ),
+                )
+            else:
+                # it is a CWL Expression in $() with no string interpolation
+                return "${return " + string.strip()[2:-1] + ";}"
     return None
 
 

--- a/cwl_utils/cwl_v1_1_expression_refactor.py
+++ b/cwl_utils/cwl_v1_1_expression_refactor.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 """CWL Expression refactoring tool for CWL v1.1 ."""
-import argparse
 import copy
 import hashlib
 import logging
-import shutil
-import sys
 from collections.abc import Mapping
-from pathlib import Path
 from typing import (
     Any,
     Dict,

--- a/cwl_utils/cwl_v1_1_expression_refactor.py
+++ b/cwl_utils/cwl_v1_1_expression_refactor.py
@@ -20,7 +20,6 @@ from typing import (
 
 from cwltool.errors import WorkflowException
 from cwltool.expression import do_eval, interpolate
-from cwltool.loghandler import _logger as _cwltoollogger
 from cwltool.sandboxjs import JavascriptException
 from cwltool.utils import CWLObjectType, CWLOutputType
 from ruamel import yaml
@@ -28,12 +27,6 @@ from schema_salad.sourceline import SourceLine
 from schema_salad.utils import json_dumps
 
 import cwl_utils.parser_v1_1 as cwl
-
-_logger = logging.getLogger("cwl-expression-refactor")  # pylint: disable=invalid-name
-defaultStreamHandler = logging.StreamHandler()  # pylint: disable=invalid-name
-_logger.addHandler(defaultStreamHandler)
-_logger.setLevel(logging.INFO)
-_cwltoollogger.setLevel(100)
 
 
 def expand_stream_shortcuts(process: cwl.CommandLineTool) -> cwl.CommandLineTool:
@@ -129,7 +122,7 @@ def get_expression(
                     fullJS=True,
                     escaping_behavior=2,
                     convert_to_expression=True,
-                )
+                ),
             )
     return None
 

--- a/cwl_utils/cwl_v1_2_expression_refactor.py
+++ b/cwl_utils/cwl_v1_2_expression_refactor.py
@@ -2,7 +2,6 @@
 """CWL Expression refactoring tool for CWL v1.2 ."""
 import copy
 import hashlib
-import logging
 from collections.abc import Mapping
 from typing import (
     Any,
@@ -114,16 +113,29 @@ def get_expression(
                 resources={},
             )
         except (WorkflowException, JavascriptException):
-            return cast(
-                str,
-                interpolate(
-                    scan=string,
-                    rootvars={"inputs": inputs, "context": self, "runtime": runtime},
-                    fullJS=True,
-                    escaping_behavior=2,
-                    convert_to_expression=True,
-                ),
-            )
+            if (
+                string[0:2] != "$("
+                or not string.endswith(")")
+                or len(string.split("$(")) > 2
+            ):
+                # then it is a string interpolation
+                return cast(
+                    str,
+                    interpolate(
+                        scan=string,
+                        rootvars={
+                            "inputs": inputs,
+                            "context": self,
+                            "runtime": runtime,
+                        },
+                        fullJS=True,
+                        escaping_behavior=2,
+                        convert_to_expression=True,
+                    ),
+                )
+            else:
+                # it is a CWL Expression in $() with no string interpolation
+                return "${return " + string.strip()[2:-1] + ";}"
     return None
 
 

--- a/cwl_utils/cwl_v1_2_expression_refactor.py
+++ b/cwl_utils/cwl_v1_2_expression_refactor.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 """CWL Expression refactoring tool for CWL v1.2 ."""
-import argparse
 import copy
 import hashlib
 import logging
-import shutil
-import sys
 from collections.abc import Mapping
-from pathlib import Path
 from typing import (
     Any,
     Dict,

--- a/cwl_utils/cwl_v1_2_expression_refactor.py
+++ b/cwl_utils/cwl_v1_2_expression_refactor.py
@@ -20,7 +20,6 @@ from typing import (
 
 from cwltool.errors import WorkflowException
 from cwltool.expression import do_eval, interpolate
-from cwltool.loghandler import _logger as _cwltoollogger
 from cwltool.sandboxjs import JavascriptException
 from cwltool.utils import CWLObjectType, CWLOutputType
 from ruamel import yaml
@@ -28,12 +27,6 @@ from schema_salad.sourceline import SourceLine
 from schema_salad.utils import json_dumps
 
 import cwl_utils.parser_v1_2 as cwl
-
-_logger = logging.getLogger("cwl-expression-refactor")  # pylint: disable=invalid-name
-defaultStreamHandler = logging.StreamHandler()  # pylint: disable=invalid-name
-_logger.addHandler(defaultStreamHandler)
-_logger.setLevel(logging.INFO)
-_cwltoollogger.setLevel(100)
 
 
 def expand_stream_shortcuts(process: cwl.CommandLineTool) -> cwl.CommandLineTool:
@@ -129,7 +122,7 @@ def get_expression(
                     fullJS=True,
                     escaping_behavior=2,
                     convert_to_expression=True,
-                )
+                ),
             )
     return None
 

--- a/cwl_utils/cwl_v1_2_expression_refactor.py
+++ b/cwl_utils/cwl_v1_2_expression_refactor.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 from cwltool.errors import WorkflowException
-from cwltool.expression import do_eval
+from cwltool.expression import do_eval, interpolate
 from cwltool.loghandler import _logger as _cwltoollogger
 from cwltool.sandboxjs import JavascriptException
 from cwltool.utils import CWLObjectType, CWLOutputType
@@ -184,6 +184,14 @@ def get_expression(
     if string.strip().startswith("${"):
         return string
     if "$(" in string:
+        runtime = {
+            "cores": 0,
+            "ram": 0,
+            "outdir": "/root",
+            "tmpdir": "/tmp",
+            "outdirSize": 0,
+            "tmpdirSize": 0,
+        }
         try:
             do_eval(
                 string,
@@ -195,9 +203,16 @@ def get_expression(
                 resources={},
             )
         except (WorkflowException, JavascriptException):
-            # TODO: what if the $() expr is in the middle of the string?
-            # TODO: what if there are multple $() expressions?
-            return "${return " + string.strip()[2:-1] + ";}"
+            return cast(
+                interpolate(
+                    scan=string,
+                    rootvars={"inputs": inputs, "context": self, "runtime": runtime},
+                    fullJS=True,
+                    escaping_behavior=2,
+                    convert_to_expression=True,
+                ),
+                str,
+            )
     return None
 
 
@@ -244,11 +259,10 @@ var runtime=$(runtime);"""
     contents += (
         """
 var ret = function(){"""
-        + etool.expression.strip()[2:-1]
+        + escape_expression_field(etool.expression.strip()[2:-1])
         + """}();
 process.stdout.write(JSON.stringify(ret));"""
     )
-    contents = escape_expression_field(contents)
     listing = [cwl.Dirent(entryname="expression.js", entry=contents, writable=None)]
     iwdr = cwl.InitialWorkDirRequirement(listing)
     containerReq = cwl.DockerRequirement(dockerPull="node:slim")
@@ -348,7 +362,15 @@ def traverse(
         else:
             return process, False
     if isinstance(process, cwl.ExpressionTool) and replace_etool:
-        return etool_to_cltool(process), True
+        expression = get_expression(process.expression, empty_inputs(process), None)
+        # Why call get_expression on an ExpressionTool?
+        # It normalizes the form of $() CWL expressions into the ${} style
+        if expression:
+            process2 = copy.deepcopy(process)
+            process2.expression = expression
+        else:
+            process2 = process
+        return etool_to_cltool(process2), True
     if isinstance(process, cwl.Workflow):
         return traverse_workflow(
             process, replace_etool, skip_command_line1, skip_command_line2
@@ -569,7 +591,9 @@ def replace_wf_input_ref_with_step_output(
 
 
 def empty_inputs(
-    process_or_step: Union[cwl.CommandLineTool, cwl.WorkflowStep, cwl.Workflow],
+    process_or_step: Union[
+        cwl.CommandLineTool, cwl.WorkflowStep, cwl.ExpressionTool, cwl.Workflow
+    ],
     parent: Optional[cwl.Workflow] = None,
 ) -> Dict[str, Any]:
     """Produce a mock input object for the given inputs."""

--- a/cwl_utils/cwl_v1_2_expression_refactor.py
+++ b/cwl_utils/cwl_v1_2_expression_refactor.py
@@ -40,84 +40,6 @@ _logger.setLevel(logging.INFO)
 _cwltoollogger.setLevel(100)
 
 
-def parse_args(args: List[str]) -> argparse.Namespace:
-    """Argument parser."""
-    parser = argparse.ArgumentParser(
-        description="Tool to refactor CWL v1.2 documents so that any CWL expression "
-        "are separate steps as either ExpressionTools or CommandLineTools. Exit code 7 "
-        "means a single CWL document was provided but it did not need modification."
-    )
-    parser.add_argument(
-        "--etools",
-        help="Output ExpressionTools, don't go all the way to CommandLineTools.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--skip-some1",
-        help="Don't process CommandLineTool.inputs.inputBinding and CommandLineTool.arguments sections.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--skip-some2",
-        help="Don't process CommandLineTool.outputEval or CommandLineTool.requirements.InitialWorkDirRequirement.",
-        action="store_true",
-    )
-    parser.add_argument("dir", help="Directory in which to save converted files")
-    parser.add_argument(
-        "inputs",
-        nargs="+",
-        help="One or more CWL documents.",
-    )
-    return parser.parse_args(args)
-
-
-def main(args: Optional[List[str]] = None) -> int:
-    """Collect the arguments and run."""
-    if not args:
-        args = sys.argv[1:]
-    return run(parse_args(args))
-
-
-def run(args: argparse.Namespace) -> int:
-    """Load the first command line argument, print the results to stdout."""
-    for document in args.inputs:
-        _logger.info("Processing %s.", document)
-        top = cwl.load_document(document)
-        output = Path(args.dir) / Path(document).name
-        result, modified = traverse(
-            top, not args.etools, False, args.skip_some1, args.skip_some2
-        )
-        if not modified:
-            if len(args.inputs) > 1:
-                shutil.copyfile(document, output)
-                continue
-            else:
-                return 7
-        if not isinstance(result, MutableSequence):
-            result_json = cwl.save(
-                result,
-                base_url=result.loadingOptions.fileuri
-                if result.loadingOptions.fileuri
-                else "",
-            )
-        #   ^^ Setting the base_url and keeping the default value
-        #      for relative_uris=True means that the IDs in the generated
-        #      JSON/YAML are kept clean of the path to the input document
-        else:
-            result_json = [
-                cwl.save(result_item, base_url=result_item.loadingOptions.fileuri)
-                for result_item in result
-            ]
-        yaml.scalarstring.walk_tree(result_json)
-        # ^ converts multine line strings to nice multiline YAML
-        with open(output, "w", encoding="utf-8") as output_filehandle:
-            output_filehandle.write(
-                "#!/usr/bin/env cwl-runner\n"
-            )  # TODO: teach the codegen to do this?
-            yaml.round_trip_dump(result_json, output_filehandle)
-    return 0
-
-
 def expand_stream_shortcuts(process: cwl.CommandLineTool) -> cwl.CommandLineTool:
     """Rewrite the "type: stdout" shortcut to use an explicit random filename."""
     if not process.outputs:
@@ -184,7 +106,7 @@ def get_expression(
     if string.strip().startswith("${"):
         return string
     if "$(" in string:
-        runtime = {
+        runtime: CWLObjectType = {
             "cores": 0,
             "ram": 0,
             "outdir": "/root",
@@ -204,14 +126,14 @@ def get_expression(
             )
         except (WorkflowException, JavascriptException):
             return cast(
+                str,
                 interpolate(
                     scan=string,
                     rootvars={"inputs": inputs, "context": self, "runtime": runtime},
                     fullJS=True,
                     escaping_behavior=2,
                     convert_to_expression=True,
-                ),
-                str,
+                )
             )
     return None
 
@@ -2350,8 +2272,3 @@ def traverse_workflow(
     else:
         workflow.requirements = None
     return workflow, modified
-
-
-if __name__ == "__main__":
-    main()
-    sys.exit(0)

--- a/cwl_utils/graph_split.py
+++ b/cwl_utils/graph_split.py
@@ -8,9 +8,7 @@ Only tested with a single v1.0 workflow.
 import argparse
 import json
 import os
-import sys
-from pathlib import Path
-from typing import IO, Any, Dict, List, MutableMapping, Set, Text, Union, cast
+from typing import Any, IO, MutableMapping, Set, Text, Union, cast
 
 from cwlformat.formatter import stringify_dict
 from ruamel import yaml

--- a/cwl_utils/image_puller.py
+++ b/cwl_utils/image_puller.py
@@ -17,12 +17,10 @@ class ImagePuller(ABC):
     @abstractmethod
     def get_image_name(self) -> str:
         """Get the engine-specific image name."""
-        pass
 
     @abstractmethod
     def save_docker_image(self) -> None:
         """Download and save the image to disk."""
-        pass
 
     @staticmethod
     def _run_command_pull(cmd_pull: List[str]) -> None:

--- a/cwl_utils/parser_v1_1.py
+++ b/cwl_utils/parser_v1_1.py
@@ -12145,3 +12145,17 @@ def load_document_by_string(string, uri, loadingOptions=None):
     loadingOptions.idx[uri] = result
 
     return _document_load(union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader, result, uri, loadingOptions)
+
+
+def load_document_by_yaml(yaml, uri, loadingOptions=None):
+    # type: (Any, str, Optional[LoadingOptions]) -> Any
+    '''Shortcut to load via a YAML object.
+    yaml: must be from ruamel.yaml.main.round_trip_load with preserve_quotes=True
+    '''
+    add_lc_filename(yaml, uri)
+
+    if loadingOptions is None:
+        loadingOptions = LoadingOptions(fileuri=uri)
+    loadingOptions.idx[uri] = yaml
+
+    return _document_load(union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader, yaml, uri, loadingOptions)

--- a/cwl_utils/parser_v1_2.py
+++ b/cwl_utils/parser_v1_2.py
@@ -13309,3 +13309,17 @@ def load_document_by_string(string, uri, loadingOptions=None):
     loadingOptions.idx[uri] = result
 
     return _document_load(union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader, result, uri, loadingOptions)
+
+
+def load_document_by_yaml(yaml, uri, loadingOptions=None):
+    # type: (Any, str, Optional[LoadingOptions]) -> Any
+    '''Shortcut to load via a YAML object.
+    yaml: must be from ruamel.yaml.main.round_trip_load with preserve_quotes=True
+    '''
+    add_lc_filename(yaml, uri)
+
+    if loadingOptions is None:
+        loadingOptions = LoadingOptions(fileuri=uri)
+    loadingOptions.idx[uri] = yaml
+
+    return _document_load(union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader, yaml, uri, loadingOptions)

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,7 @@ setup(
     test_suite="tests",
     scripts=[
         "cwl_utils/docker_extract.py",
-        "cwl_utils/cwl_v1_0_expression_refactor.py",
-        "cwl_utils/cwl_v1_1_expression_refactor.py",
-        "cwl_utils/cwl_v1_2_expression_refactor.py",
+        "cwl_utils/cwl_expression_refactor.py",
         "cwl_utils/cite_extract.py",
         "cwl_utils/graph_split.py",
     ],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "requests",
         "schema-salad >= 7, < 8",
         "typing_extensions",
-        "cwltool",
+        "cwltool >= 3.0.20201113183607",
         "cwlformat",
     ],
     setup_requires=[] + pytest_runner,

--- a/tests/test_docker_extract.py
+++ b/tests/test_docker_extract.py
@@ -1,7 +1,6 @@
 from os import environ
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest import skipIf
 
 import pytest
 

--- a/tests/test_graph_split.py
+++ b/tests/test_graph_split.py
@@ -2,7 +2,6 @@
 import os
 from io import StringIO
 from pathlib import Path
-from unittest import TestCase
 
 import requests
 


### PR DESCRIPTION
Fixes #46 

- [x] requires that https://github.com/common-workflow-language/cwltool/pull/1371 is merged and a new cwltool released

Is able to process all the `*.cwl` files in the CWL v1.0 conformance tests; and for CWL v1.1 all except `tmap-tool.cwl` (parser error) `docker-array-secondaryfiles.cwl` (stand alone CommandLineTool with dynamic secondaryfiles is not supported) and for CWL v1.2 `secondaryfiles/rename-inputs.cwl` is not supported for the same reason as  `docker-array-secondaryfiles.cwl` ;`*mixed-version*` files are not yet supported (but will be much easier to do so next)

Also moved to "all in one" script for expression refactoring for CWL version v1.0, v1.1, v1.2 combined.