### PR TITLE
Fix typo in parser example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ elif yaml_obj['cwlVersion'] == 'v1.1':
 elif yaml_obj['cwlVersion'] == 'v1.2':
     from cwl_utils import parser_v1_2 as parser
 else:
-    print("Version error. Did not recognise {} as a CWL version".format(yaml_obj["CWLVersion"]))
+    print("Version error. Did not recognise {} as a CWL version".format(yaml_obj["cwlVersion"]))
     sys.exit(1)
 
 # Import CWL Object


### PR DESCRIPTION
It fixes `yaml_obj["CWLVersion"]` to `yaml_obj["cwlVersion"]`.