### PR TITLE
Check singularity image already cached

### DIFF
--- a/cwl_utils/docker_extract.py
+++ b/cwl_utils/docker_extract.py
@@ -37,6 +37,9 @@ def arg_parser() -> argparse.ArgumentParser:
         help="Specify which command to use to run OCI containers. "
         "Defaults to 'docker' (or 'singularity' if --singularity/-s is passed).",
     )
+    parser.add_argument(
+        "--force-download", help="Force pulling a newer container.", action="store_true"
+    )
     return parser
 
 
@@ -64,6 +67,7 @@ def run(args: argparse.Namespace) -> List[cwl.DockerRequirement]:
                 args.container_engine
                 if args.container_engine is not None
                 else "singularity",
+                args.force_download,
             )
         else:
             image_puller = DockerImagePuller(
@@ -72,6 +76,7 @@ def run(args: argparse.Namespace) -> List[cwl.DockerRequirement]:
                 args.container_engine
                 if args.container_engine is not None
                 else "docker",
+                args.force_download,
             )
         image_puller.save_docker_image()
     return reqs

--- a/tests/test_docker_extract.py
+++ b/tests/test_docker_extract.py
@@ -39,6 +39,42 @@ def test_container_extraction(target: str, engine: str, tmp_path: Path) -> None:
         pytest.param("singularity", marks=needs_singularity),
     ],
 )
+def test_container_extraction_force(engine: str, tmp_path: Path) -> None:
+    """Test force pull container extraction."""
+
+    args = [
+        str(tmp_path),
+        get_data("testdata/md5sum.cwl"),
+        "--container-engine",
+        engine,
+    ]
+    if engine == "singularity":
+        args.append("--singularity")
+    reqs = run(arg_parser().parse_args(args))
+    assert len(reqs) == 1
+    assert len(list(tmp_path.iterdir())) == 1
+    args = [
+        str(tmp_path),
+        get_data("testdata/md5sum.cwl"),
+        "--container-engine",
+        engine,
+        "--force-download",
+    ]
+    if engine == "singularity":
+        args.append("--singularity")
+    reqs = run(arg_parser().parse_args(args))
+    assert len(reqs) == 1
+    assert len(list(tmp_path.iterdir())) == 1
+
+
+@pytest.mark.parametrize(
+    ("engine"),
+    [
+        pytest.param("docker", marks=needs_docker),
+        pytest.param("podman", marks=needs_podman),
+        pytest.param("singularity", marks=needs_singularity),
+    ],
+)
 def test_container_extraction_no_dockerPull(
     engine: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
If there is already exists singularity image under cache directory , `singularity pull` causes error.
To avoid error, check whether singularity image is exists or not.