### PR TITLE
Failed to run `python3 setup.py install` in a new docker environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "cwltool >= 3.0.20201113183607",
         "cwlformat",
         "cwl-upgrader >= 1.2",
+        "ruamel.yaml==0.16.12",
     ],
     setup_requires=[] + pytest_runner,
     tests_require=["pytest<7", "cwltool"],


### PR DESCRIPTION
Failed to run `python3 setup.py install` in a new docker environment.

```bash=
ubuntu@dh236 ~/git/git/sue/cwl-utils (main)> 
docker run -it --rm -v $PWD:/work -w /work docker.io/python:3.8-slim-buster bash
root@df42a1ddd7ca:/work# python3 setup.py install
running install
running bdist_egg
running egg_info
...

Installing ruamel.yaml-0.17.10-py3-none-any.whl to /usr/local/lib/python3.8/site-packages
Adding ruamel.yaml 0.17.10 to easy-install.pth file

Installed /usr/local/lib/python3.8/site-packages/ruamel.yaml-0.17.10-py3.8.egg
error: ruamel.yaml 0.17.10 is installed but ruamel.yaml==0.16.12 is required by {'cwlformat'}
```

This problem seems to occur because the version of `ruamel.yaml` is specified in [GitHub - rabix/cwl-format - setup.py](https://github.com/rabix/cwl-format/blob/dcad27b7d5a077eb080136acc186c8d7ca0e4af2/setup.py#L33).
So fixing the version of `ruamel.yaml` in cwl-utils's `setup.py` solved this problem.

I know that fixing the version of `ruamel.yaml` might cause more problems.
Maybe the `cwl-format` package should be fixed.
I'll create this PR as a report of the problem.