### PR TITLE
Make `load_document_by_path` applicable to a URI with `http` and `https` schemes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,13 +69,13 @@ Using the CWL Parsers
    from ruamel import yaml
    import sys
 
-   from cwl_utils.parser import load_document_by_path, save
+   from cwl_utils.parser import load_document_by_uri, save
 
    # File Input - This is the only thing you will need to adjust or take in as an input to your function:
    cwl_file = Path("testdata/md5sum.cwl")  # or a plain string works as well
 
    # Import CWL Object
-   cwl_obj = load_document_by_path(cwl_file)
+   cwl_obj = load_document_by_uri(cwl_file)
 
    # View CWL Object
    print("List of object attributes:\n{}".format("\n".join(map(str, dir(cwl_obj)))))

--- a/cwl_utils/parser/__init__.py
+++ b/cwl_utils/parser/__init__.py
@@ -85,7 +85,8 @@ def load_document_by_uri(
         loadingOptions = cwl_v1_2.LoadingOptions(fileuri=baseuri)
 
     doc = loadingOptions.fetcher.fetch_text(real_path)
-    assert doc is not None
+    if doc is not None:
+        raise AssertionError("fetch_text returns None")
     return load_document_by_string(doc, baseuri, loadingOptions)
 
 
@@ -108,7 +109,8 @@ def load_document_by_string(
     """Load a CWL object from a serialized YAML string."""
     yaml = yaml_no_ts()
     result = yaml.load(string)
-    assert result is not None
+    if result is not None:
+        raise AssertionError("yaml.load returns None")
     return load_document_by_yaml(result, uri, loadingOptions)
 
 

--- a/cwl_utils/parser/__init__.py
+++ b/cwl_utils/parser/__init__.py
@@ -65,11 +65,11 @@ def cwl_version(yaml: Any) -> Any:
     return yaml["cwlVersion"]
 
 
-def load_document_by_path(
+def load_document_by_uri(
     path: Union[str, Path],
     loadingOptions: Optional[LoadingOptions] = None,
 ) -> Any:
-    """Load a CWL object from a path."""
+    """Load a CWL object from a URI or a path."""
     if isinstance(path, str):
         uri = urlparse(path)
         if not uri.scheme or uri.scheme == "file":

--- a/cwl_utils/parser/__init__.py
+++ b/cwl_utils/parser/__init__.py
@@ -85,6 +85,7 @@ def load_document_by_uri(
         loadingOptions = cwl_v1_2.LoadingOptions(fileuri=baseuri)
 
     doc = loadingOptions.fetcher.fetch_text(real_path)
+    assert doc is not None
     return load_document_by_string(doc, baseuri, loadingOptions)
 
 
@@ -107,6 +108,7 @@ def load_document_by_string(
     """Load a CWL object from a serialized YAML string."""
     yaml = yaml_no_ts()
     result = yaml.load(string)
+    assert result is not None
     return load_document_by_yaml(result, uri, loadingOptions)
 
 

--- a/cwl_utils/parser/__init__.py
+++ b/cwl_utils/parser/__init__.py
@@ -85,7 +85,7 @@ def load_document_by_uri(
         loadingOptions = cwl_v1_2.LoadingOptions(fileuri=baseuri)
 
     doc = loadingOptions.fetcher.fetch_text(real_path)
-    if doc is not None:
+    if doc is None:
         raise AssertionError("fetch_text returns None")
     return load_document_by_string(doc, baseuri, loadingOptions)
 
@@ -109,7 +109,7 @@ def load_document_by_string(
     """Load a CWL object from a serialized YAML string."""
     yaml = yaml_no_ts()
     result = yaml.load(string)
-    if result is not None:
+    if result is None:
         raise AssertionError("yaml.load returns None")
     return load_document_by_yaml(result, uri, loadingOptions)
 

--- a/cwl_utils/parser/__init__.py
+++ b/cwl_utils/parser/__init__.py
@@ -85,8 +85,6 @@ def load_document_by_uri(
         loadingOptions = cwl_v1_2.LoadingOptions(fileuri=baseuri)
 
     doc = loadingOptions.fetcher.fetch_text(real_path)
-    if doc is None:
-        raise AssertionError("fetch_text returns None")
     return load_document_by_string(doc, baseuri, loadingOptions)
 
 
@@ -109,8 +107,6 @@ def load_document_by_string(
     """Load a CWL object from a serialized YAML string."""
     yaml = yaml_no_ts()
     result = yaml.load(string)
-    if result is None:
-        raise AssertionError("yaml.load returns None")
     return load_document_by_yaml(result, uri, loadingOptions)
 
 

--- a/tests/load_cwl_by_path.py
+++ b/tests/load_cwl_by_path.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from ruamel import yaml
 import sys
 
-from cwl_utils.parser import load_document_by_path, save
+from cwl_utils.parser import load_document_by_uri, save
 
 # File Input - This is the only thing you will need to adjust or take in as an input to your function:
 cwl_file = Path("testdata/md5sum.cwl")  # or a plain string works as well
 
 # Import CWL Object
-cwl_obj = load_document_by_path(cwl_file)
+cwl_obj = load_document_by_uri(cwl_file)
 
 # View CWL Object
 print("List of object attributes:\n{}".format("\n".join(map(str, dir(cwl_obj)))))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,5 @@
 """Test the load and save functions for CWL."""
-from cwl_utils.parser import cwl_version, load_document, load_document_by_path, save
+from cwl_utils.parser import cwl_version, load_document, load_document_by_uri, save
 from pathlib import Path
 from ruamel import yaml
 
@@ -28,7 +28,7 @@ def test_load_document() -> None:
 
 def test_load_document_with_uri() -> None:
     """Test load_document for a CommandLineTool in a remote URI."""
-    cwl_obj = load_document_by_path(TEST_v1_0_CWL_REMOTE)
+    cwl_obj = load_document_by_uri(TEST_v1_0_CWL_REMOTE)
     assert cwl_obj.cwlVersion == "v1.0"
     assert cwl_obj.inputs[0].id.endswith("input_file")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,10 +1,11 @@
 """Test the load and save functions for CWL."""
-from cwl_utils.parser import cwl_version, load_document, save
+from cwl_utils.parser import cwl_version, load_document, load_document_by_path, save
 from pathlib import Path
 from ruamel import yaml
 
 HERE = Path(__file__).resolve().parent
 TEST_v1_0_CWL = HERE / "../testdata/md5sum.cwl"
+TEST_v1_0_CWL_REMOTE = "https://raw.githubusercontent.com/common-workflow-language/cwl-utils/main/testdata/md5sum.cwl"
 TEST_v1_2_CWL = HERE / "../testdata/workflow_input_format_expr_v1_2.cwl"
 
 
@@ -21,6 +22,13 @@ def test_load_document() -> None:
     with open(TEST_v1_0_CWL, "r") as cwl_h:
         yaml_obj = yaml.main.round_trip_load(cwl_h, preserve_quotes=True)
     cwl_obj = load_document(yaml_obj)
+    assert cwl_obj.cwlVersion == "v1.0"
+    assert cwl_obj.inputs[0].id.endswith("input_file")
+
+
+def test_load_document_with_uri() -> None:
+    """Test load_document for a CommandLineTool in a remote URI."""
+    cwl_obj = load_document_by_path(TEST_v1_0_CWL_REMOTE)
     assert cwl_obj.cwlVersion == "v1.0"
     assert cwl_obj.inputs[0].id.endswith("input_file")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -26,7 +26,16 @@ def test_load_document() -> None:
     assert cwl_obj.inputs[0].id.endswith("input_file")
 
 
-def test_load_document_with_uri() -> None:
+def test_load_document_with_local_uri() -> None:
+    """Test load_document for a CommandLineTool in a local URI."""
+    uri = Path(TEST_v1_0_CWL).resolve().as_uri()
+    assert uri.startswith("file://")
+    cwl_obj = load_document_by_uri(uri)
+    assert cwl_obj.cwlVersion == "v1.0"
+    assert cwl_obj.inputs[0].id.endswith("input_file")
+
+
+def test_load_document_with_remote_uri() -> None:
     """Test load_document for a CommandLineTool in a remote URI."""
     cwl_obj = load_document_by_uri(TEST_v1_0_CWL_REMOTE)
     assert cwl_obj.cwlVersion == "v1.0"


### PR DESCRIPTION
`load_document` family can load remote documents in `$import` and `$include` directives with `LoadingOptions#fetcher`.

However, `load_document_by_path` only accepts a URI with `file` scheme or a local path.

This request makes it applicable to a URI with `http` and `https` schemes with a given `LoadingOptions#fetcher` or `DefaultFetcher`.
This request enables users to directly handle URIs with other schemes such as `s3`, `gs` by implementing their own `Fetcher`.

Notes:
- After merging this request, `load_document_by_path` can handle any URIs (if users can provide an appropriate fetcher) in addition to local paths. Can we rename `load_document_by_path` `load_document_by_uri`?
- I added a test for remote URI but it is a little bit fragile because it refers an external resource.