### PR TITLE
Add cwl_utils.parser.latest

### DIFF
--- a/cwl_utils/parser/__init__.py
+++ b/cwl_utils/parser/__init__.py
@@ -5,7 +5,6 @@ from schema_salad.utils import yaml_no_ts
 from . import cwl_v1_0 as cwl_v1_0
 from . import cwl_v1_1 as cwl_v1_1
 from . import cwl_v1_2 as cwl_v1_2
-from . import latest as latest
 
 import os
 from pathlib import Path

--- a/cwl_utils/parser/__init__.py
+++ b/cwl_utils/parser/__init__.py
@@ -5,6 +5,7 @@ from schema_salad.utils import yaml_no_ts
 from . import cwl_v1_0 as cwl_v1_0
 from . import cwl_v1_1 as cwl_v1_1
 from . import cwl_v1_2 as cwl_v1_2
+from . import latest as latest
 
 import os
 from pathlib import Path

--- a/cwl_utils/parser/latest.py
+++ b/cwl_utils/parser/latest.py
@@ -1,1 +1,1 @@
-from .cwl_v1_2 import *
+from .cwl_v1_2 import *  # noqa: F403

--- a/cwl_utils/parser/latest.py
+++ b/cwl_utils/parser/latest.py
@@ -1,0 +1,1 @@
+from .cwl_v1_2 import *

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -67,5 +67,5 @@ def test_latest_parser() -> None:
     uri = Path(TEST_v1_2_CWL).as_uri()
     with open(TEST_v1_2_CWL, "r") as cwl_h:
         yaml_obj12 = yaml.main.round_trip_load(cwl_h, preserve_quotes=True)
-    latest_cwl_obj = latest.load_document_by_yaml(yaml_obj12, uri) # type: ignore
+    latest_cwl_obj = latest.load_document_by_yaml(yaml_obj12, uri)  # type: ignore
     assert latest_cwl_obj.cwlVersion == "v1.2"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,9 +4,7 @@ from pathlib import Path
 from ruamel import yaml
 
 from cwl_utils.parser import cwl_version, load_document, load_document_by_uri, save
-from cwl_utils.parser.latest import (
-    load_document_by_yaml as latest_load_document_by_yaml,
-)
+import cwl_utils.parser.latest as latest
 
 HERE = Path(__file__).resolve().parent
 TEST_v1_0_CWL = HERE / "../testdata/md5sum.cwl"
@@ -69,5 +67,5 @@ def test_latest_parser() -> None:
     uri = Path(TEST_v1_2_CWL).as_uri()
     with open(TEST_v1_2_CWL, "r") as cwl_h:
         yaml_obj12 = yaml.main.round_trip_load(cwl_h, preserve_quotes=True)
-    latest_cwl_obj = latest_load_document_by_yaml(yaml_obj12, uri)
+    latest_cwl_obj = latest.load_document_by_yaml(yaml_obj12, uri) # type: ignore
     assert latest_cwl_obj.cwlVersion == "v1.2"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,7 +4,9 @@ from pathlib import Path
 from ruamel import yaml
 
 from cwl_utils.parser import cwl_version, load_document, load_document_by_uri, save
-import cwl_utils.parser.latest as latest
+from cwl_utils.parser.latest import (
+    load_document_by_yaml as latest_load_document_by_yaml,
+)
 
 HERE = Path(__file__).resolve().parent
 TEST_v1_0_CWL = HERE / "../testdata/md5sum.cwl"
@@ -67,5 +69,5 @@ def test_latest_parser() -> None:
     uri = Path(TEST_v1_2_CWL).as_uri()
     with open(TEST_v1_2_CWL, "r") as cwl_h:
         yaml_obj12 = yaml.main.round_trip_load(cwl_h, preserve_quotes=True)
-    latest_cwl_obj = latest.load_document_by_yaml(yaml_obj12, uri)
+    latest_cwl_obj = latest_load_document_by_yaml(yaml_obj12, uri)
     assert latest_cwl_obj.cwlVersion == "v1.2"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,6 @@
 """Test the load and save functions for CWL."""
 from cwl_utils.parser import cwl_version, load_document, load_document_by_uri, save
+import cwl_utils.parser.latest as latest
 from pathlib import Path
 from ruamel import yaml
 
@@ -57,3 +58,12 @@ def test_save() -> None:
     saved_obj = save([cwl_obj10, cwl_obj12])
     ver = cwl_version(saved_obj)
     assert ver == "v1.2"
+
+
+def test_latest_parser() -> None:
+    """Test the `latest` parser is same as cwl_v1_2 (current latest) parser."""
+    uri = Path(TEST_v1_2_CWL).as_uri()
+    with open(TEST_v1_2_CWL, "r") as cwl_h:
+        yaml_obj12 = yaml.main.round_trip_load(cwl_h, preserve_quotes=True)
+    latest_cwl_obj = latest.load_document_by_yaml(yaml_obj12, uri)
+    assert latest_cwl_obj.cwlVersion == "v1.2"


### PR DESCRIPTION
This request adds `cwl_utils.parser.latest` module for the latest CWL version.
It just import all the symbols in the module for the latest CWL version (i.e., `cwl_utils.paresr.cwl_v1_2`).

Related: https://github.com/common-workflow-language/cwl-utils/pull/102#discussion_r730702832