### PR TITLE
Add entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ venv.bak/
 .mypy_cache/
 
 .vscode/
+
+testenv*/
+pydocstyle_report.txt


### PR DESCRIPTION
This request adds `testenv*` and `pydocstyle_report.txt` to `.gitignore`.
These are generated by `release-test.sh` but we do not want to commit them to the repository in general.