### PR TITLE
Removed cwltool deps

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,9 @@ include Makefile
 include MANIFEST.in
 include LICENSE.txt
 include *requirements.txt
+include cwl_utils/cwlNodeEngine.js
+include cwl_utils/cwlNodeEngineJSConsole.js
+include cwl_utils/cwlNodeEngineWithContext.js
 include testdata/*.cwl
 include testdata/*.yaml
 include testdata/*.input

--- a/cwl_utils/cwlNodeEngine.js
+++ b/cwl_utils/cwlNodeEngine.js
@@ -1,0 +1,21 @@
+"use strict";
+process.stdin.setEncoding("utf8");
+var incoming = "";
+process.stdin.on("data", function(chunk) {
+  incoming += chunk;
+  var i = incoming.indexOf("\n");
+  if (i > -1) {
+    try{
+      var fn = JSON.parse(incoming.substr(0, i));
+      incoming = incoming.substr(i+1);
+      process.stdout.write(JSON.stringify(require("vm").runInNewContext(fn, {})) + "\n");
+    }
+    catch(e){
+      console.error(e)
+    }
+    /*strings to indicate the process has finished*/
+    console.log("r1cepzbhUTxtykz5XTC4");
+    console.error("r1cepzbhUTxtykz5XTC4");
+  }
+});
+process.stdin.on("end", process.exit);

--- a/cwl_utils/cwlNodeEngineJSConsole.js
+++ b/cwl_utils/cwlNodeEngineJSConsole.js
@@ -1,0 +1,32 @@
+"use strict";
+function js_console_log(){
+    console.error("[log] "+require("util").format.apply(this, arguments).split("\n").join("\n[log] "));
+}
+function js_console_err(){
+    console.error("[err] "+require("util").format.apply(this, arguments).split("\n").join("\n[err] "));
+}
+process.stdin.setEncoding("utf8");
+var incoming = "";
+process.stdin.on("data", function(chunk) {
+  incoming += chunk;
+  var i = incoming.indexOf("\n");
+  if (i > -1) {
+      try{
+        var fn = JSON.parse(incoming.substr(0, i));
+        incoming = incoming.substr(i+1);
+        process.stdout.write(JSON.stringify(require("vm").runInNewContext(fn, {
+        console: {
+            log: js_console_log, 
+            error: js_console_err
+        }
+        })) + "\n");
+    }
+    catch(e){
+        console.error(e)
+    }
+    /*strings to indicate the process has finished*/
+    console.log("r1cepzbhUTxtykz5XTC4");
+    console.error("r1cepzbhUTxtykz5XTC4");
+  }
+});
+process.stdin.on("end", process.exit);

--- a/cwl_utils/cwlNodeEngineWithContext.js
+++ b/cwl_utils/cwlNodeEngineWithContext.js
@@ -1,0 +1,37 @@
+"use strict";
+process.stdin.setEncoding("utf8");
+var incoming = "";
+var firstInput = true;
+var context = {};
+
+process.stdin.on("data", function(chunk) {
+  incoming += chunk;
+  var i = incoming.indexOf("\n");
+  while (i > -1) {
+    try{
+      var input = incoming.substr(0, i);
+      incoming = incoming.substr(i+1);
+      var fn = JSON.parse(input);
+      if(firstInput){
+        context = require("vm").runInNewContext(fn, {});
+      }
+      else{
+        process.stdout.write(JSON.stringify(require("vm").runInNewContext(fn, context)) + "\n");
+      }
+    }
+    catch(e){
+      console.error(e);
+    }
+    if(firstInput){
+      firstInput = false;
+    }
+    else{
+      /*strings to indicate the process has finished*/
+      console.log("r1cepzbhUTxtykz5XTC4");
+      console.error("r1cepzbhUTxtykz5XTC4");
+    }
+
+    i = incoming.indexOf("\n");
+  }
+});
+process.stdin.on("end", process.exit);

--- a/cwl_utils/cwl_expression_refactor.py
+++ b/cwl_utils/cwl_expression_refactor.py
@@ -8,13 +8,13 @@ import shutil
 import sys
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     List,
     MutableSequence,
     Optional,
-    TYPE_CHECKING,
     Tuple,
     Union,
 )

--- a/cwl_utils/cwl_expression_refactor.py
+++ b/cwl_utils/cwl_expression_refactor.py
@@ -8,19 +8,20 @@ import shutil
 import sys
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     List,
     MutableSequence,
     Optional,
+    TYPE_CHECKING,
     Tuple,
     Union,
 )
 
-from cwltool.loghandler import _logger as _cwltoollogger
 from ruamel import yaml
+
+from cwl_utils.loghandler import _logger as _cwlutilslogger
 
 if TYPE_CHECKING:
     from typing_extensions import Protocol
@@ -31,7 +32,7 @@ _logger = logging.getLogger("cwl-expression-refactor")  # pylint: disable=invali
 defaultStreamHandler = logging.StreamHandler()  # pylint: disable=invalid-name
 _logger.addHandler(defaultStreamHandler)
 _logger.setLevel(logging.INFO)
-_cwltoollogger.setLevel(100)
+_cwlutilslogger.setLevel(100)
 
 from cwl_utils import (
     cwl_v1_0_expression_refactor,

--- a/cwl_utils/cwl_normalizer.py
+++ b/cwl_utils/cwl_normalizer.py
@@ -15,18 +15,19 @@ from cwltool.load_tool import (
     resolve_and_validate_document,
     resolve_tool_uri,
 )
-from cwltool.loghandler import _logger as _cwltoollogger
 from cwltool.main import print_pack
 from cwltool.process import use_standard_schema
 from cwlupgrader import main as cwlupgrader
 from ruamel import yaml
 from schema_salad.sourceline import add_lc_filename
 
+from cwl_utils.loghandler import _logger as _cwlutilslogger
+
 _logger = logging.getLogger("cwl-normalizer")  # pylint: disable=invalid-name
 defaultStreamHandler = logging.StreamHandler()  # pylint: disable=invalid-name
 _logger.addHandler(defaultStreamHandler)
 _logger.setLevel(logging.INFO)
-_cwltoollogger.setLevel(100)
+_cwlutilslogger.setLevel(100)
 
 from cwl_utils import cwl_v1_2_expression_refactor
 from cwl_utils.parser.cwl_v1_2 import load_document_by_yaml, save

--- a/cwl_utils/cwl_v1_0_expression_refactor.py
+++ b/cwl_utils/cwl_v1_0_expression_refactor.py
@@ -12,22 +12,20 @@ from typing import (
     MutableSequence,
     Optional,
     Sequence,
-    Text,
     Tuple,
     Type,
     Union,
     cast,
 )
 
-from cwltool.errors import WorkflowException
-from cwltool.expression import do_eval, interpolate
-from cwltool.sandboxjs import JavascriptException
-from cwltool.utils import CWLObjectType, CWLOutputType
+from cwl_utils.expression import do_eval, interpolate
 from ruamel import yaml
 from schema_salad.sourceline import SourceLine
 from schema_salad.utils import json_dumps
 
 import cwl_utils.parser.cwl_v1_0 as cwl
+from cwl_utils.errors import JavascriptException, WorkflowException
+from cwl_utils.types import CWLObjectType, CWLOutputType
 
 
 def expand_stream_shortcuts(process: cwl.CommandLineTool) -> cwl.CommandLineTool:

--- a/cwl_utils/cwl_v1_0_expression_refactor.py
+++ b/cwl_utils/cwl_v1_0_expression_refactor.py
@@ -18,13 +18,13 @@ from typing import (
     cast,
 )
 
-from cwl_utils.expression import do_eval, interpolate
 from ruamel import yaml
 from schema_salad.sourceline import SourceLine
 from schema_salad.utils import json_dumps
 
 import cwl_utils.parser.cwl_v1_0 as cwl
 from cwl_utils.errors import JavascriptException, WorkflowException
+from cwl_utils.expression import do_eval, interpolate
 from cwl_utils.types import CWLObjectType, CWLOutputType
 
 

--- a/cwl_utils/cwl_v1_1_expression_refactor.py
+++ b/cwl_utils/cwl_v1_1_expression_refactor.py
@@ -12,22 +12,20 @@ from typing import (
     MutableSequence,
     Optional,
     Sequence,
-    Text,
     Tuple,
     Type,
     Union,
     cast,
 )
 
-from cwltool.errors import WorkflowException
-from cwltool.expression import do_eval, interpolate
-from cwltool.sandboxjs import JavascriptException
-from cwltool.utils import CWLObjectType, CWLOutputType
 from ruamel import yaml
 from schema_salad.sourceline import SourceLine
 from schema_salad.utils import json_dumps
 
 import cwl_utils.parser.cwl_v1_1 as cwl
+from cwl_utils.errors import JavascriptException, WorkflowException
+from cwl_utils.expression import do_eval, interpolate
+from cwl_utils.types import CWLObjectType, CWLOutputType
 
 
 def expand_stream_shortcuts(process: cwl.CommandLineTool) -> cwl.CommandLineTool:
@@ -184,7 +182,7 @@ var runtime=$(runtime);"""
         contents += "\n" + "\n".join(expressionLib)
     contents += (
         """
-var ret = function(){"""
+    var ret = function(){"""
         + escape_expression_field(etool.expression.strip()[2:-1])
         + """}();
 process.stdout.write(JSON.stringify(ret));"""
@@ -390,7 +388,7 @@ def generate_etool_from_expr(
         expression += "\n  var self=inputs.self;"
     expression += (
         """
-  return {"result": function(){"""
+      return {"result": function(){"""
         + expr[2:-2]
         + """}()};
  }"""
@@ -1782,7 +1780,7 @@ def generate_etool_from_expr2(
         expression += f"\n  var self=inputs.{self_name};"
     expression += (
         """
-  return {"result": function(){"""
+      return {"result": function(){"""
         + expr[2:-2]
         + """}()};
  }"""

--- a/cwl_utils/cwl_v1_2_expression_refactor.py
+++ b/cwl_utils/cwl_v1_2_expression_refactor.py
@@ -12,22 +12,20 @@ from typing import (
     MutableSequence,
     Optional,
     Sequence,
-    Text,
     Tuple,
     Type,
     Union,
     cast,
 )
 
-from cwltool.errors import WorkflowException
-from cwltool.expression import do_eval, interpolate
-from cwltool.sandboxjs import JavascriptException
-from cwltool.utils import CWLObjectType, CWLOutputType
 from ruamel import yaml
 from schema_salad.sourceline import SourceLine
 from schema_salad.utils import json_dumps
 
 import cwl_utils.parser.cwl_v1_2 as cwl
+from cwl_utils.errors import JavascriptException, WorkflowException
+from cwl_utils.expression import do_eval, interpolate
+from cwl_utils.types import CWLObjectType, CWLOutputType
 
 
 def expand_stream_shortcuts(process: cwl.CommandLineTool) -> cwl.CommandLineTool:
@@ -184,7 +182,7 @@ var runtime=$(runtime);"""
         contents += "\n" + "\n".join(expressionLib)
     contents += (
         """
-var ret = function(){"""
+    var ret = function(){"""
         + escape_expression_field(etool.expression.strip()[2:-1])
         + """}();
 process.stdout.write(JSON.stringify(ret));"""
@@ -390,7 +388,7 @@ def generate_etool_from_expr(
         expression += "\n  var self=inputs.self;"
     expression += (
         """
-  return {"result": function(){"""
+      return {"result": function(){"""
         + expr[2:-2]
         + """}()};
  }"""
@@ -1878,7 +1876,7 @@ def generate_etool_from_expr2(
         expression += f"\n  var self=inputs.{self_name};"
     expression += (
         """
-  return {"result": function(){"""
+      return {"result": function(){"""
         + expr[2:-2]
         + """}()};
  }"""

--- a/cwl_utils/errors.py
+++ b/cwl_utils/errors.py
@@ -1,7 +1,6 @@
 class ArrayMissingItems(BaseException):
     """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
 
-    pass
 
 
 class JavascriptException(Exception):
@@ -11,19 +10,16 @@ class JavascriptException(Exception):
 class MissingKeyField(BaseException):
     """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
 
-    pass
 
 
 class MissingTypeName(BaseException):
     """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
 
-    pass
 
 
 class RecordMissingFields(BaseException):
     """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
 
-    pass
 
 
 class SubstitutionError(Exception):

--- a/cwl_utils/errors.py
+++ b/cwl_utils/errors.py
@@ -1,4 +1,28 @@
+class ArrayMissingItems(BaseException):
+    """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
+
+    pass
+
+
 class JavascriptException(Exception):
+    pass
+
+
+class MissingKeyField(BaseException):
+    """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
+
+    pass
+
+
+class MissingTypeName(BaseException):
+    """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
+
+    pass
+
+
+class RecordMissingFields(BaseException):
+    """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
+
     pass
 
 

--- a/cwl_utils/errors.py
+++ b/cwl_utils/errors.py
@@ -2,7 +2,6 @@ class ArrayMissingItems(BaseException):
     """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
 
 
-
 class JavascriptException(Exception):
     pass
 
@@ -11,15 +10,12 @@ class MissingKeyField(BaseException):
     """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
 
 
-
 class MissingTypeName(BaseException):
     """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
 
 
-
 class RecordMissingFields(BaseException):
     """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
-
 
 
 class SubstitutionError(Exception):

--- a/cwl_utils/errors.py
+++ b/cwl_utils/errors.py
@@ -1,0 +1,10 @@
+class JavascriptException(Exception):
+    pass
+
+
+class SubstitutionError(Exception):
+    pass
+
+
+class WorkflowException(Exception):
+    pass

--- a/cwl_utils/expression.py
+++ b/cwl_utils/expression.py
@@ -1,0 +1,316 @@
+import asyncio
+import copy
+import inspect
+import json
+from typing import Any, Dict, List, MutableMapping, Optional, Tuple, Union, cast
+
+from schema_salad.utils import json_dumps
+
+from cwl_utils.errors import JavascriptException, SubstitutionError, WorkflowException
+from cwl_utils.loghandler import _logger
+from cwl_utils.sandbox import JSEngine, default_timeout, get_js_engine, param_re
+from cwl_utils.types import CWLObjectType, CWLOutputType
+from cwl_utils.utils import bytes2str_in_dicts
+
+
+def _convert_dumper(string: str) -> str:
+    return f"{json.dumps(string)} + "
+
+
+def scanner(scan: str) -> Optional[Tuple[int, int]]:
+    DEFAULT = 0
+    DOLLAR = 1
+    PAREN = 2
+    BRACE = 3
+    SINGLE_QUOTE = 4
+    DOUBLE_QUOTE = 5
+    BACKSLASH = 6
+
+    i = 0
+    stack = [DEFAULT]
+    start = 0
+    while i < len(scan):
+        state = stack[-1]
+        c = scan[i]
+
+        if state == DEFAULT:
+            if c == "$":
+                stack.append(DOLLAR)
+            elif c == "\\":
+                stack.append(BACKSLASH)
+        elif state == BACKSLASH:
+            stack.pop()
+            if stack[-1] == DEFAULT:
+                return i - 1, i + 1
+        elif state == DOLLAR:
+            if c == "(":
+                start = i - 1
+                stack.append(PAREN)
+            elif c == "{":
+                start = i - 1
+                stack.append(BRACE)
+            else:
+                stack.pop()
+                i -= 1
+        elif state == PAREN:
+            if c == "(":
+                stack.append(PAREN)
+            elif c == ")":
+                stack.pop()
+                if stack[-1] == DOLLAR:
+                    return start, i + 1
+            elif c == "'":
+                stack.append(SINGLE_QUOTE)
+            elif c == '"':
+                stack.append(DOUBLE_QUOTE)
+        elif state == BRACE:
+            if c == "{":
+                stack.append(BRACE)
+            elif c == "}":
+                stack.pop()
+                if stack[-1] == DOLLAR:
+                    return start, i + 1
+            elif c == "'":
+                stack.append(SINGLE_QUOTE)
+            elif c == '"':
+                stack.append(DOUBLE_QUOTE)
+        elif state == SINGLE_QUOTE:
+            if c == "'":
+                stack.pop()
+            elif c == "\\":
+                stack.append(BACKSLASH)
+        elif state == DOUBLE_QUOTE:
+            if c == '"':
+                stack.pop()
+            elif c == "\\":
+                stack.append(BACKSLASH)
+        i += 1
+
+    if len(stack) > 1 and not (len(stack) == 2 and stack[1] in (BACKSLASH, DOLLAR)):
+        raise SubstitutionError(
+            "Substitution error, unfinished block starting at position {}: '{}' stack was {}".format(
+                start, scan[start:], stack
+            )
+        )
+    return None
+
+
+def get_loop():
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.new_event_loop()
+
+
+def evaluator(
+    js_engine: JSEngine, ex: str, obj: CWLObjectType, jslib: str, fullJS: bool, **kwargs
+):
+    js_engine = js_engine or get_js_engine()
+    match = param_re.match(ex)
+    expression_parse_exception = None
+
+    if match is not None:
+        first_symbol = match.group(1)
+        first_symbol_end = match.end(1)
+
+        if first_symbol_end + 1 == len(ex) and first_symbol == "null":
+            return None
+        try:
+            if first_symbol not in obj:
+                raise WorkflowException("%s is not defined" % first_symbol)
+
+            if inspect.iscoroutinefunction(js_engine.eval):
+                return get_loop().run_until_complete(
+                    js_engine.regex_eval(
+                        first_symbol,
+                        ex[first_symbol_end:-1],
+                        cast(CWLOutputType, obj[first_symbol]),
+                        **kwargs,
+                    )
+                )
+            else:
+                return js_engine.regex_eval(
+                    first_symbol,
+                    ex[first_symbol_end:-1],
+                    cast(CWLOutputType, obj[first_symbol]),
+                    **kwargs,
+                )
+        except WorkflowException as werr:
+            expression_parse_exception = werr
+    if fullJS:
+        if inspect.iscoroutinefunction(js_engine.eval):
+            return get_loop().run_until_complete(js_engine.eval(ex, jslib, **kwargs))
+        else:
+            return js_engine.eval(ex, jslib, **kwargs)
+    else:
+        if expression_parse_exception is not None:
+            raise JavascriptException(
+                "Syntax error in parameter reference '%s': %s. This could be "
+                "due to using Javascript code without specifying "
+                "InlineJavascriptRequirement." % (ex[1:-1], expression_parse_exception)
+            )
+        else:
+            raise JavascriptException(
+                "Syntax error in parameter reference '%s'. This could be due "
+                "to using Javascript code without specifying "
+                "InlineJavascriptRequirement." % ex
+            )
+
+
+def interpolate(
+    scan: str,
+    rootvars: CWLObjectType,
+    jslib: str = "",
+    fullJS: bool = False,
+    strip_whitespace: bool = True,
+    escaping_behavior: int = 2,
+    convert_to_expression: bool = False,
+    js_engine: Optional[JSEngine] = None,
+    **kwargs,
+) -> Optional[CWLOutputType]:
+    """
+    Interpolate and evaluate.
+
+    Note: only call with convert_to_expression=True on CWL Expressions in $()
+    form that need interpolation.
+    """
+    if strip_whitespace:
+        scan = scan.strip()
+    parts = []
+    if convert_to_expression:
+        dump = _convert_dumper
+        parts.append("${return ")
+    else:
+
+        def dump(string):
+            return string
+
+    w = scanner(scan)
+    while w:
+        if convert_to_expression:
+            parts.append(f'"{scan[0: w[0]]}" + ')
+        else:
+            parts.append(scan[0 : w[0]])
+
+        if scan[w[0]] == "$":
+            if not convert_to_expression:
+                e = evaluator(
+                    js_engine, scan[w[0] + 1 : w[1]], rootvars, jslib, fullJS, **kwargs
+                )
+                if w[0] == 0 and w[1] == len(scan) and len(parts) <= 1:
+                    return e
+
+                leaf = json_dumps(e, sort_keys=True)
+                if leaf[0] == '"':
+                    leaf = json.loads(leaf)
+                parts.append(leaf)
+            else:
+                parts.append(
+                    "function(){var item ="
+                    + scan[w[0] : w[1]][2:-1]
+                    + '; if (typeof(item) === "string"){ return item; } else { return JSON.stringify(item); }}() + '
+                )
+        elif scan[w[0]] == "\\":
+            if escaping_behavior == 1:
+                # Old behavior.  Just skip the next character.
+                e = scan[w[1] - 1]
+                parts.append(dump(e))
+            elif escaping_behavior == 2:
+                # Backslash quoting requires a three character lookahead.
+                e = scan[w[0] : w[1] + 1]
+                if e in ("\\$(", "\\${"):
+                    # Suppress start of a parameter reference, drop the
+                    # backslash.
+                    parts.append(dump(e[1:]))
+                    w = (w[0], w[1] + 1)
+                elif e[1] == "\\":
+                    # Double backslash, becomes a single backslash
+                    parts.append(dump("\\"))
+                else:
+                    # Some other text, add it as-is (including the
+                    # backslash) and resume scanning.
+                    parts.append(dump(e[:2]))
+            else:
+                raise Exception("Unknown escaping behavior %s" % escaping_behavior)
+        scan = scan[w[1] :]
+        w = scanner(scan)
+    if convert_to_expression:
+        parts.append(f'"{scan}"')
+        parts.append(";}")
+    else:
+        parts.append(scan)
+    return "".join(parts)
+
+
+def jshead(engine_config: List[str], rootvars: CWLObjectType) -> str:
+    # make sure all the byte strings are converted
+    # to str in `rootvars` dict.
+
+    return "\n".join(
+        engine_config
+        + [f"var {k} = {json_dumps(v, indent=4)};" for k, v in rootvars.items()]
+    )
+
+
+def needs_parsing(snippet: Any) -> bool:
+    return isinstance(snippet, str) and ("$(" in snippet or "${" in snippet)
+
+
+def do_eval(
+    ex: Optional[CWLOutputType],
+    jobinput: CWLObjectType,
+    requirements: List[CWLObjectType],
+    outdir: Optional[str],
+    tmpdir: Optional[str],
+    resources: Dict[str, Union[float, int]],
+    context: Optional[CWLOutputType] = None,
+    timeout: float = default_timeout,
+    strip_whitespace: bool = True,
+    cwlVersion: str = "",
+    **kwargs,
+) -> Optional[CWLOutputType]:
+    runtime = cast(MutableMapping[str, Union[int, str, None]], copy.deepcopy(resources))
+    runtime["tmpdir"] = tmpdir if tmpdir else None
+    runtime["outdir"] = outdir if outdir else None
+
+    rootvars = cast(
+        CWLObjectType,
+        bytes2str_in_dicts({"inputs": jobinput, "self": context, "runtime": runtime}),
+    )
+
+    if isinstance(ex, str) and needs_parsing(ex):
+        fullJS = False
+        jslib = ""
+        for r in reversed(requirements):
+            if r["class"] == "InlineJavascriptRequirement":
+                fullJS = True
+                jslib = jshead(cast(List[str], r.get("expressionLib", [])), rootvars)
+                break
+
+        try:
+            return interpolate(
+                ex,
+                rootvars,
+                timeout=timeout,
+                fullJS=fullJS,
+                jslib=jslib,
+                strip_whitespace=strip_whitespace,
+                escaping_behavior=1
+                if cwlVersion
+                in (
+                    "v1.0",
+                    "v1.1.0-dev1",
+                    "v1.1",
+                    "v1.2.0-dev1",
+                    "v1.2.0-dev2",
+                    "v1.2.0-dev3",
+                )
+                else 2,
+                **kwargs,
+            )
+
+        except Exception as e:
+            _logger.exception(e)
+            raise WorkflowException("Expression evaluation error:\n%s" % str(e)) from e
+    else:
+        return ex

--- a/cwl_utils/graph_split.py
+++ b/cwl_utils/graph_split.py
@@ -11,7 +11,7 @@ Only tested with a single v1.0 workflow.
 import argparse
 import json
 import os
-from typing import IO, Any, MutableMapping, Set, Text, Union, cast
+from typing import Any, IO, MutableMapping, Set, Union, cast
 
 from cwlformat.formatter import stringify_dict
 from ruamel import yaml

--- a/cwl_utils/loghandler.py
+++ b/cwl_utils/loghandler.py
@@ -1,0 +1,6 @@
+import logging
+
+_logger = logging.getLogger("cwl_utils")  # pylint: disable=invalid-name
+defaultStreamHandler = logging.StreamHandler()  # pylint: disable=invalid-name
+_logger.addHandler(defaultStreamHandler)
+_logger.setLevel(logging.INFO)

--- a/cwl_utils/pack.py
+++ b/cwl_utils/pack.py
@@ -18,16 +18,13 @@ import os
 import sys
 import urllib.parse
 import urllib.request
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, ItemsView, List, Optional, Tuple, cast
 
-import ruamel.yaml
 from packaging import version
 
 from cwl_utils import schemadef, utils
 
 logger = logging.getLogger(__name__)
-
-fast_yaml = ruamel.yaml.YAML(typ="safe")
 
 
 def get_inner_dict(
@@ -172,7 +169,7 @@ def resolve_imports(cwl: Any, base_url: urllib.parse.ParseResult) -> Any:
     if isinstance(cwl, dict):
         itr = cwl.items()
     elif isinstance(cwl, list):
-        itr = [(n, v) for n, v in enumerate(cwl)]
+        itr = cast(ItemsView[Any, Any], [(n, v) for n, v in enumerate(cwl)])
     else:
         return cwl
 

--- a/cwl_utils/pack.py
+++ b/cwl_utils/pack.py
@@ -1,0 +1,277 @@
+"""
+The link resolution is as follows:
+
+We always have two components: the base and the link
+If the link is a url or absolute path it is what is used to fetch the data.
+If the link is a relative path it is combined with the base and that is what is
+used to fetch data
+
+From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py
+"""
+
+#  Copyright (c) 2021 Michael R. Crusoe
+#  Copyright (c) 2020 Seven Bridges
+#  See https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/LICENSE
+
+import logging
+import os
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+import ruamel.yaml
+from packaging import version
+
+from cwl_utils import schemadef, utils
+
+logger = logging.getLogger(__name__)
+
+fast_yaml = ruamel.yaml.YAML(typ="safe")
+
+
+def get_inner_dict(
+    cwl: Dict[str, Any], path: List[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    if len(path) == 0:
+        return cwl
+
+    if isinstance(cwl, dict):
+        _v = cwl.get(path[0]["key"])
+        if _v is not None:
+            return get_inner_dict(_v, path[1:])
+
+    elif isinstance(cwl, list):  # Going to assume this is a map expressed as list
+        for _v in cwl:
+            if isinstance(_v, dict):
+                if _v.get(path[0]["key_field"]) == path[0]["key"]:
+                    return get_inner_dict(_v, path[1:])
+
+    return None
+
+
+def pack_process(
+    cwl: Dict[str, Any],
+    base_url: urllib.parse.ParseResult,
+    cwl_version: str,
+    parent_user_defined_types: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    cwl = listify_everything(cwl)
+    cwl = normalize_sources(cwl)
+    cwl, user_defined_types = load_schemadefs(cwl, base_url, parent_user_defined_types)
+    cwl = resolve_schemadefs(cwl, base_url, user_defined_types)
+    cwl = resolve_imports(cwl, base_url)
+    cwl = resolve_steps(
+        cwl,
+        base_url,
+        cwl.get("cwlVersion", cwl_version),
+        user_defined_types,
+    )
+    cwl = add_missing_requirements(cwl)
+    return cwl
+
+
+def listify_everything(cwl: Dict[str, Any]) -> Dict[str, Any]:
+    for port in ["inputs", "outputs"]:
+        cwl[port] = utils.normalize_to_list(
+            cwl.get(port, []), key_field="id", value_field="type"
+        )
+
+    cwl["requirements"] = utils.normalize_to_list(
+        cwl.get("requirements", []), key_field="class", value_field=None
+    )
+
+    if cwl.get("class") != "Workflow":
+        return cwl
+
+    cwl["steps"] = utils.normalize_to_list(
+        cwl.get("steps", []), key_field="id", value_field=None
+    )
+
+    for _, v in enumerate(cwl["steps"]):
+        if isinstance(v, dict):
+            v["in"] = utils.normalize_to_list(
+                v.get("in", []), key_field="id", value_field="source"
+            )
+
+    return cwl
+
+
+def dictify_requirements(cwl: Dict[str, Any]) -> Dict[str, Any]:
+    cwl["requirements"] = utils.normalize_to_map(
+        cwl.get("requirements", {}), key_field="class"
+    )
+    return cwl
+
+
+def normalize_sources(cwl: Dict[str, Any]) -> Dict[str, Any]:
+    if cwl.get("class") != "Workflow":
+        return cwl
+
+    for _step in cwl.get("steps", {}):
+        if not isinstance(_step, dict):
+            continue
+
+        _inputs = _step.get("in", {})
+        for k, _input in enumerate(_inputs):
+            if isinstance(_input, str):
+                _inputs[k] = _normalize(_input)
+            elif isinstance(_input, dict):
+                _src = _input.get("source")
+                if isinstance(_src, str):
+                    _input["source"] = _normalize(_input["source"])
+
+    _outputs = cwl.get("outputs", {})
+    for k, _output in enumerate(_outputs):
+        if isinstance(_output, str):
+            _outputs[k] = _normalize(_output)
+        elif isinstance(_output, dict):
+            _src = _output.get("outputSource")
+            if isinstance(_src, str):
+                _output["outputSource"] = _normalize(_output["outputSource"])
+
+    return cwl
+
+
+def _normalize(s: str) -> str:
+    if s.startswith("#"):
+        return s[1:]
+    else:
+        return s
+
+
+def load_schemadefs(
+    cwl: Dict[str, Any],
+    base_url: urllib.parse.ParseResult,
+    parent_user_defined_types: Optional[Dict[str, Any]] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    user_defined_types = schemadef.build_user_defined_type_dict(cwl, base_url)
+    if parent_user_defined_types is not None:
+        user_defined_types.update(parent_user_defined_types)
+
+    cwl["requirements"] = [
+        req
+        for req in cwl.get("requirements", [])
+        if req.get("class") != "SchemaDefRequirement"
+    ]
+
+    return cwl, user_defined_types
+
+
+def resolve_schemadefs(
+    cwl: Dict[str, Any],
+    base_url: urllib.parse.ParseResult,
+    user_defined_types: Dict[str, Any],
+) -> Dict[str, Any]:
+    cwl = schemadef.inline_types(cwl, "inputs", base_url, user_defined_types)
+    cwl = schemadef.inline_types(cwl, "outputs", base_url, user_defined_types)
+    return cwl
+
+
+def resolve_imports(cwl: Any, base_url: urllib.parse.ParseResult) -> Any:
+    if isinstance(cwl, dict):
+        itr = cwl.items()
+    elif isinstance(cwl, list):
+        itr = [(n, v) for n, v in enumerate(cwl)]
+    else:
+        return cwl
+
+    for k, v in itr:
+        if isinstance(v, dict):
+            if len(v) == 1:
+                _k = list(v.keys())[0]
+                if _k in ["$import", "$include"]:
+                    cwl[k], this_base_url = utils.load_linked_file(
+                        base_url, v[_k], is_import=_k == "$import"
+                    )
+
+        cwl[k] = resolve_imports(cwl[k], base_url)
+
+    return cwl
+
+
+def resolve_steps(
+    cwl: Dict[str, Any],
+    base_url: urllib.parse.ParseResult,
+    cwl_version: str,
+    parent_user_defined_types: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    if isinstance(cwl, str):
+        raise RuntimeError(f"{base_url.geturl()}: Expecting a process, found a string")
+
+    if not isinstance(cwl, dict):
+        return cwl
+
+    if cwl.get("class") != "Workflow":
+        return cwl
+
+    workflow_id = cwl.get("id", os.path.basename(base_url.path))
+    for _, v in enumerate(cwl["steps"]):
+        if isinstance(v, dict):
+            sys.stderr.write(
+                f"\n--\nRecursing into step {base_url.geturl()}:{v['id']}\n"
+            )
+
+            _run = v.get("run")
+            if isinstance(_run, str):
+                v["run"], new_base_url = utils.load_linked_file(
+                    base_url, _run, is_import=True
+                )
+                v["run"] = pack_process(
+                    v["run"],
+                    new_base_url,
+                    cwl.get("cwlVersion", cwl_version),
+                )
+            else:
+                v["run"] = pack_process(
+                    v["run"],
+                    base_url,
+                    cwl.get("cwlVersion", cwl_version),
+                    parent_user_defined_types,
+                )
+            if "cwlVersion" in v["run"]:
+                parent_version = version.parse(
+                    cwl.get("cwlVersion", cwl_version).strip("v")
+                )
+                this_version = version.parse(v["run"]["cwlVersion"].strip("v"))
+                if this_version > parent_version:
+                    cwl["cwlVersion"] = v["run"]["cwlVersion"]
+                    # not really enough, but hope for the best
+
+    return cwl
+
+
+def add_missing_requirements(cwl: Dict[str, Any]) -> Dict[str, Any]:
+    requirements = cwl.get("requirements", [])
+    present = {req["class"] for req in requirements}
+
+    def _add_req(_req_name: str) -> None:
+        nonlocal requirements
+        if _req_name not in present:
+            requirements += [{"class": _req_name}]
+
+    if cwl.get("class") == "Workflow":
+        sub_worflow = False
+        for step in cwl["steps"]:
+            if step["run"]["class"] == "Workflow":
+                sub_worflow = True
+                break
+        if sub_worflow:
+            _add_req("SubworkflowFeatureRequirement")
+    return cwl
+
+
+def pack(cwl_path: str) -> Dict[str, Any]:
+    sys.stderr.write(f"Packing {cwl_path}\n")
+    file_path_url = urllib.parse.urlparse(cwl_path)
+
+    cwl, full_url = cast(
+        Tuple[Dict[str, Any], urllib.parse.ParseResult],
+        utils.load_linked_file(base_url=file_path_url, link="", is_import=True),
+    )
+    if "$graph" in cwl:
+        # assume already packed
+        return cwl
+    cwl = pack_process(cwl, full_url, cwl["cwlVersion"])
+
+    return cwl

--- a/cwl_utils/parser/__init__.py
+++ b/cwl_utils/parser/__init__.py
@@ -4,11 +4,9 @@ import os
 from pathlib import Path
 from typing import (
     Any,
-    Dict,
     MutableMapping,
     MutableSequence,
     Optional,
-    Tuple,
     Union,
     cast,
 )
@@ -17,9 +15,7 @@ from urllib.parse import unquote_plus, urlparse
 from schema_salad.exceptions import ValidationException
 from schema_salad.utils import yaml_no_ts
 
-from . import cwl_v1_0 as cwl_v1_0
-from . import cwl_v1_1 as cwl_v1_1
-from . import cwl_v1_2 as cwl_v1_2
+from . import cwl_v1_0 as cwl_v1_0, cwl_v1_1 as cwl_v1_1, cwl_v1_2 as cwl_v1_2
 
 LoadingOptions = Union[
     cwl_v1_0.LoadingOptions, cwl_v1_1.LoadingOptions, cwl_v1_2.LoadingOptions

--- a/cwl_utils/parser/__init__.py
+++ b/cwl_utils/parser/__init__.py
@@ -2,20 +2,15 @@
 
 import os
 from pathlib import Path
-from typing import (
-    Any,
-    MutableMapping,
-    MutableSequence,
-    Optional,
-    Union,
-    cast,
-)
+from typing import Any, MutableMapping, MutableSequence, Optional, Union, cast
 from urllib.parse import unquote_plus, urlparse
 
 from schema_salad.exceptions import ValidationException
 from schema_salad.utils import yaml_no_ts
 
-from . import cwl_v1_0 as cwl_v1_0, cwl_v1_1 as cwl_v1_1, cwl_v1_2 as cwl_v1_2
+from . import cwl_v1_0 as cwl_v1_0
+from . import cwl_v1_1 as cwl_v1_1
+from . import cwl_v1_2 as cwl_v1_2
 
 LoadingOptions = Union[
     cwl_v1_0.LoadingOptions, cwl_v1_1.LoadingOptions, cwl_v1_2.LoadingOptions

--- a/cwl_utils/sandbox.py
+++ b/cwl_utils/sandbox.py
@@ -1,0 +1,513 @@
+import collections
+import errno
+import json
+import os
+import re
+import select
+import subprocess
+import threading
+from abc import ABC, abstractmethod
+from io import BytesIO
+from typing import Mapping, MutableMapping, MutableSequence, Optional, Tuple, cast
+
+from pkg_resources import resource_stream
+from schema_salad.utils import json_dumps
+
+from cwl_utils.errors import JavascriptException, WorkflowException
+from cwl_utils.loghandler import _logger
+from cwl_utils.types import CWLOutputType
+from cwl_utils.utils import kill_processes, singularity_supports_userns
+
+default_timeout = 20
+
+
+seg_symbol = r"""\w+"""
+seg_single = r"""\['([^']|\\')+'\]"""
+seg_double = r"""\["([^"]|\\")+"\]"""
+seg_index = r"""\[[0-9]+\]"""
+segments = rf"(\.{seg_symbol}|{seg_single}|{seg_double}|{seg_index})"
+segment_re = re.compile(segments, flags=re.UNICODE)
+param_str = rf"\(({seg_symbol}){segments}*\)$"
+param_re = re.compile(param_str, flags=re.UNICODE)
+
+
+def code_fragment_to_js(jscript: str, jslib: str = "") -> str:
+    if isinstance(jscript, str) and len(jscript) > 1 and jscript[0] == "{":
+        inner_js = jscript
+    else:
+        inner_js = "{return (%s);}" % jscript
+
+    return f'"use strict";\n{jslib}\n(function(){inner_js})()'
+
+
+def linenum(fn) -> str:
+    lines = fn.splitlines()
+    ofs = 0
+    maxlines = 99
+    if len(lines) > maxlines:
+        ofs = len(lines) - maxlines
+        lines = lines[-maxlines:]
+    return "\n".join("%02i %s" % (i + ofs + 1, b) for i, b in enumerate(lines))
+
+
+def stdfmt(data: str) -> str:
+    if "\n" in data:
+        return "\n" + data.strip()
+    return data
+
+
+class JSEngine(ABC):
+    @abstractmethod
+    def eval(self, scan: str, jslib: str = "", **kwargs):
+        ...
+
+    @abstractmethod
+    def regex_eval(
+        self,
+        parsed_string: str,
+        remaining_string: str,
+        current_value: CWLOutputType,
+        **kwargs,
+    ):
+        ...
+
+
+class NodeJSEngine(JSEngine):
+    localdata = threading.local()
+
+    def __init__(
+        self,
+        have_node_slim: bool = False,
+        minimum_node_version_str: str = "0.10.26",
+        process_finished_str: str = "r1cepzbhUTxtykz5XTC4\n",
+    ):
+        self.have_node_slim: bool = have_node_slim
+        self.minimum_node_version_str: str = minimum_node_version_str
+        self.process_finished_str: str = process_finished_str
+        self.processes_to_kill = (
+            collections.deque()
+        )  # type: Deque[subprocess.Popen[str]]
+
+    def __del__(self):
+        kill_processes(self.processes_to_kill)
+
+    def _check_js_threshold_version(self, working_alias: str) -> bool:
+        """
+        Check if the nodeJS engine version on the system with the allowed minimum version.
+
+        https://github.com/nodejs/node/blob/master/CHANGELOG.md#nodejs-changelog
+        """
+        # parse nodejs version into int Tuple: 'v4.2.6\n' -> [4, 2, 6]
+        current_version_str = subprocess.check_output(
+            [working_alias, "-v"], universal_newlines=True
+        )
+        current_version = [
+            int(v) for v in current_version_str.strip().strip("v").split(".")
+        ]
+        minimum_node_version = [
+            int(v) for v in self.minimum_node_version_str.split(".")
+        ]
+
+        return current_version >= minimum_node_version
+
+    def _exec_js_process(
+        self,
+        js_text: str,
+        timeout: float = default_timeout,
+        js_console: bool = False,
+        context: Optional[str] = None,
+        force_docker_pull: bool = False,
+        container_engine: str = "docker",
+    ) -> Tuple[int, str, str]:
+
+        if not hasattr(self.localdata, "procs"):
+            self.localdata.procs = {}
+
+        if js_console and context is not None:
+            raise NotImplementedError("js_console=True and context not implemented")
+
+        if js_console:
+            js_engine = "cwlNodeEngineJSConsole.js"
+            _logger.warning(
+                "Running with support for javascript console in expressions (DO NOT USE IN PRODUCTION)"
+            )
+        elif context is not None:
+            js_engine = "cwlNodeEngineWithContext.js"
+        else:
+            js_engine = "cwlNodeEngine.js"
+
+        created_new_process = False
+
+        if context is not None:
+            nodejs = self.localdata.procs.get((js_engine, context))
+        else:
+            nodejs = self.localdata.procs.get(js_engine)
+
+        if nodejs is None or nodejs.poll() is not None:
+            res = resource_stream(__name__, js_engine)
+            js_engine_code = res.read().decode("utf-8")
+
+            created_new_process = True
+
+            new_proc = self._new_js_proc(
+                js_engine_code,
+                force_docker_pull=force_docker_pull,
+                container_engine=container_engine,
+            )
+
+            if context is None:
+                self.localdata.procs[js_engine] = new_proc
+                nodejs = new_proc
+            else:
+                self.localdata.procs[(js_engine, context)] = new_proc
+                nodejs = new_proc
+
+        killed = []
+
+        def terminate() -> None:
+            """Kill the node process if it exceeds timeout limit."""
+            try:
+                killed.append(True)
+                nodejs.kill()
+            except OSError:
+                pass
+
+        timer = threading.Timer(timeout, terminate)
+        timer.daemon = True
+        timer.start()
+
+        stdin_text = ""
+        if created_new_process and context is not None:
+            stdin_text = json_dumps(context) + "\n"
+        stdin_text += json_dumps(js_text) + "\n"
+
+        stdin_buf = BytesIO(stdin_text.encode("utf-8"))
+        stdout_buf = BytesIO()
+        stderr_buf = BytesIO()
+
+        rselect = [nodejs.stdout, nodejs.stderr]  # type: List[BytesIO]
+        wselect = [nodejs.stdin]  # type: List[BytesIO]
+
+        def process_finished() -> bool:
+            return stdout_buf.getvalue().decode("utf-8").endswith(
+                self.process_finished_str
+            ) and stderr_buf.getvalue().decode("utf-8").endswith(
+                self.process_finished_str
+            )
+
+        while not process_finished() and timer.is_alive():
+            rready, wready, _ = select.select(rselect, wselect, [])
+            try:
+                if nodejs.stdin in wready:
+                    buf = stdin_buf.read(select.PIPE_BUF)
+                    if buf:
+                        os.write(nodejs.stdin.fileno(), buf)
+                for pipes in ((nodejs.stdout, stdout_buf), (nodejs.stderr, stderr_buf)):
+                    if pipes[0] in rready:
+                        buf = os.read(pipes[0].fileno(), select.PIPE_BUF)
+                        if buf:
+                            pipes[1].write(buf)
+            except OSError:
+                break
+        timer.cancel()
+
+        stdin_buf.close()
+        stdoutdata = stdout_buf.getvalue()[: -len(self.process_finished_str) - 1]
+        stderrdata = stderr_buf.getvalue()[: -len(self.process_finished_str) - 1]
+
+        nodejs.poll()
+
+        if nodejs.poll() not in (None, 0):
+            if killed:
+                returncode = -1
+            else:
+                returncode = nodejs.returncode
+        else:
+            returncode = 0
+
+        return returncode, stdoutdata.decode("utf-8"), stderrdata.decode("utf-8")
+
+    def _new_js_proc(
+        self,
+        js_text: str,
+        force_docker_pull: bool = False,
+        container_engine: str = "docker",
+    ) -> "subprocess.Popen[str]":
+        """Return a subprocess ready to submit javascript to."""
+        required_node_version, docker = (False,) * 2
+        nodejs = None  # type: Optional[subprocess.Popen[str]]
+        trynodes = ("nodejs", "node")
+        for n in trynodes:
+            try:
+                if (
+                    subprocess.check_output(
+                        [n, "--eval", "process.stdout.write('t')"],
+                        universal_newlines=True,
+                    )
+                    != "t"
+                ):
+                    continue
+                else:
+                    nodejs = subprocess.Popen(  # nosec
+                        [n, "--eval", js_text],
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        universal_newlines=True,
+                    )
+                    self.processes_to_kill.append(nodejs)
+                    required_node_version = self._check_js_threshold_version(n)
+                    break
+            except (subprocess.CalledProcessError, OSError):
+                pass
+
+        if nodejs is None or nodejs is not None and required_node_version is False:
+            try:
+                nodeimg = "docker.io/node:slim"
+                if container_engine == "singularity":
+                    nodeimg = f"docker://{nodeimg}"
+
+                if not self.have_node_slim:
+                    if container_engine in ("docker", "podman"):
+                        dockerimgs = subprocess.check_output(  # nosec
+                            [container_engine, "images", "-q", nodeimg],
+                            universal_newlines=True,
+                        )
+                    elif container_engine != "singularity":
+                        raise Exception(
+                            f"Unknown container_engine: {container_engine}."
+                        )
+                    # if output is an empty string
+                    if (
+                        container_engine == "singularity"
+                        or len(dockerimgs.split("\n")) <= 1
+                        or force_docker_pull
+                    ):
+                        # pull node:slim docker container
+                        nodejs_pull_commands = [container_engine, "pull"]
+                        if container_engine == "singularity":
+                            nodejs_pull_commands.append("--force")
+                        nodejs_pull_commands.append(nodeimg)
+                        nodejsimg = subprocess.check_output(
+                            nodejs_pull_commands, universal_newlines=True
+                        )
+                        _logger.debug(
+                            "Pulled Docker image %s %s using %s",
+                            nodeimg,
+                            nodejsimg,
+                            container_engine,
+                        )
+                    self.have_node_slim = True
+                nodejs_commands = [container_engine]
+                if container_engine != "singularity":
+                    nodejs_commands.extend(
+                        [
+                            "run",
+                            "--attach=STDIN",
+                            "--attach=STDOUT",
+                            "--attach=STDERR",
+                            "--sig-proxy=true",
+                            "--interactive",
+                            "--rm",
+                        ]
+                    )
+                else:
+                    nodejs_commands.extend(
+                        [
+                            "exec",
+                            "--contain",
+                            "--ipc",
+                            "--cleanenv",
+                            "--userns" if singularity_supports_userns() else "--pid",
+                        ]
+                    )
+                nodejs_commands.extend(
+                    [
+                        nodeimg,
+                        "node",
+                        "--eval",
+                        js_text,
+                    ],
+                )
+                _logger.debug("Running nodejs via %s", nodejs_commands[:-1])
+                nodejs = subprocess.Popen(  # nosec
+                    nodejs_commands,
+                    universal_newlines=True,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                self.processes_to_kill.append(nodejs)
+                docker = True
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    pass
+                else:
+                    raise
+            except subprocess.CalledProcessError:
+                pass
+
+        # docker failed and nodejs not on system
+        if nodejs is None:
+            raise JavascriptException(
+                "NodeJSEngine requires Node.js engine to evaluate and validate "
+                "Javascript expressions, but couldn't find it.  Tried {trynodes}, "
+                f"{container_engine} run node:slim".format(
+                    trynodes=", ".join(trynodes), container_engine=container_engine
+                )
+            )
+
+        # docker failed, but nodejs is installed on system but the version is below the required version
+        if docker is False and required_node_version is False:
+            raise JavascriptException(
+                "NodeJSEngine requires minimum v{} version of Node.js engine.".format(
+                    self.minimum_node_version_str
+                ),
+                "Try updating: https://docs.npmjs.com/getting-started/installing-node",
+            )
+
+        return nodejs
+
+    def eval(
+        self,
+        scan: str,
+        jslib: str = "",
+        timeout: float = default_timeout,
+        force_docker_pull: bool = False,
+        debug: bool = False,
+        js_console: bool = False,
+        container_engine: str = "docker",
+    ) -> CWLOutputType:
+        fn = code_fragment_to_js(scan, jslib)
+        returncode, stdout, stderr = self._exec_js_process(
+            fn,
+            timeout,
+            js_console=js_console,
+            force_docker_pull=force_docker_pull,
+            container_engine=container_engine,
+        )
+        if js_console:
+            if stderr is not None:
+                _logger.info("Javascript console output:")
+                _logger.info("----------------------------------------")
+                _logger.info(
+                    "\n".join(
+                        re.findall(r"^[[](?:log|err)[]].*$", stderr, flags=re.MULTILINE)
+                    )
+                )
+                _logger.info("----------------------------------------")
+        if returncode != 0:
+            if debug:
+                info = (
+                    "returncode was: %s\nscript was:\n%s\nstdout was: %s\nstderr was: %s\n"
+                    % (returncode, linenum(fn), stdfmt(stdout), stdfmt(stderr))
+                )
+            else:
+                info = "Javascript expression was: {}\nstdout was: {}\nstderr was: {}".format(
+                    scan, stdfmt(stdout), stdfmt(stderr)
+                )
+
+            if returncode == -1:
+                raise JavascriptException(
+                    f"Long-running script killed after {timeout} seconds: {info}"
+                )
+            else:
+                raise JavascriptException(info)
+        try:
+            return cast(CWLOutputType, json.loads(stdout))
+        except ValueError as err:
+            raise JavascriptException(
+                "{}\nscript was:\n{}\nstdout was: '{}'\nstderr was: '{}'\n".format(
+                    err, linenum(fn), stdout, stderr
+                )
+            ) from err
+
+    def regex_eval(
+        self,
+        parsed_string: str,
+        remaining_string: str,
+        current_value: CWLOutputType,
+        **kwargs,
+    ):
+        if remaining_string:
+            m = segment_re.match(remaining_string)
+            if not m:
+                return current_value
+            next_segment_str = m.group(1)
+            key = None  # type: Optional[Union[str, int]]
+            if next_segment_str[0] == ".":
+                key = next_segment_str[1:]
+            elif next_segment_str[1] in ("'", '"'):
+                key = next_segment_str[2:-2].replace("\\'", "'").replace('\\"', '"')
+            if key is not None:
+                if (
+                    isinstance(current_value, MutableSequence)
+                    and key == "length"
+                    and not remaining_string[m.end(1) :]
+                ):
+                    return len(current_value)
+                if not isinstance(current_value, MutableMapping):
+                    raise WorkflowException(
+                        "%s is a %s, cannot index on string '%s'"
+                        % (parsed_string, type(current_value).__name__, key)
+                    )
+                if key not in current_value:
+                    raise WorkflowException(
+                        f"{parsed_string} does not contain key '{key}'"
+                    )
+            else:
+                try:
+                    key = int(next_segment_str[1:-1])
+                except ValueError as v:
+                    raise WorkflowException(str(v)) from v
+                if not isinstance(current_value, MutableSequence):
+                    raise WorkflowException(
+                        "%s is a %s, cannot index on int '%s'"
+                        % (parsed_string, type(current_value).__name__, key)
+                    )
+                if key and key >= len(current_value):
+                    raise WorkflowException(
+                        "%s list index %i out of range" % (parsed_string, key)
+                    )
+
+            if isinstance(current_value, Mapping):
+                try:
+                    return self.regex_eval(
+                        parsed_string + remaining_string,
+                        remaining_string[m.end(1) :],
+                        cast(CWLOutputType, current_value[cast(str, key)]),
+                    )
+                except KeyError:
+                    raise WorkflowException(
+                        f"{parsed_string} doesn't have property {key}"
+                    )
+            elif isinstance(current_value, list) and isinstance(key, int):
+                try:
+                    return self.regex_eval(
+                        parsed_string + remaining_string,
+                        remaining_string[m.end(1) :],
+                        current_value[key],
+                    )
+                except KeyError:
+                    raise WorkflowException(
+                        f"{parsed_string} doesn't have property {key}"
+                    )
+            else:
+                raise WorkflowException(f"{parsed_string} doesn't have property {key}")
+        else:
+            return current_value
+
+
+__js_engine: Optional[JSEngine] = None
+
+
+def get_js_engine() -> JSEngine:
+    return __js_engine
+
+
+def set_js_engine(js_engine: JSEngine):
+    global __js_engine
+    __js_engine = js_engine
+
+
+set_js_engine(NodeJSEngine())

--- a/cwl_utils/sandboxjs.py
+++ b/cwl_utils/sandboxjs.py
@@ -522,3 +522,42 @@ def get_js_engine() -> JSEngine:
 def set_js_engine(js_engine: JSEngine) -> None:
     global __js_engine
     __js_engine = js_engine
+
+
+# The following functions are maintained for compatibility purposes
+def check_js_threshold_version(*args: Any, **kwargs: Any) -> bool:
+    _check_js_threshold_version = getattr(
+        get_js_engine(), "check_js_threshold_version", None
+    )
+    if callable(_check_js_threshold_version):
+        return _check_js_threshold_version(*args, **kwargs)
+    else:
+        raise NotImplementedError(
+            "Method check_js_threshold_version is not implemented in js engine {}".format(
+                get_js_engine().__class__.__name__
+            )
+        )
+
+
+def exec_js_process(*args: Any, **kwargs: Any) -> Tuple[int, str, str]:
+    _exec_js_process = getattr(get_js_engine(), "exec_js_process", None)
+    if callable(_exec_js_process):
+        return _exec_js_process(*args, **kwargs)
+    else:
+        raise NotImplementedError(
+            "Method exec_js_process is not implemented in js engine {}".format(
+                get_js_engine().__class__.__name__
+            )
+        )
+
+
+def new_js_proc(*args, **kwargs) -> "subprocess.Popen[str]":
+    _new_js_proc = getattr(get_js_engine(), "new_js_proc", None)
+    if callable(_new_js_proc):
+        return _new_js_proc(*args, **kwargs)
+    else:
+        raise NotImplementedError(
+            "Method new_js_proc is not implemented in js engine {}".format(
+                get_js_engine().__class__.__name__
+            )
+        )

--- a/cwl_utils/sandboxjs.py
+++ b/cwl_utils/sandboxjs.py
@@ -530,7 +530,7 @@ def check_js_threshold_version(*args: Any, **kwargs: Any) -> bool:
         get_js_engine(), "check_js_threshold_version", None
     )
     if callable(_check_js_threshold_version):
-        return _check_js_threshold_version(*args, **kwargs)
+        return cast(bool, _check_js_threshold_version(*args, **kwargs))
     else:
         raise NotImplementedError(
             "Method check_js_threshold_version is not implemented in js engine {}".format(
@@ -542,7 +542,7 @@ def check_js_threshold_version(*args: Any, **kwargs: Any) -> bool:
 def exec_js_process(*args: Any, **kwargs: Any) -> Tuple[int, str, str]:
     _exec_js_process = getattr(get_js_engine(), "exec_js_process", None)
     if callable(_exec_js_process):
-        return _exec_js_process(*args, **kwargs)
+        return cast(Tuple[int, str, str], _exec_js_process(*args, **kwargs))
     else:
         raise NotImplementedError(
             "Method exec_js_process is not implemented in js engine {}".format(
@@ -551,10 +551,10 @@ def exec_js_process(*args: Any, **kwargs: Any) -> Tuple[int, str, str]:
         )
 
 
-def new_js_proc(*args, **kwargs) -> "subprocess.Popen[str]":
+def new_js_proc(*args: Any, **kwargs: Any) -> "subprocess.Popen[str]":
     _new_js_proc = getattr(get_js_engine(), "new_js_proc", None)
     if callable(_new_js_proc):
-        return _new_js_proc(*args, **kwargs)
+        return cast("subprocess.Popen[str]", _new_js_proc(*args, **kwargs))
     else:
         raise NotImplementedError(
             "Method new_js_proc is not implemented in js engine {}".format(

--- a/cwl_utils/schemadef.py
+++ b/cwl_utils/schemadef.py
@@ -1,0 +1,234 @@
+"""
+Valid forms of user defined types stored in external file
+
+A single dictionary (tests/types/singletype.yml)
+A list of dictionaries (e.g. tests/types/recursive.yml)
+Types can refer to other types in the file
+Names can not clash across files (This seems arbitrary and we allow that for packing)
+Only records and arrays can be defined (https://github.com/common-workflow-language/cwl-v1.2/pull/14)
+
+From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py
+"""
+
+#  Copyright (c) 2021 Michael R. Crusoe
+#  Copyright (c) 2020 Seven Bridges
+#  See https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/LICENSE
+
+import sys
+import urllib.parse
+from copy import deepcopy
+from typing import Any, Dict
+
+from cwl_utils import errors, types, utils
+
+
+def build_user_defined_type_dict(
+    cwl: Dict[str, Any], base_url: urllib.parse.ParseResult
+) -> Dict[str, Any]:
+    user_defined_types = {}
+    # Check for `$import` directly under `requirements` so we can specially handle
+    # the new base_url
+    for index, entry in enumerate(cwl.get("requirements", [])):
+        if isinstance(entry, dict) and "$import" in entry:
+            requirement, new_base_url = utils.load_linked_file(
+                base_url, entry["$import"], is_import=True
+            )
+            if requirement["class"] == "SchemaDefRequirement":
+                cwl["requirements"][index] = requirement
+                type_definition_list = requirement["types"]
+                path_prefix = new_base_url.geturl()
+                sys.stderr.write(
+                    f"Parsing {len(type_definition_list)} types from {path_prefix}\n"
+                )
+                for v in type_definition_list:
+                    k = v.get("name")
+                    if k is None:
+                        raise RuntimeError(f"In file {path_prefix} type missing name")
+                    user_defined_types[f"{path_prefix}#{k}"] = v
+    return _build_user_defined_type_dict(cwl, base_url, user_defined_types)
+
+
+def _build_user_defined_type_dict(
+    cwl: Dict[str, Any],
+    base_url: urllib.parse.ParseResult,
+    user_defined_types: Dict[str, Any],
+) -> Dict[str, Any]:
+    schemadef = next(
+        (
+            req
+            for req in cwl.get("requirements", [])
+            if req.get("class") == "SchemaDefRequirement"
+        ),
+        {},
+    )
+    schema_list = schemadef.get("types", [])
+
+    if not isinstance(schema_list, list):
+        raise RuntimeError(
+            f"In file {base_url.geturl()}: "
+            f"Schemadef types have to be a list\n"
+            f"Instead, got: {schema_list}"
+        )
+
+    for schema in schema_list:
+        if not isinstance(schema, dict):
+            raise RuntimeError(
+                f"In file {base_url.geturl()}: "
+                f"User type has to be a dict\n"
+                f"Instead, got: {schema}"
+            )
+
+        if len(schema.keys()) == 1 and list(schema.keys())[0] == "$import":
+            type_definition_list, this_url = utils.load_linked_file(
+                base_url, schema["$import"], is_import=True
+            )
+            # This is always a list
+            if isinstance(type_definition_list, dict):
+                type_definition_list = [type_definition_list]
+                # except when it isn't
+
+            path_prefix = (
+                this_url.geturl()
+            )  # sbpack.lib.normalized_path(schema["$import"], base_url).geturl()
+            sys.stderr.write(
+                f"Parsing {len(type_definition_list)} types from {path_prefix}\n"
+            )
+            for v in type_definition_list:
+                k = v.get("name")
+                if k is None:
+                    raise RuntimeError(f"In file {path_prefix} type missing name")
+                user_defined_types[f"{path_prefix}#{k}"] = v
+
+        else:
+            path_prefix = base_url.geturl()
+            user_defined_types[f"{path_prefix}#{schema.get('name')}"] = schema
+
+    # sys.stderr.write(str(user_defined_types))
+    # sys.stderr.write("\n")
+
+    return user_defined_types
+
+
+# port = "input" or "output"
+def inline_types(
+    cwl: Dict[str, Any],
+    port: str,
+    base_url: urllib.parse.ParseResult,
+    user_defined_types: Dict[str, Any],
+) -> Dict[str, Any]:
+    if (
+        len(cwl[port]) == 1
+        and isinstance(cwl[port][0], dict)
+        and cwl[port][0]["id"] == "$import"
+    ):
+        defs, base_url = utils.load_linked_file(
+            base_url, cwl[port][0]["type"], is_import=True
+        )
+    else:
+        defs = cwl[port]
+
+    cwl[port] = [_inline_type(v, base_url, user_defined_types) for v in defs]
+    return cwl
+
+
+def _inline_type(
+    v: Any, base_url: urllib.parse.ParseResult, user_defined_types: Dict[str, Any]
+) -> Any:
+    try:
+        _inline_type.type_name_uniq_id += 1
+    except AttributeError:
+        _inline_type.type_name_uniq_id = 1
+    try:
+        len(_inline_type.type_names)
+    except AttributeError:
+        _inline_type.type_names = set()
+
+    if isinstance(v, str):
+
+        # Handle syntactic sugar
+        if v.endswith("[]"):
+            return {
+                "type": "array",
+                "items": _inline_type(v[:-2], base_url, user_defined_types),
+            }
+
+        if v.endswith("?"):
+            return ["null", _inline_type(v[:-1], base_url, user_defined_types)]
+
+        if v in types.built_in_types:
+            return v
+
+        if "#" not in v:
+            path_prefix = base_url
+            path_suffix = v
+        else:
+            parts = v.split("#")
+            path_prefix = utils.resolved_path(base_url, parts[0])
+            path_suffix = parts[1]
+
+        path = f"{path_prefix.geturl()}#{path_suffix}"
+
+        if path not in user_defined_types:
+            raise RuntimeError(
+                f"Could not find type '{path}' in {str(user_defined_types)}"
+            )
+        else:
+            resolve_type = deepcopy(user_defined_types[path])
+            # resolve_type.pop("name", None) # Should work, but cwltool complains
+            if "name" in resolve_type:
+                user_type_name = resolve_type["name"]
+                if user_type_name in _inline_type.type_names:
+                    resolve_type[
+                        "name"
+                    ] = f"{user_type_name}_{_inline_type.type_name_uniq_id}"
+                else:
+                    _inline_type.type_names.add(user_type_name)
+            else:
+                resolve_type["name"] = f"user_type_{_inline_type.type_name_uniq_id}"
+            return _inline_type(resolve_type, path_prefix, user_defined_types)
+
+    elif isinstance(v, list):
+        return [_inline_type(_v, base_url, user_defined_types) for _v in v]
+
+    elif isinstance(v, dict):
+        _type = v.get("type")
+        if _type is None:
+            raise errors.MissingTypeName(
+                f"In file {base_url.geturl()}, type {_type.get('name')} is missing type name"
+            )
+
+        elif _type == "enum":
+            return v
+
+        elif _type == "array":
+            if "items" not in v:
+                raise errors.ArrayMissingItems(
+                    f"In file {base_url.geturl()}, array type {_type.get('name')} is missing 'items'"
+                )
+
+            v["items"] = _inline_type(v["items"], base_url, user_defined_types)
+            return v
+
+        elif _type == "record":
+            if "fields" not in v:
+                raise errors.RecordMissingFields(
+                    f"In file {base_url.geturl()}, record type {_type.get('name')} is missing 'fields'"
+                )
+
+            fields = utils.normalize_to_list(
+                v["fields"], key_field="name", value_field="type"
+            )
+            v["fields"] = [
+                _inline_type(_f, base_url, user_defined_types) for _f in fields
+            ]
+            return v
+
+        elif _type in types.built_in_types:
+            return v
+
+        else:
+            v["type"] = _inline_type(_type, base_url, user_defined_types)
+            return v
+
+    else:
+        raise RuntimeError("Found a type sbpack can not understand")

--- a/cwl_utils/types.py
+++ b/cwl_utils/types.py
@@ -1,5 +1,23 @@
 from typing import Any, MutableMapping, MutableSequence, Optional, Union
 
+# From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py
+built_in_types = [
+    "null",
+    "boolean",
+    "int",
+    "long",
+    "float",
+    "double",
+    "string",
+    "File",
+    "Directory",
+    "stdin",
+    "stdout",
+    "stderr",
+    "Any",
+]
+
+
 CWLOutputAtomType = Union[
     None,
     bool,

--- a/cwl_utils/types.py
+++ b/cwl_utils/types.py
@@ -1,0 +1,29 @@
+from typing import Any, MutableMapping, MutableSequence, Optional, Union
+
+CWLOutputAtomType = Union[
+    None,
+    bool,
+    str,
+    int,
+    float,
+    MutableSequence[
+        Union[
+            None, bool, str, int, float, MutableSequence[Any], MutableMapping[str, Any]
+        ]
+    ],
+    MutableMapping[
+        str,
+        Union[
+            None, bool, str, int, float, MutableSequence[Any], MutableMapping[str, Any]
+        ],
+    ],
+]
+CWLOutputType = Union[
+    bool,
+    str,
+    int,
+    float,
+    MutableSequence[CWLOutputAtomType],
+    MutableMapping[str, CWLOutputAtomType],
+]
+CWLObjectType = MutableMapping[str, Optional[CWLOutputType]]

--- a/cwl_utils/utils.py
+++ b/cwl_utils/utils.py
@@ -1,0 +1,88 @@
+import os
+import subprocess
+from subprocess import DEVNULL, PIPE, Popen, TimeoutExpired
+from typing import Any, MutableMapping, MutableSequence, Union
+
+
+_USERNS = None
+
+
+def bytes2str_in_dicts(
+    inp: Union[MutableMapping[str, Any], MutableSequence[Any], Any],
+):
+    # type: (...) -> Union[str, MutableSequence[Any], MutableMapping[str, Any]]
+    """
+    Convert any present byte string to unicode string, inplace.
+
+    input is a dict of nested dicts and lists
+    """
+    # if input is dict, recursively call for each value
+    if isinstance(inp, MutableMapping):
+        for k in inp:
+            inp[k] = bytes2str_in_dicts(inp[k])
+        return inp
+
+    # if list, iterate through list and fn call
+    # for all its elements
+    if isinstance(inp, MutableSequence):
+        for idx, value in enumerate(inp):
+            inp[idx] = bytes2str_in_dicts(value)
+            return inp
+
+    # if value is bytes, return decoded string,
+    elif isinstance(inp, bytes):
+        return inp.decode("utf-8")
+
+    # simply return elements itself
+    return inp
+
+
+def kill_processes(processes_to_kill):
+    while processes_to_kill:
+        process = processes_to_kill.popleft()
+        if isinstance(process.args, MutableSequence):
+            args = process.args
+        else:
+            args = [process.args]
+        cidfile = [str(arg).split("=")[1] for arg in args if "--cidfile" in str(arg)]
+        if cidfile:  # Try to be nice
+            try:
+                with open(cidfile[0]) as inp_stream:
+                    p = subprocess.Popen(  # nosec
+                        ["docker", "kill", inp_stream.read()], shell=False  # nosec
+                    )
+                    try:
+                        p.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        p.kill()
+            except FileNotFoundError:
+                pass
+        if process.stdin:
+            process.stdin.close()
+        try:
+            process.wait(10)
+        except subprocess.TimeoutExpired:
+            pass
+        process.kill()
+
+
+def singularity_supports_userns() -> bool:
+    """Confirm if the version of Singularity install supports the --userns flag."""
+    global _USERNS  # pylint: disable=global-statement
+    if _USERNS is None:
+        try:
+            hello_image = os.path.join(os.path.dirname(__file__), "hello.simg")
+            result = Popen(  # nosec
+                ["singularity", "exec", "--userns", hello_image, "true"],
+                stderr=PIPE,
+                stdout=DEVNULL,
+                universal_newlines=True,
+            ).communicate(timeout=60)[1]
+            _USERNS = (
+                "No valid /bin/sh" in result
+                or "/bin/sh doesn't exist in container" in result
+                or "executable file not found in" in result
+            )
+        except TimeoutExpired:
+            _USERNS = False
+    return _USERNS

--- a/cwl_utils/utils.py
+++ b/cwl_utils/utils.py
@@ -1,10 +1,51 @@
 import os
-import subprocess
-from subprocess import DEVNULL, PIPE, Popen, TimeoutExpired
-from typing import Any, MutableMapping, MutableSequence, Union
+import pathlib
+import subprocess  # nosec
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from copy import deepcopy
+from typing import (
+    Any,
+    Deque,
+    Dict,
+    List,
+    MutableMapping,
+    MutableSequence,
+    Optional,
+    Tuple,
+    Union,
+)
 
+import ruamel.yaml
+from ruamel.yaml.parser import ParserError
+from ruamel.yaml.scanner import ScannerError
+
+from cwl_utils.errors import MissingKeyField
+
+fast_yaml = ruamel.yaml.YAML(typ="safe")
 
 _USERNS = None
+
+
+def _is_github_symbolic_link(base_url: urllib.parse.ParseResult, contents: str) -> bool:
+    """Look for remote path with contents that is a single line with no new
+    line with an extension.
+
+    https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py
+    """
+    if base_url.scheme in ["file://", ""]:
+        return False
+
+    idx = contents.find("\n")
+    if idx > -1:
+        return False
+
+    if "." not in contents:
+        return False
+
+    return True
 
 
 def bytes2str_in_dicts(
@@ -37,7 +78,9 @@ def bytes2str_in_dicts(
     return inp
 
 
-def kill_processes(processes_to_kill):
+def kill_processes(
+    processes_to_kill,  # type: Deque[subprocess.Popen[str]]
+) -> None:
     while processes_to_kill:
         process = processes_to_kill.popleft()
         if isinstance(process.args, MutableSequence):
@@ -66,16 +109,148 @@ def kill_processes(processes_to_kill):
         process.kill()
 
 
+def load_linked_file(
+    base_url: urllib.parse.ParseResult, link: str, is_import: bool = False
+) -> Tuple[Any, urllib.parse.ParseResult]:
+    """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
+    new_url = resolved_path(base_url, link)
+
+    if new_url.scheme in ["file://", ""]:
+        contents = pathlib.Path(new_url.path).open().read()
+    else:
+        try:
+            contents = (
+                urllib.request.urlopen(new_url.geturl()).read().decode("utf-8")  # nosec
+            )
+        except urllib.error.HTTPError as e:
+            e.msg += f"\n===\nCould not find linked file: {new_url.geturl()}\n===\n"
+            raise SystemExit(e)
+
+    if _is_github_symbolic_link(new_url, contents):
+        # This is an exception for symbolic links on github
+        sys.stderr.write(
+            f"{new_url.geturl()}: found file-like string in contents.\n"
+            f"Treating as github symbolic link to {contents}\n"
+        )
+        return load_linked_file(new_url, contents, is_import=is_import)
+
+    if is_import:
+        try:
+            _node = fast_yaml.load(contents)
+        except ParserError as e:
+            e.context = f"\n===\nMalformed file: {new_url.geturl()}\n===\n" + e.context
+            raise SystemExit(e)
+        except ScannerError as e:
+            e.problem = f"\n===\nMalformed file: {new_url.geturl()}\n===\n" + e.problem
+            raise SystemExit(e)
+
+    else:
+        _node = contents
+
+    return _node, new_url
+
+
+def normalize_to_map(
+    obj: Union[List[Any], Dict[str, Any]], key_field: str
+) -> Dict[str, Any]:
+    """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
+    if isinstance(obj, dict):
+        return deepcopy(obj)
+    elif isinstance(obj, list):
+        map_obj = {}
+        for v in obj:
+            if not isinstance(v, dict):
+                raise RuntimeError("Expecting a dict here")
+            k = v.get(key_field)
+            if k is None:
+                raise MissingKeyField(key_field)
+            v.pop(key_field, None)
+            map_obj[k] = v
+        return map_obj
+    else:
+        raise RuntimeError("Expecting a dictionary or a list here")
+
+
+def normalize_to_list(
+    obj: Union[List[Any], Dict[str, Any]], key_field: str, value_field: Optional[str]
+) -> List[Any]:
+    """From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py"""
+    if isinstance(obj, list):
+        return deepcopy(obj)
+    elif isinstance(obj, dict):
+        map_list = []
+        for k, v in obj.items():
+            if not isinstance(v, dict):
+                if value_field is None:
+                    raise RuntimeError(f"Expecting a dict here, got {v}")
+                v = {value_field: v}
+            v.update({key_field: k})
+            map_list += [v]
+        return map_list
+    else:
+        raise RuntimeError("Expecting a dictionary or a list here")
+
+
+def resolved_path(
+    base_url: urllib.parse.ParseResult, link: str
+) -> urllib.parse.ParseResult:
+    """
+    Given a base_url ("this document") and a link ("string in this document")
+    return a new url (urllib.parse.ParseResult) that allows us to retrieve the
+    linked document. This function will
+    1. Resolve the path, which means dot and double dot components are resolved
+    2. Use the OS appropriate path resolution for local paths, and network
+       apropriate resolution for network paths
+
+    From https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/sbpack/lib.py
+    """
+    link_url = urllib.parse.urlparse(link)
+    # The link will always Posix
+
+    if link_url.scheme == "file://":
+        # Absolute local path
+        new_url = urllib.parse.ParseResult(link_url)
+
+    elif link_url.scheme == "":
+        # Relative path, can be local or remote
+        if base_url.scheme in ["file://", ""]:
+            # Local relative path
+            if link == "":
+                new_url = base_url
+            else:
+                new_url = base_url._replace(
+                    path=str(
+                        (
+                            pathlib.Path(base_url.path).parent / pathlib.Path(link)
+                        ).resolve()
+                    )
+                )
+
+        else:
+            # Remote relative path
+            new_url = urllib.parse.urlparse(
+                urllib.parse.urljoin(base_url.geturl(), link_url.path)
+            )
+            # We need urljoin because we need to resolve relative links in a
+            # platform independent manner
+
+    else:
+        # Absolute remote path
+        new_url = link_url
+
+    return new_url
+
+
 def singularity_supports_userns() -> bool:
     """Confirm if the version of Singularity install supports the --userns flag."""
     global _USERNS  # pylint: disable=global-statement
     if _USERNS is None:
         try:
             hello_image = os.path.join(os.path.dirname(__file__), "hello.simg")
-            result = Popen(  # nosec
+            result = subprocess.Popen(  # nosec
                 ["singularity", "exec", "--userns", hello_image, "true"],
-                stderr=PIPE,
-                stdout=DEVNULL,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
                 universal_newlines=True,
             ).communicate(timeout=60)[1]
             _USERNS = (
@@ -83,6 +258,6 @@ def singularity_supports_userns() -> bool:
                 or "/bin/sh doesn't exist in container" in result
                 or "executable file not found in" in result
             )
-        except TimeoutExpired:
+        except subprocess.TimeoutExpired:
             _USERNS = False
     return _USERNS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 schema-salad >= 7, < 9
-cwltool
 cwl-upgrader >= 1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-requests
-schema-salad >= 7, < 9
 cwl-upgrader >= 1.2
+packaging
+requests
+schema-salad >= 8.2, < 9

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import pathlib
 import sys
 from typing import List
 
@@ -31,11 +32,11 @@ setup(
         "cwl_utils.testdata": "testdata",
     },
     include_package_data=True,
-    install_requires=[
-        "requests",
-        "schema-salad >= 8.2, < 9",
-        "cwl-upgrader >= 1.2",
-    ],
+    install_requires=open(
+        os.path.join(pathlib.Path(__file__).parent, "requirements.txt")
+    )
+    .read()
+    .splitlines(),
     tests_require=["pytest<7"],
     test_suite="tests",
     scripts=[

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,9 @@ setup(
     install_requires=[
         "requests",
         "schema-salad >= 8.2, < 9",
-        "cwltool >= 3.0.20201113183607",
         "cwl-upgrader >= 1.2",
     ],
-    tests_require=["pytest<7", "cwltool"],
+    tests_require=["pytest<7"],
     test_suite="tests",
     scripts=[
         "cwl_utils/docker_extract.py",

--- a/tests/load_cwl_by_path.py
+++ b/tests/load_cwl_by_path.py
@@ -1,9 +1,7 @@
 """This is the example from README.md, please synchronize all changes between the two."""
 # SPDX-License-Identifier: Apache-2.0
-import sys
 from pathlib import Path
 
-from ruamel import yaml
 
 from cwl_utils.parser import load_document_by_uri, save
 

--- a/tests/test_etools_to_clt.py
+++ b/tests/test_etools_to_clt.py
@@ -8,7 +8,6 @@ from typing import Generator
 import pytest
 import requests
 from _pytest.tmpdir import TempPathFactory
-from cwltool.errors import WorkflowException
 from pytest import raises
 
 import cwl_utils.parser.cwl_v1_0 as parser
@@ -17,6 +16,7 @@ import cwl_utils.parser.cwl_v1_2 as parser2
 from cwl_utils.cwl_v1_0_expression_refactor import traverse as traverse0
 from cwl_utils.cwl_v1_1_expression_refactor import traverse as traverse1
 from cwl_utils.cwl_v1_2_expression_refactor import traverse as traverse2
+from cwl_utils.errors import WorkflowException
 
 HERE = Path(__file__).resolve().parent
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,14 +3,14 @@ from pathlib import Path
 
 from ruamel import yaml
 
+import cwl_utils.parser.latest as latest
 from cwl_utils.parser import (
+    cwl_v1_2,
     cwl_version,
     load_document,
     load_document_by_uri,
     save,
-    cwl_v1_2,
 )
-import cwl_utils.parser.latest as latest
 
 HERE = Path(__file__).resolve().parent
 TEST_v1_0_CWL = HERE / "../testdata/md5sum.cwl"
@@ -71,7 +71,7 @@ def test_save() -> None:
 def test_latest_parser() -> None:
     """Test the `latest` parser is same as cwl_v1_2 (current latest) parser."""
     uri = Path(TEST_v1_2_CWL).as_uri()
-    with open(TEST_v1_2_CWL, "r") as cwl_h:
+    with open(TEST_v1_2_CWL) as cwl_h:
         yaml_obj12 = yaml.main.round_trip_load(cwl_h, preserve_quotes=True)
     latest_cwl_obj = latest.load_document_by_yaml(yaml_obj12, uri)  # type: ignore
     assert latest_cwl_obj.cwlVersion == "v1.2"


### PR DESCRIPTION
This PR removes all `cwltool` dependencies from the `cwl-utils` package, such that the CWL parsing tools can become independent of any particular implementation (including the reference one).
Moreover, JS logic has been modularised, allowing for easier implementations of different JS parsing and evaluating tools.