### PR TITLE
Added stdstreams to file conversion utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ venv.bak/
 
 testenv*/
 pydocstyle_report.txt
+
+# PyCharm
+.idea/
+

--- a/cwl_utils/parser/cwl_v1_0_utils.py
+++ b/cwl_utils/parser/cwl_v1_0_utils.py
@@ -14,7 +14,7 @@ def convert_stdstreams_to_files(clt: CommandLineTool):
                 raise ValidationException(
                     "Not allowed to specify outputBinding when using stdout shortcut.")
             if clt.stdout is None:
-                clt.stdout = str(hashlib.sha1(json_dumps(
+                clt.stdout = str(hashlib.sha1(json_dumps(  # nosec
                     clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
             out.type = 'File'
             out.outputBinding = CommandOutputBinding(glob=clt.stdout)
@@ -23,7 +23,7 @@ def convert_stdstreams_to_files(clt: CommandLineTool):
                 raise ValidationException(
                     "Not allowed to specify outputBinding when using stderr shortcut.")
             if clt.stderr is None:
-                clt.stderr = str(hashlib.sha1(json_dumps(
+                clt.stderr = str(hashlib.sha1(json_dumps(  # nosec
                     clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
             out.type = 'File'
             out.outputBinding = CommandOutputBinding(glob=clt.stderr)

--- a/cwl_utils/parser/cwl_v1_0_utils.py
+++ b/cwl_utils/parser/cwl_v1_0_utils.py
@@ -1,0 +1,40 @@
+import hashlib
+from typing import cast
+
+from schema_salad.exceptions import ValidationException
+from schema_salad.utils import json_dumps
+
+from cwl_utils.parser.cwl_v1_0 import CommandLineTool, CommandOutputBinding
+
+
+def convert_stdstreams_to_files(clt: CommandLineTool):
+    for out in clt.outputs:
+        if out.type == 'stdout':
+            if out.outputBinding is not None:
+                raise ValidationException(
+                    "Not allowed to specify outputBinding when using stdout shortcut.")
+            if clt.stdout is None:
+                clt.stdout = str(hashlib.sha1(json_dumps(
+                    clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
+            out.type = 'File'
+            out.outputBinding = CommandOutputBinding(glob=clt.stdout)
+        elif out.type == 'stderr':
+            if out.outputBinding is not None:
+                raise ValidationException(
+                    "Not allowed to specify outputBinding when using stderr shortcut.")
+            if clt.stderr is None:
+                clt.stderr = str(hashlib.sha1(json_dumps(
+                    clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
+            out.type = 'File'
+            out.outputBinding = CommandOutputBinding(glob=clt.stderr)
+    for inp in clt.inputs:
+        if inp.type == 'stdin':
+            if inp.inputBinding is not None:
+                raise ValidationException(
+                    "Not allowed to specify unputBinding when using stdin shortcut.")
+            if clt.stdin is not None:
+                raise ValidationException(
+                    "Not allowed to specify stdin path when using stdin type shortcut.")
+            else:
+                clt.stdin = '$(inputs.%s.path)' % cast(str, inp.id).rpartition('#')[2].split('/')[-1]
+                inp.type = 'File'

--- a/cwl_utils/parser/cwl_v1_0_utils.py
+++ b/cwl_utils/parser/cwl_v1_0_utils.py
@@ -27,14 +27,3 @@ def convert_stdstreams_to_files(clt: CommandLineTool):
                     clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
             out.type = 'File'
             out.outputBinding = CommandOutputBinding(glob=clt.stderr)
-    for inp in clt.inputs:
-        if inp.type == 'stdin':
-            if inp.inputBinding is not None:
-                raise ValidationException(
-                    "Not allowed to specify unputBinding when using stdin shortcut.")
-            if clt.stdin is not None:
-                raise ValidationException(
-                    "Not allowed to specify stdin path when using stdin type shortcut.")
-            else:
-                clt.stdin = '$(inputs.%s.path)' % cast(str, inp.id).rpartition('#')[2].split('/')[-1]
-                inp.type = 'File'

--- a/cwl_utils/parser/cwl_v1_0_utils.py
+++ b/cwl_utils/parser/cwl_v1_0_utils.py
@@ -1,5 +1,4 @@
 import hashlib
-from typing import cast
 
 from schema_salad.exceptions import ValidationException
 from schema_salad.utils import json_dumps
@@ -7,7 +6,7 @@ from schema_salad.utils import json_dumps
 from cwl_utils.parser.cwl_v1_0 import CommandLineTool, CommandOutputBinding
 
 
-def convert_stdstreams_to_files(clt: CommandLineTool):
+def convert_stdstreams_to_files(clt: CommandLineTool) -> None:
     for out in clt.outputs:
         if out.type == 'stdout':
             if out.outputBinding is not None:

--- a/cwl_utils/parser/cwl_v1_1_utils.py
+++ b/cwl_utils/parser/cwl_v1_1_utils.py
@@ -14,7 +14,7 @@ def convert_stdstreams_to_files(clt: CommandLineTool):
                 raise ValidationException(
                     "Not allowed to specify outputBinding when using stdout shortcut.")
             if clt.stdout is None:
-                clt.stdout = str(hashlib.sha1(json_dumps(
+                clt.stdout = str(hashlib.sha1(json_dumps(  # nosec
                     clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
             out.type = 'File'
             out.outputBinding = CommandOutputBinding(glob=clt.stdout)
@@ -23,7 +23,7 @@ def convert_stdstreams_to_files(clt: CommandLineTool):
                 raise ValidationException(
                     "Not allowed to specify outputBinding when using stderr shortcut.")
             if clt.stderr is None:
-                clt.stderr = str(hashlib.sha1(json_dumps(
+                clt.stderr = str(hashlib.sha1(json_dumps(  # nosec
                     clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
             out.type = 'File'
             out.outputBinding = CommandOutputBinding(glob=clt.stderr)

--- a/cwl_utils/parser/cwl_v1_1_utils.py
+++ b/cwl_utils/parser/cwl_v1_1_utils.py
@@ -7,7 +7,7 @@ from schema_salad.utils import json_dumps
 from cwl_utils.parser.cwl_v1_1 import CommandLineTool, CommandOutputBinding
 
 
-def convert_stdstreams_to_files(clt: CommandLineTool):
+def convert_stdstreams_to_files(clt: CommandLineTool) -> None:
     for out in clt.outputs:
         if out.type == 'stdout':
             if out.outputBinding is not None:

--- a/cwl_utils/parser/cwl_v1_1_utils.py
+++ b/cwl_utils/parser/cwl_v1_1_utils.py
@@ -1,0 +1,40 @@
+import hashlib
+from typing import cast
+
+from schema_salad.exceptions import ValidationException
+from schema_salad.utils import json_dumps
+
+from cwl_utils.parser.cwl_v1_1 import CommandLineTool, CommandOutputBinding
+
+
+def convert_stdstreams_to_files(clt: CommandLineTool):
+    for out in clt.outputs:
+        if out.type == 'stdout':
+            if out.outputBinding is not None:
+                raise ValidationException(
+                    "Not allowed to specify outputBinding when using stdout shortcut.")
+            if clt.stdout is None:
+                clt.stdout = str(hashlib.sha1(json_dumps(
+                    clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
+            out.type = 'File'
+            out.outputBinding = CommandOutputBinding(glob=clt.stdout)
+        elif out.type == 'stderr':
+            if out.outputBinding is not None:
+                raise ValidationException(
+                    "Not allowed to specify outputBinding when using stderr shortcut.")
+            if clt.stderr is None:
+                clt.stderr = str(hashlib.sha1(json_dumps(
+                    clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
+            out.type = 'File'
+            out.outputBinding = CommandOutputBinding(glob=clt.stderr)
+    for inp in clt.inputs:
+        if inp.type == 'stdin':
+            if inp.inputBinding is not None:
+                raise ValidationException(
+                    "Not allowed to specify unputBinding when using stdin shortcut.")
+            if clt.stdin is not None:
+                raise ValidationException(
+                    "Not allowed to specify stdin path when using stdin type shortcut.")
+            else:
+                clt.stdin = '$(inputs.%s.path)' % cast(str, inp.id).rpartition('#')[2].split('/')[-1]
+                inp.type = 'File'

--- a/cwl_utils/parser/cwl_v1_2_utils.py
+++ b/cwl_utils/parser/cwl_v1_2_utils.py
@@ -14,7 +14,7 @@ def convert_stdstreams_to_files(clt: CommandLineTool):
                 raise ValidationException(
                     "Not allowed to specify outputBinding when using stdout shortcut.")
             if clt.stdout is None:
-                clt.stdout = str(hashlib.sha1(json_dumps(
+                clt.stdout = str(hashlib.sha1(json_dumps(  # nosec
                     clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
             out.type = 'File'
             out.outputBinding = CommandOutputBinding(glob=clt.stdout)
@@ -23,7 +23,7 @@ def convert_stdstreams_to_files(clt: CommandLineTool):
                 raise ValidationException(
                     "Not allowed to specify outputBinding when using stderr shortcut.")
             if clt.stderr is None:
-                clt.stderr = str(hashlib.sha1(json_dumps(
+                clt.stderr = str(hashlib.sha1(json_dumps(  # nosec
                     clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
             out.type = 'File'
             out.outputBinding = CommandOutputBinding(glob=clt.stderr)

--- a/cwl_utils/parser/cwl_v1_2_utils.py
+++ b/cwl_utils/parser/cwl_v1_2_utils.py
@@ -7,7 +7,7 @@ from schema_salad.utils import json_dumps
 from cwl_utils.parser.cwl_v1_2 import CommandLineTool, CommandOutputBinding
 
 
-def convert_stdstreams_to_files(clt: CommandLineTool):
+def convert_stdstreams_to_files(clt: CommandLineTool) -> None:
     for out in clt.outputs:
         if out.type == 'stdout':
             if out.outputBinding is not None:

--- a/cwl_utils/parser/cwl_v1_2_utils.py
+++ b/cwl_utils/parser/cwl_v1_2_utils.py
@@ -1,0 +1,40 @@
+import hashlib
+from typing import cast
+
+from schema_salad.exceptions import ValidationException
+from schema_salad.utils import json_dumps
+
+from cwl_utils.parser.cwl_v1_2 import CommandLineTool, CommandOutputBinding
+
+
+def convert_stdstreams_to_files(clt: CommandLineTool):
+    for out in clt.outputs:
+        if out.type == 'stdout':
+            if out.outputBinding is not None:
+                raise ValidationException(
+                    "Not allowed to specify outputBinding when using stdout shortcut.")
+            if clt.stdout is None:
+                clt.stdout = str(hashlib.sha1(json_dumps(
+                    clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
+            out.type = 'File'
+            out.outputBinding = CommandOutputBinding(glob=clt.stdout)
+        elif out.type == 'stderr':
+            if out.outputBinding is not None:
+                raise ValidationException(
+                    "Not allowed to specify outputBinding when using stderr shortcut.")
+            if clt.stderr is None:
+                clt.stderr = str(hashlib.sha1(json_dumps(
+                    clt.save(), sort_keys=True).encode('utf-8')).hexdigest())
+            out.type = 'File'
+            out.outputBinding = CommandOutputBinding(glob=clt.stderr)
+    for inp in clt.inputs:
+        if inp.type == 'stdin':
+            if inp.inputBinding is not None:
+                raise ValidationException(
+                    "Not allowed to specify unputBinding when using stdin shortcut.")
+            if clt.stdin is not None:
+                raise ValidationException(
+                    "Not allowed to specify stdin path when using stdin type shortcut.")
+            else:
+                clt.stdin = '$(inputs.%s.path)' % cast(str, inp.id).rpartition('#')[2].split('/')[-1]
+                inp.type = 'File'

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -1,6 +1,6 @@
 """Test the CWL parsers utility functions."""
 
-from _pytest.python_api import raises
+from pytest import raises
 from schema_salad.exceptions import ValidationException
 
 import cwl_utils.parser.cwl_v1_0

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -1,3 +1,5 @@
+"""Test the CWL parsers utility functions."""
+
 from _pytest.python_api import raises
 from schema_salad.exceptions import ValidationException
 
@@ -10,6 +12,7 @@ import cwl_utils.parser.cwl_v1_2_utils
 
 
 def test_v1_0_stdout_to_file() -> None:
+    """Test that stdout shortcut is converted to stdout parameter with CWL v1.0."""
     clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
         inputs=[],
         outputs=[
@@ -22,6 +25,7 @@ def test_v1_0_stdout_to_file() -> None:
 
 
 def test_v1_0_stdout_to_file_with_binding() -> None:
+    """Test that outputBinding is not allowed with stdout shortcut with CWL v1.0."""
     with raises(ValidationException):
         clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
             inputs=[],
@@ -39,6 +43,7 @@ def test_v1_0_stdout_to_file_with_binding() -> None:
 
 
 def test_v1_0_stdout_to_file_preserve_original() -> None:
+    """Test that stdout parameter prevails on stdout shortcut with CWL v1.0."""
     clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
         inputs=[],
         outputs=[
@@ -52,6 +57,7 @@ def test_v1_0_stdout_to_file_preserve_original() -> None:
 
 
 def test_v1_0_stderr_to_file() -> None:
+    """Test that stderr shortcut is converted to stderr parameter with CWL v1.0."""
     clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
         inputs=[],
         outputs=[
@@ -64,6 +70,7 @@ def test_v1_0_stderr_to_file() -> None:
 
 
 def test_v1_0_stderr_to_file_with_binding() -> None:
+    """Test that outputBinding is not allowed with stderr shortcut with CWL v1.0."""
     with raises(ValidationException):
         clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
             inputs=[],
@@ -81,6 +88,7 @@ def test_v1_0_stderr_to_file_with_binding() -> None:
 
 
 def test_v1_0_stderr_to_file_preserve_original() -> None:
+    """Test that stderr parameter prevails on stdout shortcut with CWL v1.0."""
     clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
         inputs=[],
         outputs=[
@@ -94,6 +102,7 @@ def test_v1_0_stderr_to_file_preserve_original() -> None:
 
 
 def test_v1_1_stdout_to_file() -> None:
+    """Test that stdout shortcut is converted to stdout parameter with CWL v1.1."""
     clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
         inputs=[],
         outputs=[
@@ -106,6 +115,7 @@ def test_v1_1_stdout_to_file() -> None:
 
 
 def test_v1_1_stdout_to_file_with_binding() -> None:
+    """Test that outputBinding is not allowed with stdout shortcut with CWL v1.1."""
     with raises(ValidationException):
         clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
             inputs=[],
@@ -123,6 +133,7 @@ def test_v1_1_stdout_to_file_with_binding() -> None:
 
 
 def test_v1_1_stdout_to_file_preserve_original() -> None:
+    """Test that stdout parameter prevails on stdout shortcut with CWL v1.1."""
     clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
         inputs=[],
         outputs=[
@@ -136,6 +147,7 @@ def test_v1_1_stdout_to_file_preserve_original() -> None:
 
 
 def test_v1_1_stderr_to_file() -> None:
+    """Test that stderr shortcut is converted to stderr parameter with CWL v1.1."""
     clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
         inputs=[],
         outputs=[
@@ -148,6 +160,7 @@ def test_v1_1_stderr_to_file() -> None:
 
 
 def test_v1_1_stderr_to_file_with_binding() -> None:
+    """Test that outputBinding is not allowed with stderr shortcut with CWL v1.1."""
     with raises(ValidationException):
         clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
             inputs=[],
@@ -165,6 +178,7 @@ def test_v1_1_stderr_to_file_with_binding() -> None:
 
 
 def test_v1_1_stderr_to_file_preserve_original() -> None:
+    """Test that stderr parameter prevails on stdout shortcut with CWL v1.1."""
     clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
         inputs=[],
         outputs=[
@@ -178,6 +192,7 @@ def test_v1_1_stderr_to_file_preserve_original() -> None:
 
 
 def test_v1_1_stdin_to_file() -> None:
+    """Test that stdin shortcut is converted to stdin parameter with CWL v1.1."""
     clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
         inputs=[
             cwl_utils.parser.cwl_v1_1.CommandInputParameter(id="test", type="stdin")
@@ -189,6 +204,7 @@ def test_v1_1_stdin_to_file() -> None:
 
 
 def test_v1_1_stdin_to_file_with_binding() -> None:
+    """Test that inputBinding is not allowed with stdin shortcut with CWL v1.1."""
     with raises(ValidationException):
         clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
             inputs=[
@@ -206,6 +222,7 @@ def test_v1_1_stdin_to_file_with_binding() -> None:
 
 
 def test_v1_1_stdin_to_file_fail_with_original() -> None:
+    """Test that stdin shortcut fails when stdin parameter is defined with CWL v1.1."""
     with raises(ValidationException):
         clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
             inputs=[
@@ -218,6 +235,7 @@ def test_v1_1_stdin_to_file_fail_with_original() -> None:
 
 
 def test_v1_2_stdout_to_file() -> None:
+    """Test that stdout shortcut is converted to stdout parameter with CWL v1.2."""
     clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
         inputs=[],
         outputs=[
@@ -230,6 +248,7 @@ def test_v1_2_stdout_to_file() -> None:
 
 
 def test_v1_2_stdout_to_file_with_binding() -> None:
+    """Test that outputBinding is not allowed with stdout shortcut with CWL v1.2."""
     with raises(ValidationException):
         clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
             inputs=[],
@@ -247,6 +266,7 @@ def test_v1_2_stdout_to_file_with_binding() -> None:
 
 
 def test_v1_2_stdout_to_file_preserve_original() -> None:
+    """Test that stdout parameter prevails on stdout shortcut with CWL v1.2."""
     clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
         inputs=[],
         outputs=[
@@ -260,6 +280,7 @@ def test_v1_2_stdout_to_file_preserve_original() -> None:
 
 
 def test_v1_2_stderr_to_file() -> None:
+    """Test that stderr shortcut is converted to stderr parameter with CWL v1.2."""
     clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
         inputs=[],
         outputs=[
@@ -272,6 +293,7 @@ def test_v1_2_stderr_to_file() -> None:
 
 
 def test_v1_2_stderr_to_file_with_binding() -> None:
+    """Test that outputBinding is not allowed with stderr shortcut with CWL v1.2."""
     with raises(ValidationException):
         clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
             inputs=[],
@@ -289,6 +311,7 @@ def test_v1_2_stderr_to_file_with_binding() -> None:
 
 
 def test_v1_2_stderr_to_file_preserve_original() -> None:
+    """Test that stderr parameter prevails on stdout shortcut with CWL v1.2."""
     clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
         inputs=[],
         outputs=[
@@ -302,6 +325,7 @@ def test_v1_2_stderr_to_file_preserve_original() -> None:
 
 
 def test_v1_2_stdin_to_file() -> None:
+    """Test that stdin shortcut is converted to stdin parameter with CWL v1.2."""
     clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
         inputs=[
             cwl_utils.parser.cwl_v1_2.CommandInputParameter(id="test", type="stdin")
@@ -313,6 +337,7 @@ def test_v1_2_stdin_to_file() -> None:
 
 
 def test_v1_2_stdin_to_file_with_binding() -> None:
+    """Test that inputBinding is not allowed with stdin shortcut with CWL v1.2."""
     with raises(ValidationException):
         clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
             inputs=[
@@ -330,6 +355,7 @@ def test_v1_2_stdin_to_file_with_binding() -> None:
 
 
 def test_v1_2_stdin_to_file_fail_with_original() -> None:
+    """Test that stdin shortcut fails when stdin parameter is defined with CWL v1.2."""
     with raises(ValidationException):
         clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
             inputs=[

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -1,0 +1,341 @@
+from _pytest.python_api import raises
+from schema_salad.exceptions import ValidationException
+
+import cwl_utils.parser.cwl_v1_0
+import cwl_utils.parser.cwl_v1_0_utils
+import cwl_utils.parser.cwl_v1_1
+import cwl_utils.parser.cwl_v1_1_utils
+import cwl_utils.parser.cwl_v1_2
+import cwl_utils.parser.cwl_v1_2_utils
+
+
+def test_v1_0_stdout_to_file() -> None:
+    clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_0.CommandOutputParameter(id="test", type="stdout")
+        ],
+    )
+    cwl_utils.parser.cwl_v1_0_utils.convert_stdstreams_to_files(clt)
+    assert clt.stdout is not None
+    assert clt.stdout == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_0_stdout_to_file_with_binding() -> None:
+    with raises(ValidationException):
+        clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
+            inputs=[],
+            outputs=[
+                cwl_utils.parser.cwl_v1_0.CommandOutputParameter(
+                    id="test",
+                    type="stdout",
+                    outputBinding=cwl_utils.parser.cwl_v1_0.CommandOutputBinding(
+                        glob="output.txt"
+                    ),
+                )
+            ],
+        )
+        cwl_utils.parser.cwl_v1_0_utils.convert_stdstreams_to_files(clt)
+
+
+def test_v1_0_stdout_to_file_preserve_original() -> None:
+    clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_0.CommandOutputParameter(id="test", type="stdout")
+        ],
+        stdout="original.txt",
+    )
+    cwl_utils.parser.cwl_v1_0_utils.convert_stdstreams_to_files(clt)
+    assert clt.stdout == "original.txt"
+    assert clt.stdout == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_0_stderr_to_file() -> None:
+    clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_0.CommandOutputParameter(id="test", type="stderr")
+        ],
+    )
+    cwl_utils.parser.cwl_v1_0_utils.convert_stdstreams_to_files(clt)
+    assert clt.stderr is not None
+    assert clt.stderr == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_0_stderr_to_file_with_binding() -> None:
+    with raises(ValidationException):
+        clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
+            inputs=[],
+            outputs=[
+                cwl_utils.parser.cwl_v1_0.CommandOutputParameter(
+                    id="test",
+                    type="stderr",
+                    outputBinding=cwl_utils.parser.cwl_v1_0.CommandOutputBinding(
+                        glob="err.txt"
+                    ),
+                )
+            ],
+        )
+        cwl_utils.parser.cwl_v1_0_utils.convert_stdstreams_to_files(clt)
+
+
+def test_v1_0_stderr_to_file_preserve_original() -> None:
+    clt = cwl_utils.parser.cwl_v1_0.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_0.CommandOutputParameter(id="test", type="stderr")
+        ],
+        stderr="original.txt",
+    )
+    cwl_utils.parser.cwl_v1_0_utils.convert_stdstreams_to_files(clt)
+    assert clt.stderr == "original.txt"
+    assert clt.stderr == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_1_stdout_to_file() -> None:
+    clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_1.CommandOutputParameter(id="test", type="stdout")
+        ],
+    )
+    cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
+    assert clt.stdout is not None
+    assert clt.stdout == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_1_stdout_to_file_with_binding() -> None:
+    with raises(ValidationException):
+        clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
+            inputs=[],
+            outputs=[
+                cwl_utils.parser.cwl_v1_1.CommandOutputParameter(
+                    id="test",
+                    type="stdout",
+                    outputBinding=cwl_utils.parser.cwl_v1_1.CommandOutputBinding(
+                        glob="output.txt"
+                    ),
+                )
+            ],
+        )
+        cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
+
+
+def test_v1_1_stdout_to_file_preserve_original() -> None:
+    clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_1.CommandOutputParameter(id="test", type="stdout")
+        ],
+        stdout="original.txt",
+    )
+    cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
+    assert clt.stdout == "original.txt"
+    assert clt.stdout == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_1_stderr_to_file() -> None:
+    clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_1.CommandOutputParameter(id="test", type="stderr")
+        ],
+    )
+    cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
+    assert clt.stderr is not None
+    assert clt.stderr == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_1_stderr_to_file_with_binding() -> None:
+    with raises(ValidationException):
+        clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
+            inputs=[],
+            outputs=[
+                cwl_utils.parser.cwl_v1_1.CommandOutputParameter(
+                    id="test",
+                    type="stderr",
+                    outputBinding=cwl_utils.parser.cwl_v1_1.CommandOutputBinding(
+                        glob="err.txt"
+                    ),
+                )
+            ],
+        )
+        cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
+
+
+def test_v1_1_stderr_to_file_preserve_original() -> None:
+    clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_1.CommandOutputParameter(id="test", type="stderr")
+        ],
+        stderr="original.txt",
+    )
+    cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
+    assert clt.stderr == "original.txt"
+    assert clt.stderr == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_1_stdin_to_file() -> None:
+    clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
+        inputs=[
+            cwl_utils.parser.cwl_v1_1.CommandInputParameter(id="test", type="stdin")
+        ],
+        outputs=[],
+    )
+    cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
+    assert clt.stdin is not None
+
+
+def test_v1_1_stdin_to_file_with_binding() -> None:
+    with raises(ValidationException):
+        clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
+            inputs=[
+                cwl_utils.parser.cwl_v1_1.CommandInputParameter(
+                    id="test",
+                    type="stdin",
+                    inputBinding=cwl_utils.parser.cwl_v1_1.CommandLineBinding(
+                        prefix="--test"
+                    ),
+                )
+            ],
+            outputs=[],
+        )
+        cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
+
+
+def test_v1_1_stdin_to_file_fail_with_original() -> None:
+    with raises(ValidationException):
+        clt = cwl_utils.parser.cwl_v1_1.CommandLineTool(
+            inputs=[
+                cwl_utils.parser.cwl_v1_1.CommandInputParameter(id="test", type="stdin")
+            ],
+            outputs=[],
+            stdin="original.txt",
+        )
+        cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
+
+
+def test_v1_2_stdout_to_file() -> None:
+    clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_2.CommandOutputParameter(id="test", type="stdout")
+        ],
+    )
+    cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
+    assert clt.stdout is not None
+    assert clt.stdout == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_2_stdout_to_file_with_binding() -> None:
+    with raises(ValidationException):
+        clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
+            inputs=[],
+            outputs=[
+                cwl_utils.parser.cwl_v1_2.CommandOutputParameter(
+                    id="test",
+                    type="stdout",
+                    outputBinding=cwl_utils.parser.cwl_v1_2.CommandOutputBinding(
+                        glob="output.txt"
+                    ),
+                )
+            ],
+        )
+        cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
+
+
+def test_v1_2_stdout_to_file_preserve_original() -> None:
+    clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_2.CommandOutputParameter(id="test", type="stdout")
+        ],
+        stdout="original.txt",
+    )
+    cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
+    assert clt.stdout == "original.txt"
+    assert clt.stdout == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_2_stderr_to_file() -> None:
+    clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_2.CommandOutputParameter(id="test", type="stderr")
+        ],
+    )
+    cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
+    assert clt.stderr is not None
+    assert clt.stderr == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_2_stderr_to_file_with_binding() -> None:
+    with raises(ValidationException):
+        clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
+            inputs=[],
+            outputs=[
+                cwl_utils.parser.cwl_v1_2.CommandOutputParameter(
+                    id="test",
+                    type="stderr",
+                    outputBinding=cwl_utils.parser.cwl_v1_2.CommandOutputBinding(
+                        glob="err.txt"
+                    ),
+                )
+            ],
+        )
+        cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
+
+
+def test_v1_2_stderr_to_file_preserve_original() -> None:
+    clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
+        inputs=[],
+        outputs=[
+            cwl_utils.parser.cwl_v1_2.CommandOutputParameter(id="test", type="stderr")
+        ],
+        stderr="original.txt",
+    )
+    cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
+    assert clt.stderr == "original.txt"
+    assert clt.stderr == clt.outputs[0].outputBinding.glob
+
+
+def test_v1_2_stdin_to_file() -> None:
+    clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
+        inputs=[
+            cwl_utils.parser.cwl_v1_2.CommandInputParameter(id="test", type="stdin")
+        ],
+        outputs=[],
+    )
+    cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
+    assert clt.stdin is not None
+
+
+def test_v1_2_stdin_to_file_with_binding() -> None:
+    with raises(ValidationException):
+        clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
+            inputs=[
+                cwl_utils.parser.cwl_v1_2.CommandInputParameter(
+                    id="test",
+                    type="stdin",
+                    inputBinding=cwl_utils.parser.cwl_v1_2.CommandLineBinding(
+                        prefix="--test"
+                    ),
+                )
+            ],
+            outputs=[],
+        )
+        cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
+
+
+def test_v1_2_stdin_to_file_fail_with_original() -> None:
+    with raises(ValidationException):
+        clt = cwl_utils.parser.cwl_v1_2.CommandLineTool(
+            inputs=[
+                cwl_utils.parser.cwl_v1_2.CommandInputParameter(id="test", type="stdin")
+            ],
+            outputs=[],
+            stdin="original.txt",
+        )
+        cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)


### PR DESCRIPTION
Added three `utils` files for the three available CWL versions in the `parser` module.
This structure enforces separation of concerns, which is good. However, it creates a lot of redundancy, which is not good for manually-maintained code.
I'd like to discuss if there are better ways to proceed (e.g., auto-generating the `_utils` files, too?) 