### PR TITLE
Add missing cwlformat to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cwl-upgrader >= 1.2.3
+cwlformat
 packaging
 rdflib
 requests


### PR DESCRIPTION
Added `cwl-graph-split --help` to the Conda recipe tests, in https://github.com/conda-forge/staged-recipes/pull/19969, but it failed due to missing import :+1: 

Maybe we should test that here in this repository as well, not sure if calling that command directly in GH Actions, or in a `pytest` test, etc.

-Bruno