### PR TITLE
docker extract parser updated to v1.2

### DIFF
--- a/cwl_utils/docker_extract.py
+++ b/cwl_utils/docker_extract.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Iterator, List, Union, cast
 
-import cwl_utils.parser.cwl_v1_0 as cwl
+import cwl_utils.parser.cwl_v1_2 as cwl
 from cwl_utils.image_puller import (
     DockerImagePuller,
     ImagePuller,


### PR DESCRIPTION
I found that the docker extract tool would not work with my new workflows using the v1.0 parser. So I've updated this to the v1.2 parser. 