### PR TITLE
packing: Allow `$import`s in type fields

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,11 @@ include testdata/*.yaml
 include testdata/*.input
 include testdata/*.ttl
 include testdata/*.owl
+include testdata/*.js
+include testdata/remote-cwl/*.cwl
+include testdata/workflows/*.cwl
+include testdata/workflows/*.yaml
+include testdata/types/*.yml
 include testdata/checker_wf/*.cwl
 include cwl_utils/py.typed
 include docs/conf.py docs/Makefile docs/_static/favicon.ico docs/requirements.txt

--- a/cwl_utils/schemadef.py
+++ b/cwl_utils/schemadef.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+#  Copyright (c) 2023 Genomics plc
 #  Copyright (c) 2021 Michael R. Crusoe
 #  Copyright (c) 2020 Seven Bridges
 #  See https://github.com/rabix/sbpack/blob/b8404a0859ffcbe1edae6d8f934e51847b003320/LICENSE
@@ -191,6 +192,12 @@ def _inline_type(
         return [_inline_type(_v, base_url, user_defined_types) for _v in v]
 
     elif isinstance(v, dict):
+        if v.get("$import") is not None:
+            imported_type, import_base_url = utils.load_linked_file(
+                base_url, v["$import"], is_import=True
+            )
+            return _inline_type(imported_type, import_base_url, user_defined_types)
+
         _type = v.get("type")
         if _type is None:
             raise errors.MissingTypeName(

--- a/testdata/lib.js
+++ b/testdata/lib.js
@@ -1,0 +1,7 @@
+var foo = function(x) {
+    return 2 * x
+}
+
+var bar = function(n, x) {
+    return `{n} engineers walk into a {x}`
+}

--- a/testdata/remote-cwl/tool1.cwl
+++ b/testdata/remote-cwl/tool1.cwl
@@ -1,0 +1,26 @@
+# We have this tool to test both local and remote packing
+
+class: CommandLineTool
+cwlVersion: v1.0
+inputs:
+  in1: 
+    type: string
+    inputBinding: 
+      position: 1
+      valueFrom: A_$(inputs.in1)_B_${return inputs.in1}_C_$(inputs.in1)
+baseCommand: echo
+arguments:
+  - valueFrom: $(runtime)
+outputs:
+  out1:
+    type: string
+    outputBinding:
+      glob: out.txt
+      loadContents: true
+      outputEval: $(self)_D_$(runtime)
+
+stdout: out.txt
+requirements:
+  InlineJavascriptRequirement:
+    expressionLib:
+      - $include: ../lib.js

--- a/testdata/remote-cwl/tool2.cwl
+++ b/testdata/remote-cwl/tool2.cwl
@@ -1,0 +1,26 @@
+# We have this tool to test both local and remote packing
+
+class: CommandLineTool
+cwlVersion: v1.0
+inputs:
+  in1:
+    type: ../types/testtypes.yml#my_boolean_array
+    inputBinding:
+      position: 1
+      valueFrom: A_$(inputs.in1)_B_${return inputs.in1}_C_$(inputs.in1)
+baseCommand: echo
+arguments:
+  - valueFrom: $(runtime)
+outputs:
+  out1:
+    type: string
+    outputBinding:
+      glob: out.txt
+      loadContents: true
+      outputEval: $(self)_D_$(runtime)
+
+stdout: out.txt
+requirements:
+  SchemaDefRequirement:
+    types: 
+      - $import: ../types/testtypes.yml

--- a/testdata/remote-cwl/wf1.cwl
+++ b/testdata/remote-cwl/wf1.cwl
@@ -1,0 +1,27 @@
+class: Workflow
+cwlVersion: v1.0
+inputs:
+  - id: in1
+    type: ../types/testtypes.yml#my_boolean_array
+
+steps:
+  s1:
+    run: ./tool2.cwl
+    in:
+      in1: "#in1"   # This should be normalized out
+    out: [out1]
+  s2:
+    run: tool1.cwl
+    in:
+      in1: s1/out1
+    out: [out1]
+
+outputs:
+  - id: out1 
+    type: string 
+    outputSource: "#s2/out1"
+
+requirements:
+  SchemaDefRequirement:
+    types:
+      - $import: ../types/testtypes.yml

--- a/testdata/types/array.yml
+++ b/testdata/types/array.yml
@@ -1,0 +1,30 @@
+# Contains arrays and intra-file type reference
+
+# class: SchemaDefRequirement
+# types: ...
+# This form does not work with cwltool, even though it can be found here
+# https://github.com/NCI-GDC/gdc-dnaseq-cwl/blob/master/tools/readgroup_path.yml
+# Notably, that .yml file is never used, so likely they tried it, failed and
+# forgot to take it out
+
+
+  - name: sample_meta2  #duplicate names are not fine across files
+    type: record
+    fields:
+      - name: prop
+        type: string
+
+  - name: study_meta
+    type: array
+    items: sample_meta2
+
+  # Apparently can't declare an array inside an array?
+  # - name: study_meta_too
+  #   type: array
+  #   items: [string, sample_meta2, study_meta]
+    
+  - name: study_meta_too
+    type: record
+    fields:
+      meta1: sample_meta2
+      meta2: study_meta

--- a/testdata/types/recursive.yml
+++ b/testdata/types/recursive.yml
@@ -1,0 +1,26 @@
+# Contains records and intra-file type reference
+# You can't have an enum in a user type
+
+- name: sample_meta
+  type: record
+  fields:
+    - name: sample
+      type: ["null", string]
+    - name: species
+      type: string
+
+- name: file_with_sample_meta
+  type: record
+  fields:
+    - name: file
+      type: File
+    - name: meta
+      type: sample_meta
+
+- name: info_with_sample_meta
+  type: record
+  fields:
+    comment: 
+      type: string
+    meta: 
+      type: sample_meta

--- a/testdata/types/singletype.yml
+++ b/testdata/types/singletype.yml
@@ -1,0 +1,7 @@
+# You can not use the dictionary format shown in
+# singletype2.yml. It has to be this
+
+name: simple_record
+type: record
+fields:
+  prop: string

--- a/testdata/types/singletype2.yml
+++ b/testdata/types/singletype2.yml
@@ -1,0 +1,6 @@
+# You can not use this dictionary format
+
+simple_record2:
+  type: record
+  fields:
+    prop: string

--- a/testdata/types/testtypes.yml
+++ b/testdata/types/testtypes.yml
@@ -1,0 +1,9 @@
+- name: my_boolean_array
+  type: array
+  items: boolean
+  label: "A boolean array"
+
+- name: my_enum
+  type: enum
+  symbols: [a, b, c]
+  label: "A required enum"

--- a/testdata/wf2.cwl
+++ b/testdata/wf2.cwl
@@ -1,0 +1,29 @@
+class: Workflow
+cwlVersion: v1.0
+inputs:
+  in1: types/testtypes.yml#my_boolean_array
+  in2: 
+    type: types/testtypes.yml#my_enum
+
+steps:
+  s1:
+    run: remote-cwl/wf1.cwl
+    in:
+      - id: in1
+        source: "#in1"
+    out: [out1]
+  s2:
+    run: remote-cwl/tool1.cwl
+    in:
+      in1: s1/out1
+    out: [out1]
+
+outputs:
+  out1: 
+    type: string 
+    outputSource: "#s2/out1"
+
+requirements:
+  SchemaDefRequirement:
+    types:
+      - $import: types/testtypes.yml

--- a/testdata/workflows/count-lines16-wf.cwl
+++ b/testdata/workflows/count-lines16-wf.cwl
@@ -1,0 +1,32 @@
+#!/usr/bin/env cwl-runner
+class: Workflow
+cwlVersion: v1.2
+inputs:
+  file1: File
+outputs:
+  count_output: {type: int, outputSource: step1/count_output}
+requirements:
+  SubworkflowFeatureRequirement: {}
+steps:
+  step1:
+    in: {file1: file1}
+    out: [count_output]
+    run:
+      class: Workflow
+      inputs:
+        file1: File
+      outputs:
+        count_output: {type: int, outputSource: step2/count_output}
+      steps:
+        step1: {run: wc-tool.cwl, in: {file1: file1}, out: [output]}
+        step2:
+          in: {file1: step1/output}
+          out: [count_output]
+          run:
+            class: Workflow
+            inputs:
+              file1: File
+            outputs:
+              count_output: {type: int, outputSource: step1/output}
+            steps:
+              step1: {run: parseInt-tool.cwl, in: {file1: file1}, out: [output]}

--- a/testdata/workflows/import-in-type.cwl
+++ b/testdata/workflows/import-in-type.cwl
@@ -1,0 +1,19 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+cwlVersion: v1.2
+
+inputs:
+ file1:
+  type:
+    $import: type-import.yaml
+
+outputs:
+  output:
+    type: File
+    outputBinding: { glob: output }
+
+baseCommand: [wc, -l]
+
+stdin: $(inputs.file1.path)
+stdout: output

--- a/testdata/workflows/parseInt-tool.cwl
+++ b/testdata/workflows/parseInt-tool.cwl
@@ -1,0 +1,16 @@
+#!/usr/bin/env cwl-runner
+
+class: ExpressionTool
+requirements:
+  - class: InlineJavascriptRequirement
+cwlVersion: v1.2
+
+inputs:
+  file1:
+    type: File
+    loadContents: true
+
+outputs:
+  output: int
+
+expression: "$({'output': parseInt(inputs.file1.contents)})"

--- a/testdata/workflows/scatter-wf4.cwl
+++ b/testdata/workflows/scatter-wf4.cwl
@@ -1,0 +1,46 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.2
+$graph:
+- id: echo
+  class: CommandLineTool
+  inputs:
+    echo_in1:
+      type: string
+      inputBinding: {}
+    echo_in2:
+      type: string
+      inputBinding: {}
+  outputs:
+    echo_out:
+      type: string
+      outputBinding:
+        glob: "step1_out"
+        loadContents: true
+        outputEval: $(self[0].contents)
+  baseCommand: "echo"
+  arguments: ["-n", "foo"]
+  stdout: step1_out
+
+- id: main
+  class: Workflow
+  inputs:
+    inp1: string[]
+    inp2: string[]
+  requirements:
+    - class: ScatterFeatureRequirement
+  steps:
+    step1:
+      scatter: [echo_in1, echo_in2]
+      scatterMethod: dotproduct
+      in:
+        echo_in1: inp1
+        echo_in2: inp2
+      out: [echo_out]
+      run: "#echo"
+
+  outputs:
+    - id: out
+      outputSource: step1/echo_out
+      type:
+        type: array
+        items: string

--- a/testdata/workflows/type-import.yaml
+++ b/testdata/workflows/type-import.yaml
@@ -1,0 +1,2 @@
+- File
+- Directory

--- a/testdata/workflows/wc-tool.cwl
+++ b/testdata/workflows/wc-tool.cwl
@@ -1,0 +1,17 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+cwlVersion: v1.2
+
+inputs:
+  file1: File
+
+outputs:
+  output:
+    type: File
+    outputBinding: { glob: output }
+
+baseCommand: [wc, -l]
+
+stdin: $(inputs.file1.path)
+stdout: output

--- a/testdata/workflows/wf5.cwl
+++ b/testdata/workflows/wf5.cwl
@@ -1,0 +1,40 @@
+# Checks symbolic links on github
+
+class: Workflow
+cwlVersion: v1.0
+inputs:
+  in1:
+    type: ../types/recursive.yml#file_with_sample_meta
+  in2:
+    type: ../types/array.yml#study_meta_too
+  in3:
+    type: ../types/singletype.yml#simple_record
+  in4:
+    type: [string, ../types/recursive.yml#sample_meta]
+
+steps:
+  s1:
+    run: ../tools/link-to-clt1.cwl
+    in:
+      in1: "#in1"   # This should be normalized out
+      in2: in2
+      in3: in3
+      in4: in4
+    out: [out2]
+
+outputs:
+  - id: out1
+    type: ../types/array.yml#study_meta_too
+    outputSource: "#s1/out2"
+
+requirements:
+  SchemaDefRequirement:
+    types:
+    - $import: ../types/recursive.yml
+    - $import: ../types/array.yml
+    - $import: ../types/singletype.yml
+    - name: user_type1  # For tools/clt2.cwl
+      type: record
+      fields:
+          - name: prop
+            type: string

--- a/tests/test_packing.py
+++ b/tests/test_packing.py
@@ -1,0 +1,102 @@
+from typing import Any, List
+
+from cwl_utils.pack import pack
+
+from .util import get_data
+
+
+def _find(l_item: List[Any], key: str, val: str) -> Any:
+    return next(_x for _x in l_item if _x[key] == val)
+
+
+def test_port_normalization() -> None:
+    cwl = pack(get_data("testdata/remote-cwl/wf1.cwl"))
+    step_s1 = _find(cwl.get("steps", []), "id", "s1")
+    step_in1 = _find(step_s1.get("in"), "id", "in1")
+    assert step_in1["source"] == "in1"
+
+    cwl = pack(get_data("testdata/wf2.cwl"))
+    step_s1 = _find(cwl.get("steps", []), "id", "s1")
+    step_in1 = _find(step_s1.get("in"), "id", "in1")
+    assert step_in1["source"] == "in1"
+
+    out1 = _find(cwl.get("outputs", []), "id", "out1")
+    assert out1.get("outputSource") == "s2/out1"
+
+
+def test_include() -> None:
+    cwl = pack(get_data("testdata/remote-cwl/tool1.cwl"))
+    assert "arguments" in cwl
+    assert isinstance(cwl.get("arguments"), list)
+
+    inline_js_req = _find(
+        cwl.get("requirements", []), "class", "InlineJavascriptRequirement"
+    )
+    include_js = inline_js_req.get("expressionLib")
+
+    assert isinstance(include_js, list)
+    assert "engineers walk into a" in include_js[0]
+
+
+def test_schema_def1() -> None:
+    cwl = pack(get_data("testdata/remote-cwl/tool2.cwl"))
+    _type = _find(cwl.get("inputs", []), "id", "in1").get("type")
+    assert isinstance(_type, dict)
+    assert _type.get("type") == "array"
+
+
+def test_schema_def2() -> None:
+    cwl = pack(get_data("testdata/wf2.cwl"))
+    _type = _find(cwl.get("inputs", []), "id", "in2").get("type")
+    assert isinstance(_type, dict)
+    assert _type.get("type") == "enum"
+
+
+def test_step_packing() -> None:
+    cwl = pack(get_data("testdata/remote-cwl/wf1.cwl"))
+    s1 = _find(cwl.get("steps", []), "id", "s1")
+    tool2 = s1.get("run")
+    _type = _find(tool2.get("inputs"), "id", "in1").get("type")
+    assert isinstance(_type, dict)
+    assert _type.get("type") == "array"
+
+
+def test_embedded_packing() -> None:
+    pack(get_data("testdata/workflows/count-lines16-wf.cwl"))
+
+
+def test_remote_packing() -> None:
+    cwl = pack(
+        "https://raw.githubusercontent.com/kaushik-work/sbpack/master/tests/wf2.cwl"
+    )
+    s1 = _find(cwl.get("steps", []), "id", "s1")
+    wf1 = s1.get("run")
+    assert wf1.get("class") == "Workflow"
+
+    tool2 = _find(wf1.get("steps"), "id", "s1").get("run")
+    _type = _find(tool2.get("inputs"), "id", "in1").get("type")
+    assert isinstance(_type, dict)
+    assert _type.get("type") == "array"
+
+
+def test_remote_packing_github_soft_links() -> None:
+    cwl = pack(
+        "https://raw.githubusercontent.com/rabix/sbpack/master/tests/workflows/wf5.cwl"
+    )
+    s1 = _find(cwl.get("steps", []), "id", "s1")
+    tool1 = s1.get("run")
+    assert tool1.get("class") == "CommandLineTool"
+
+
+def test_already_packed_graph() -> None:
+    """Workflow already packed in a $graph."""
+    cwl = pack(get_data("testdata/workflows/scatter-wf4.cwl"))
+    assert "inputs" not in cwl
+    assert "outputs" not in cwl
+    assert "$graph" in cwl
+    assert "requirements" not in cwl
+
+
+def test_import_in_type() -> None:
+    cwl = pack(get_data("testdata/workflows/import-in-type.cwl"))
+    assert cwl["inputs"][0]["type"] == ["File", "Directory"]


### PR DESCRIPTION
Brings in https://github.com/rabix/sbpack/pull/67

+ the packing tests that we didn't originally include when we brought in sbpack to cwl-utils