### PR TITLE
Do not require docker save

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,11 @@ the software container images in Docker format.
 
 .. code:: bash
 
-   cwl-docker-extract DIRECTORY path_to_my_workflow.cwl
+   cwl-docker-extract path_to_my_workflow.cwl
+
+.. code:: bash
+
+   cwl-docker-extract --dir DIRECTORY path_to_my_workflow.cwl
 
 Or you can use the Singularity software container engine to download and
 save the software container images and convert them to the Singularity
@@ -57,7 +61,7 @@ format at the same time.
 
 .. code:: bash
 
-   cwl-docker-extract --singularity DIRECTORY path_to_my_workflow.cwl
+   cwl-docker-extract --singularity --dir DIRECTORY path_to_my_workflow.cwl
 
 
 Print all referenced software packages

--- a/cwl_utils/docker_extract.py
+++ b/cwl_utils/docker_extract.py
@@ -21,10 +21,10 @@ def arg_parser() -> argparse.ArgumentParser:
         description="Save container images specified in a CWL document (Workflow or CommandLineTool). "
         "For CWL Workflows, all steps will also be searched (recursively)."
     )
-    parser.add_argument("dir", help="Directory in which to save images")
     parser.add_argument(
         "input", help="Input CWL document (CWL Workflow or CWL CommandLineTool)"
     )
+    parser.add_argument("--dir", help="Directory in which to save images")
     parser.add_argument(
         "-s",
         "--singularity",
@@ -45,7 +45,12 @@ def arg_parser() -> argparse.ArgumentParser:
 
 def run(args: argparse.Namespace) -> List[cwl.DockerRequirement]:
     """Extract the docker reqs and download them using Singularity or Docker."""
-    os.makedirs(args.dir, exist_ok=True)
+    if args.singularity and not args.dir:
+        print("Error! Must specify --dir if using --singularity")
+        sys.exit(1)
+
+    if args.dir:
+        os.makedirs(args.dir, exist_ok=True)
 
     top = cwl.load_document_by_uri(args.input)
     reqs: List[cwl.DockerRequirement] = []

--- a/tests/test_docker_extract.py
+++ b/tests/test_docker_extract.py
@@ -23,7 +23,7 @@ from .util import get_data, needs_docker, needs_podman, needs_singularity
 def test_container_extraction(target: str, engine: str, tmp_path: Path) -> None:
     """Test container extraction tool."""
 
-    args = [str(tmp_path), get_data(target), "--container-engine", engine]
+    args = ["--dir", str(tmp_path), get_data(target), "--container-engine", engine]
     if engine == "singularity":
         args.append("--singularity")
     reqs = run(arg_parser().parse_args(args))
@@ -43,6 +43,7 @@ def test_container_extraction_force(engine: str, tmp_path: Path) -> None:
     """Test force pull container extraction."""
 
     args = [
+        "--dir",
         str(tmp_path),
         get_data("testdata/md5sum.cwl"),
         "--container-engine",
@@ -54,6 +55,7 @@ def test_container_extraction_force(engine: str, tmp_path: Path) -> None:
     assert len(reqs) == 1
     assert len(list(tmp_path.iterdir())) == 1
     args = [
+        "--dir",
         str(tmp_path),
         get_data("testdata/md5sum.cwl"),
         "--container-engine",
@@ -81,6 +83,7 @@ def test_container_extraction_no_dockerPull(
     """Test container extraction tool when dockerPull is missing."""
 
     args = [
+        "--dir",
         str(tmp_path),
         get_data("testdata/debian_image_id.cwl"),
         "--container-engine",
@@ -113,6 +116,7 @@ def test_container_extraction_embedded_step(engine: str, tmp_path: Path) -> None
     """Test container extraction tool."""
 
     args = [
+        "--dir",
         str(tmp_path),
         get_data("testdata/workflows/count-lines16-wf.cwl"),
         "--container-engine",


### PR DESCRIPTION
The primary purpose of cwl-docker-extract is to pull all images in a workflow (and subworkflows, etc) and populate the default docker / --container-engine cache. Additionally copying the images to another directory is often unnecessary and takes up 2X the disk space. For large workflows that have many unoptimized images, this could approach 100GB. This PR makes copying optional (for docker only).