### PR TITLE
Replace ":" in singularity image name with "_"

### DIFF
--- a/cwl_utils/image_puller.py
+++ b/cwl_utils/image_puller.py
@@ -89,7 +89,7 @@ class DockerImagePuller(ImagePuller):
 class SingularityImagePuller(ImagePuller):
     """Pull docker image with Singularity."""
 
-    CHARS_TO_REPLACE = ["/"]
+    CHARS_TO_REPLACE = ["/", ":"]
     NEW_CHAR = "_"
 
     def get_image_name(self) -> str:


### PR DESCRIPTION
Currently if a `CommandLineTool`'s `DockerRequirement` lacks a tag and we use `Singularity` as the container engine, there is a mismatch between the name of the saved singularity container and the normalized name `cwltool` looks for. Here is an example. Assume the following section in a `CommandLineTool`:
```
hints:
  DockerRequirement:
    dockerPull: someuser/somecontainer
```
Now `extract_docker_requirements` modifies the `dockerPull` value to `someuser/somecontainer:latest`. 
Then if Singularity is used as the container engine, `SingularityImagePuller` saves the image as `someuser_somecontainer_latest.sif`. This is due to the code [here](https://github.com/common-workflow-language/cwl-utils/blob/70fbcd9776071edc2fd884308b016a4901b97554/cwl_utils/image_puller.py#L55)

However, in `cwltool`, when `Singularity` looks for the image, it looks for `someuser_somecontainer.sif`. This is due to the `_normalize_sif_id` function [here](https://github.com/common-workflow-language/cwltool/blob/main/cwltool/singularity.py#L140)

Due to this naming mismatch, `cwltool` fails to find the image and errors out.
Since the `docker pull` documentation says that if no tag is specified it always pulls the `latest` and `singularity pull` also behaves the same way (I could not find any explicit documentation though), I propose to remove this on the fly modification.

I am also open to other suggestions. 