### PR TITLE
Fix `load_document_by_uri` method

### DIFF
--- a/testdata/remote-cwl/tool1.cwl
+++ b/testdata/remote-cwl/tool1.cwl
@@ -2,7 +2,7 @@
 # We have this tool to test both local and remote packing
 
 class: CommandLineTool
-cwlVersion: v1.0
+cwlVersion: v1.2
 inputs:
   in1: 
     type: string

--- a/testdata/remote-cwl/tool2.cwl
+++ b/testdata/remote-cwl/tool2.cwl
@@ -2,7 +2,7 @@
 # We have this tool to test both local and remote packing
 
 class: CommandLineTool
-cwlVersion: v1.0
+cwlVersion: v1.2
 inputs:
   in1:
     type: ../types/testtypes.yml#my_boolean_array

--- a/testdata/remote-cwl/wf1.cwl
+++ b/testdata/remote-cwl/wf1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.0
+cwlVersion: v1.2
 inputs:
   - id: in1
     type: ../types/testtypes.yml#my_boolean_array

--- a/testdata/wf2.cwl
+++ b/testdata/wf2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.0
+cwlVersion: v1.2
 inputs:
   in1: types/testtypes.yml#my_boolean_array
   in2: 

--- a/testdata/workflows/wf5.cwl
+++ b/testdata/workflows/wf5.cwl
@@ -2,7 +2,7 @@
 # Checks symbolic links on github
 
 class: Workflow
-cwlVersion: v1.0
+cwlVersion: v1.2
 inputs:
   in1:
     type: ../types/recursive.yml#file_with_sample_meta

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -105,6 +105,7 @@ def test_static_checker_success(cwlVersion: str) -> None:
                 "testdata/cond-single-source-wf-005.1.cwl",
                 "testdata/extensions/all-output-loop_v1_2.cwl",
                 "testdata/extensions/single-var-loop_v1_2.cwl",
+                "testdata/wf2.cwl",
             ]
         )
     for test_file in test_files:


### PR DESCRIPTION
This commit adjusts the `load_document_by_uri` method, ensuring that the `LoadingOptions` object used to parse the document contains the correct values for `fileuri` and `baseuri`.