### PR TITLE
sandboxjs: make node image discovery more robust

### DIFF
--- a/cwl_utils/sandboxjs.py
+++ b/cwl_utils/sandboxjs.py
@@ -301,11 +301,11 @@ class NodeJSEngine(JSEngine):
 
         if nodejs is None or nodejs is not None and required_node_version is False:
             try:
-                nodeimg = "docker.io/node:alpine"
+                nodeimg = "node:alpine"
                 if container_engine == "singularity":
-                    nodeimg = f"docker://{nodeimg}"
+                    nodeimg = f"docker://docker.io/{nodeimg}"
                 elif container_engine in ("podman", "udocker"):
-                    nodeimg = "docker.io/library/node:alpine"
+                    nodeimg = f"docker.io/library/{nodeimg}"
 
                 if not self.have_node_slim:
                     singularity_cache: Optional[str] = None


### PR DESCRIPTION
`docker images` strips out the "docker.io" registry, so change our query to match
