### PR TITLE
Return if in input record schema type or input array schema type

### DIFF
--- a/cwl_utils/utils.py
+++ b/cwl_utils/utils.py
@@ -21,7 +21,7 @@ from cwl_utils.errors import MissingKeyField
 from cwl_utils.loghandler import _logger
 
 # Type hinting
-from cwl_utils.parser import InputRecordSchemaTypes
+from cwl_utils.parser import InputArraySchemaTypes, InputRecordSchemaTypes
 
 # Load as 1.2 files
 from cwl_utils.parser.cwl_v1_2 import InputArraySchema as InputArraySchemaV1_2
@@ -341,7 +341,7 @@ def sanitise_schema_field(
     schema_field_item = deepcopy(schema_field_item)
     required = True
 
-    if isinstance(schema_field_item, InputRecordSchemaTypes):
+    if isinstance(schema_field_item, (InputRecordSchemaTypes, InputArraySchemaTypes)):
         return schema_field_item
 
     if isinstance(schema_field_item.get("type"), list):


### PR DESCRIPTION
Complex workflow as an example here:

Gives the following error:

```pytb
Loading the CWL document
Failed to generate JSON Schema from CWL inputs object. Error: 'CommandInputArraySchema' object has no attribute 'get'
Traceback (most recent call last):
  File "/home/alexiswl/miniconda3/envs/cwl-ica/lib/python3.13/site-packages/cwl_utils/inputs_schema_gen.py", line 610, in run
    jsonschema = cwl_to_jsonschema(cwl_obj)
  File "/home/alexiswl/miniconda3/envs/cwl-ica/lib/python3.13/site-packages/cwl_utils/inputs_schema_gen.py", line 387, in cwl_to_jsonschema
    workflow_schema_definitions_list = list(
        map(
    ...<4 lines>...
        )
    )
  File "/home/alexiswl/miniconda3/envs/cwl-ica/lib/python3.13/site-packages/cwl_utils/inputs_schema_gen.py", line 389, in <lambda>
    lambda complex_schema_values_iter: generate_definition_from_schema(
                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        complex_schema_values_iter
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/home/alexiswl/miniconda3/envs/cwl-ica/lib/python3.13/site-packages/cwl_utils/inputs_schema_gen.py", line 277, in generate_definition_from_schema
    get_value_from_uri(field.name): sanitise_schema_field(
                                    ~~~~~~~~~~~~~~~~~~~~~^
        {"type": field.type_}
        ^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/alexiswl/miniconda3/envs/cwl-ica/lib/python3.13/site-packages/cwl_utils/utils.py", line 359, in sanitise_schema_field
    schema_field_item["type"] = list(
                                ~~~~^
        map(
        ^^^^
    ...<2 lines>...
        )
        ^
    )
    ^
  File "/home/alexiswl/miniconda3/envs/cwl-ica/lib/python3.13/site-packages/cwl_utils/utils.py", line 361, in <lambda>
    lambda field_subtypes: sanitise_schema_field(field_subtypes),
                           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/alexiswl/miniconda3/envs/cwl-ica/lib/python3.13/site-packages/cwl_utils/utils.py", line 347, in sanitise_schema_field
    if isinstance(schema_field_item.get("type"), list):
                  ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'CommandInputArraySchema' object has no attribute 'get'
```


[dragen-wgts-dna-pipeline__4.4.4.zip](https://github.com/user-attachments/files/20769011/dragen-wgts-dna-pipeline__4.4.4.zip)

Expected output, as generated using the following fix

<details>

<summary>Click to expand</summary>

```
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "definitions": {
    "File": {
      "additionalProperties": false,
      "description": "Represents a file (or group of files when `secondaryFiles` is provided) that\nwill be accessible by tools using standard POSIX file system call API such as\nopen(2) and read(2).\n\nFiles are represented as objects with `class` of `File`.  File objects have\na number of properties that provide metadata about the file.\n\nThe `location` property of a File is a URI that uniquely identifies the\nfile.  Implementations must support the `file://` URI scheme and may support\nother schemes such as `http://` and `https://`.  The value of `location` may also be a\nrelative reference, in which case it must be resolved relative to the URI\nof the document it appears in.  Alternately to `location`, implementations\nmust also accept the `path` property on File, which must be a filesystem\npath available on the same host as the CWL runner (for inputs) or the\nruntime environment of a command line tool execution (for command line tool\noutputs).\n\nIf no `location` or `path` is specified, a file object must specify\n`contents` with the UTF-8 text content of the file.  This is a \"file\nliteral\".  File literals do not correspond to external resources, but are\ncreated on disk with `contents` with when needed for executing a tool.\nWhere appropriate, expressions can return file literals to define new files\non a runtime.  The maximum size of `contents` is 64 kilobytes.\n\nThe `basename` property defines the filename on disk where the file is\nstaged.  This may differ from the resource name.  If not provided,\n`basename` must be computed from the last path part of `location` and made\navailable to expressions.\n\nThe `secondaryFiles` property is a list of File or Directory objects that\nmust be staged in the same directory as the primary file.  It is an error\nfor file names to be duplicated in `secondaryFiles`.\n\nThe `size` property is the size in bytes of the File.  It must be computed\nfrom the resource and made available to expressions.  The `checksum` field\ncontains a cryptographic hash of the file content for use it verifying file\ncontents.  Implementations may, at user option, enable or disable\ncomputation of the `checksum` field for performance or other reasons.\nHowever, the ability to compute output checksums is required to pass the\nCWL conformance test suite.\n\nWhen executing a CommandLineTool, the files and secondary files may be\nstaged to an arbitrary directory, but must use the value of `basename` for\nthe filename.  The `path` property must be file path in the context of the\ntool execution runtime (local to the compute node, or within the executing\ncontainer).  All computed properties should be available to expressions.\nFile literals also must be staged and `path` must be set.\n\nWhen collecting CommandLineTool outputs, `glob` matching returns file paths\n(with the `path` property) and the derived properties. This can all be\nmodified by `outputEval`.  Alternately, if the file `cwl.output.json` is\npresent in the output, `outputBinding` is ignored.\n\nFile objects in the output must provide either a `location` URI or a `path`\nproperty in the context of the tool execution runtime (local to the compute\nnode, or within the executing container).\n\nWhen evaluating an ExpressionTool, file objects must be referenced via\n`location` (the expression tool does not have access to files on disk so\n`path` is meaningless) or as file literals.  It is legal to return a file\nobject with an existing `location` but a different `basename`.  The\n`loadContents` field of ExpressionTool inputs behaves the same as on\nCommandLineTool inputs, however it is not meaningful on the outputs.\n\nAn ExpressionTool may forward file references from input to output by using\nthe same value for `location`.",
      "properties": {
        "basename": {
          "description": "The base name of the file, that is, the name of the file without any\nleading directory path.  The base name must not contain a slash `/`.\n\nIf not provided, the implementation must set this field based on the\n`location` field by taking the final path component after parsing\n`location` as an IRI.  If `basename` is provided, it is not required to\nmatch the value from `location`.\n\nWhen this file is made available to a CommandLineTool, it must be named\nwith `basename`, i.e. the final component of the `path` field must match\n`basename`.",
          "type": "string"
        },
        "checksum": {
          "description": "Optional hash code for validating file integrity.  Currently, must be in the form\n\"sha1$ + hexadecimal string\" using the SHA-1 algorithm.",
          "type": "string"
        },
        "class": {
          "const": "File",
          "description": "Must be `File` to indicate this object describes a file.",
          "type": "string"
        },
        "contents": {
          "description": "File contents literal.\n\nIf neither `location` nor `path` is provided, `contents` must be\nnon-null.  The implementation must assign a unique identifier for the\n`location` field.  When the file is staged as input to CommandLineTool,\nthe value of `contents` must be written to a file.\n\nIf `contents` is set as a result of a Javascript expression,\nan `entry` in `InitialWorkDirRequirement`, or read in from\n`cwl.output.json`, there is no specified upper limit on the\nsize of `contents`.  Implementations may have practical limits\non the size of `contents` based on memory and storage\navailable to the workflow runner or other factors.\n\nIf the `loadContents` field of an `InputParameter` or\n`OutputParameter` is true, and the input or output File object\n`location` is valid, the file must be a UTF-8 text file 64 KiB\nor smaller, and the implementation must read the entire\ncontents of the file and place it in the `contents` field.  If\nthe size of the file is greater than 64 KiB, the\nimplementation must raise a fatal error.",
          "type": "string"
        },
        "dirname": {
          "description": "The name of the directory containing file, that is, the path leading up\nto the final slash in the path such that `dirname + '/' + basename ==\npath`.\n\nThe implementation must set this field based on the value of `path`\nprior to evaluating parameter references or expressions in a\nCommandLineTool document.  This field must not be used in any other\ncontext.",
          "type": "string"
        },
        "format": {
          "description": "The format of the file: this must be an IRI of a concept node that\nrepresents the file format, preferably defined within an ontology.\nIf no ontology is available, file formats may be tested by exact match.\n\nReasoning about format compatibility must be done by checking that an\ninput file format is the same, `owl:equivalentClass` or\n`rdfs:subClassOf` the format required by the input parameter.\n`owl:equivalentClass` is transitive with `rdfs:subClassOf`, e.g. if\n`<B> owl:equivalentClass <C>` and `<B> owl:subclassOf <A>` then infer\n`<C> owl:subclassOf <A>`.\n\nFile format ontologies may be provided in the \"$schemas\" metadata at the\nroot of the document.  If no ontologies are specified in `$schemas`, the\nruntime may perform exact file format matches.",
          "type": "string"
        },
        "location": {
          "description": "An IRI that identifies the file resource.  This may be a relative\nreference, in which case it must be resolved using the base IRI of the\ndocument.  The location may refer to a local or remote resource; the\nimplementation must use the IRI to retrieve file content.  If an\nimplementation is unable to retrieve the file content stored at a\nremote resource (due to unsupported protocol, access denied, or other\nissue) it must signal an error.\n\nIf the `location` field is not provided, the `contents` field must be\nprovided.  The implementation must assign a unique identifier for\nthe `location` field.\n\nIf the `path` field is provided but the `location` field is not, an\nimplementation may assign the value of the `path` field to `location`,\nthen follow the rules above.",
          "type": "string"
        },
        "nameext": {
          "description": "The basename extension such that `nameroot + nameext == basename`, and\n`nameext` is empty or begins with a period and contains at most one\nperiod.  Leading periods on the basename are ignored; a basename of\n`.cshrc` will have an empty `nameext`.\n\nThe implementation must set this field automatically based on the value\nof `basename` prior to evaluating parameter references or expressions.",
          "type": "string"
        },
        "nameroot": {
          "description": "The basename root such that `nameroot + nameext == basename`, and\n`nameext` is empty or begins with a period and contains at most one\nperiod.  For the purposes of path splitting leading periods on the\nbasename are ignored; a basename of `.cshrc` will have a nameroot of\n`.cshrc`.\n\nThe implementation must set this field automatically based on the value\nof `basename` prior to evaluating parameter references or expressions.",
          "type": "string"
        },
        "path": {
          "description": "The local host path where the File is available when a CommandLineTool is\nexecuted.  This field must be set by the implementation.  The final\npath component must match the value of `basename`.  This field\nmust not be used in any other context.  The command line tool being\nexecuted must be able to access the file at `path` using the POSIX\n`open(2)` syscall.\n\nAs a special case, if the `path` field is provided but the `location`\nfield is not, an implementation may assign the value of the `path`\nfield to `location`, and remove the `path` field.\n\nIf the `path` contains [POSIX shell metacharacters](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_02)\n(`|`,`&`, `;`, `<`, `>`, `(`,`)`, `$`,`` ` ``, `\\`, `\"`, `'`,\n`<space>`, `<tab>`, and `<newline>`) or characters\n[not allowed](http://www.iana.org/assignments/idna-tables-6.3.0/idna-tables-6.3.0.xhtml)\nfor [Internationalized Domain Names for Applications](https://tools.ietf.org/html/rfc6452)\nthen implementations may terminate the process with a\n`permanentFailure`.",
          "type": "string"
        },
        "secondaryFiles": {
          "description": "A list of additional files or directories that are associated with the\nprimary file and must be transferred alongside the primary file.\nExamples include indexes of the primary file, or external references\nwhich must be included when loading primary document.  A file object\nlisted in `secondaryFiles` may itself include `secondaryFiles` for\nwhich the same rules apply.",
          "items": {
            "anyOf": [
              {
                "$ref": "#/definitions/File"
              },
              {
                "$ref": "#/definitions/Directory"
              }
            ]
          },
          "type": "array"
        },
        "size": {
          "description": "Optional file size (in bytes)",
          "type": "number"
        }
      },
      "required": [
        "class"
      ],
      "type": "object"
    },
    "Directory": {
      "additionalProperties": false,
      "description": "Represents a directory to present to a command line tool.\n\nDirectories are represented as objects with `class` of `Directory`.  Directory objects have\na number of properties that provide metadata about the directory.\n\nThe `location` property of a Directory is a URI that uniquely identifies\nthe directory.  Implementations must support the file:// URI scheme and may\nsupport other schemes such as http://.  Alternately to `location`,\nimplementations must also accept the `path` property on Directory, which\nmust be a filesystem path available on the same host as the CWL runner (for\ninputs) or the runtime environment of a command line tool execution (for\ncommand line tool outputs).\n\nA Directory object may have a `listing` field.  This is a list of File and\nDirectory objects that are contained in the Directory.  For each entry in\n`listing`, the `basename` property defines the name of the File or\nSubdirectory when staged to disk.  If `listing` is not provided, the\nimplementation must have some way of fetching the Directory listing at\nruntime based on the `location` field.\n\nIf a Directory does not have `location`, it is a Directory literal.  A\nDirectory literal must provide `listing`.  Directory literals must be\ncreated on disk at runtime as needed.\n\nThe resources in a Directory literal do not need to have any implied\nrelationship in their `location`.  For example, a Directory listing may\ncontain two files located on different hosts.  It is the responsibility of\nthe runtime to ensure that those files are staged to disk appropriately.\nSecondary files associated with files in `listing` must also be staged to\nthe same Directory.\n\nWhen executing a CommandLineTool, Directories must be recursively staged\nfirst and have local values of `path` assigned.\n\nDirectory objects in CommandLineTool output must provide either a\n`location` URI or a `path` property in the context of the tool execution\nruntime (local to the compute node, or within the executing container).\n\nAn ExpressionTool may forward file references from input to output by using\nthe same value for `location`.\n\nName conflicts (the same `basename` appearing multiple times in `listing`\nor in any entry in `secondaryFiles` in the listing) is a fatal error.",
      "properties": {
        "basename": {
          "description": "The base name of the directory, that is, the name of the file without any\nleading directory path.  The base name must not contain a slash `/`.\n\nIf not provided, the implementation must set this field based on the\n`location` field by taking the final path component after parsing\n`location` as an IRI.  If `basename` is provided, it is not required to\nmatch the value from `location`.\n\nWhen this file is made available to a CommandLineTool, it must be named\nwith `basename`, i.e. the final component of the `path` field must match\n`basename`.",
          "type": "string"
        },
        "class": {
          "const": "Directory",
          "description": "Must be `Directory` to indicate this object describes a Directory.",
          "type": "string"
        },
        "listing": {
          "description": "List of files or subdirectories contained in this directory.  The name\nof each file or subdirectory is determined by the `basename` field of\neach `File` or `Directory` object.  It is an error if a `File` shares a\n`basename` with any other entry in `listing`.  If two or more\n`Directory` object share the same `basename`, this must be treated as\nequivalent to a single subdirectory with the listings recursively\nmerged.",
          "items": {
            "anyOf": [
              {
                "$ref": "#/definitions/File"
              },
              {
                "$ref": "#/definitions/Directory"
              }
            ]
          },
          "type": "array"
        },
        "location": {
          "description": "An IRI that identifies the directory resource.  This may be a relative\nreference, in which case it must be resolved using the base IRI of the\ndocument.  The location may refer to a local or remote resource.  If\nthe `listing` field is not set, the implementation must use the\nlocation IRI to retrieve directory listing.  If an implementation is\nunable to retrieve the directory listing stored at a remote resource (due to\nunsupported protocol, access denied, or other issue) it must signal an\nerror.\n\nIf the `location` field is not provided, the `listing` field must be\nprovided.  The implementation must assign a unique identifier for\nthe `location` field.\n\nIf the `path` field is provided but the `location` field is not, an\nimplementation may assign the value of the `path` field to `location`,\nthen follow the rules above.",
          "type": "string"
        },
        "path": {
          "description": "The local path where the Directory is made available prior to executing a\nCommandLineTool.  This must be set by the implementation.  This field\nmust not be used in any other context.  The command line tool being\nexecuted must be able to access the directory at `path` using the POSIX\n`opendir(2)` syscall.\n\nIf the `path` contains [POSIX shell metacharacters](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_02)\n(`|`,`&`, `;`, `<`, `>`, `(`,`)`, `$`,`` ` ``, `\\`, `\"`, `'`,\n`<space>`, `<tab>`, and `<newline>`) or characters\n[not allowed](http://www.iana.org/assignments/idna-tables-6.3.0/idna-tables-6.3.0.xhtml)\nfor [Internationalized Domain Names for Applications](https://tools.ietf.org/html/rfc6452)\nthen implementations may terminate the process with a\n`permanentFailure`.",
          "type": "string"
        }
      },
      "required": [
        "class"
      ],
      "type": "object"
    },
    "DragenReference": {
      "type": "object",
      "properties": {
        "name": {
          "type": "string",
          "description": ""
        },
        "structure": {
          "type": "string",
          "enum": [
            "linear",
            "graph"
          ],
          "description": ""
        },
        "tarball": {
          "$ref": "#/definitions/File",
          "description": ""
        }
      },
      "required": [
        "name",
        "structure",
        "tarball"
      ]
    },
    "FastqListRowsInput": {
      "type": "object",
      "properties": {
        "fastq_list_rows": {
          "type": "array",
          "items": {
            "type": "object",
            "properties": {
              "rgid": {
                "type": "string"
              },
              "rglb": {
                "type": "string"
              },
              "rgsm": {
                "type": "string"
              },
              "rgcn": {
                "oneOf": [
                  {
                    "type": "null"
                  },
                  {
                    "type": "string"
                  }
                ]
              },
              "rgds": {
                "oneOf": [
                  {
                    "type": "null"
                  },
                  {
                    "type": "string"
                  }
                ]
              },
              "rgdt": {
                "oneOf": [
                  {
                    "type": "null"
                  },
                  {
                    "type": "string"
                  }
                ]
              },
              "rgpl": {
                "oneOf": [
                  {
                    "type": "null"
                  },
                  {
                    "type": "string"
                  }
                ]
              },
              "lane": {
                "type": "integer"
              },
              "read_1": {
                "oneOf": [
                  {
                    "$ref": "#/definitions/File"
                  },
                  {
                    "type": "string"
                  }
                ]
              },
              "read_2": {
                "oneOf": [
                  {
                    "type": "null"
                  },
                  {
                    "$ref": "#/definitions/File"
                  },
                  {
                    "type": "string"
                  }
                ]
              }
            }
          },
          "description": ""
        }
      },
      "required": [
        "fastq_list_rows"
      ]
    },
    "BamInput": {
      "type": "object",
      "properties": {
        "bam_input": {
          "$ref": "#/definitions/File",
          "description": ""
        }
      },
      "required": [
        "bam_input"
      ]
    },
    "CramInput": {
      "type": "object",
      "properties": {
        "cram_input": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "cram_reference": {
          "$ref": "#/definitions/File",
          "description": ""
        }
      },
      "required": [
        "cram_input"
      ]
    },
    "DragenWgtsAlignmentOptions": {
      "type": "object",
      "properties": {
        "enable_duplicate_marking": {
          "type": "boolean",
          "description": ""
        },
        "enable_deterministic_sort": {
          "type": "boolean",
          "description": ""
        },
        "enable_sampling": {
          "type": "boolean",
          "description": ""
        },
        "enable_down_sampler": {
          "type": "boolean",
          "description": ""
        },
        "append_read_index_to_name": {
          "type": "boolean",
          "description": ""
        },
        "fastq_offset": {
          "type": "integer",
          "description": ""
        },
        "filter_flags_from_output": {
          "type": "integer",
          "description": ""
        },
        "generate_md_tags": {
          "type": "boolean",
          "description": ""
        },
        "generate_sa_tags": {
          "type": "boolean",
          "description": ""
        },
        "generate_zs_tags": {
          "type": "boolean",
          "description": ""
        },
        "input_qname_suffix_delimiter": {
          "type": "string",
          "description": ""
        },
        "output_format": {
          "type": "string",
          "description": ""
        },
        "preserve_bqsr_tags": {
          "type": "boolean",
          "description": ""
        },
        "preserve_map_align_order": {
          "type": "boolean",
          "description": ""
        },
        "qc_coverage": {
          "type": "array",
          "items": {
            "type": "object",
            "properties": {
              "region": {
                "$ref": "#/definitions/File"
              },
              "report_type": {
                "type": "string"
              },
              "thresholds": {
                "oneOf": [
                  {
                    "type": "null"
                  },
                  {
                    "type": "array",
                    "items": {
                      "type": "integer"
                    }
                  }
                ]
              }
            }
          },
          "description": ""
        },
        "ref_sequence_filter": {
          "type": "boolean",
          "description": ""
        },
        "remove_duplicates": {
          "type": "boolean",
          "description": ""
        },
        "sample_size": {
          "type": "integer",
          "description": ""
        },
        "strip_input_qname_suffixes": {
          "type": "boolean",
          "description": ""
        },
        "aligner": {
          "type": "object",
          "properties": {
            "aln_min_score": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "clip_pe_overhang": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "dedup_min_qual": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "en_alt_hap_aln": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "en_chimeric_aln": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "gap_ext_pen": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "gap_open_pen": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "global": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "hard_clip_tags": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "hard_clips": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "mapq_floor_1snp": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "map_orientations": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "mapq_max": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "mapq_strict_sjs": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "match_n_score": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "match_score": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "max_rescues": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "min_overhang": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "min_score_coeff": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "number"
                }
              ]
            },
            "mismatch_pen": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "no_noncan_motifs": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "no_unclip_score": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "no_unpaired": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "pe_max_penalty": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "pe_orientation": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "rescue_sigmas": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "number"
                }
              ]
            },
            "sec_aligns": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "sec_aligns_hard": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "sec_phred_delta": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "sec_score_delta": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "number"
                }
              ]
            },
            "supp_aligns": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "supp_as_sec": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "supp_min_score_adj": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "unclip_score": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "unpaired_pen": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            }
          },
          "description": ""
        },
        "mapper": {
          "type": "object",
          "properties": {
            "ann_sj_max_indel": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "edit_chain_limit": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "edit_mode": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "edit_read_len": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "edit_seed_num": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "map_orientations": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "max_intron_bases": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "min_intron_bases": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            },
            "seed_density": {
              "oneOf": [
                {
                  "type": "null"
                },
                {
                  "type": "integer"
                }
              ]
            }
          },
          "description": ""
        },
        "rrna_filter_enable": {
          "type": "boolean",
          "description": ""
        },
        "rrna_filter_contig": {
          "type": "string",
          "description": ""
        },
        "rna_library_type": {
          "type": "string",
          "description": ""
        },
        "rna_mapq_unique": {
          "type": "integer",
          "description": ""
        },
        "rna_ann_sj_min_len": {
          "type": "integer",
          "description": ""
        }
      },
      "required": []
    },
    "DragenSnvVariantCallerOptions": {
      "type": "object",
      "properties": {
        "enable_variant_caller": {
          "type": "boolean",
          "description": ""
        },
        "enable_methylation_calling": {
          "type": "boolean",
          "description": ""
        },
        "enable_variant_deduplication": {
          "type": "boolean",
          "description": ""
        },
        "enable_vcf_compression": {
          "type": "boolean",
          "description": ""
        },
        "enable_vcf_indexing": {
          "type": "boolean",
          "description": ""
        },
        "dbsnp": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "vd_eh_vcf": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "vd_output_match_log": {
          "type": "boolean",
          "description": ""
        },
        "vd_small_variant_vcf": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "vd_sv_vcf": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "dn_cnv_vcf": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "dn_input_vcf": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "dn_output_vcf": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "dn_sv_vcf": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "enable_joint_genotyping": {
          "type": "boolean",
          "description": ""
        },
        "enable_multi_sample_gvcf": {
          "type": "boolean",
          "description": ""
        },
        "enable_vlrd": {
          "type": "boolean",
          "description": ""
        },
        "pedigree_file": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "qc_snp_denovo_quality_threshold": {
          "type": "integer",
          "description": ""
        },
        "qc_indel_denovo_quality_threshold": {
          "type": "integer",
          "description": ""
        },
        "variant": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "variant_list": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "vc_af_call_threshold": {
          "type": "integer",
          "description": ""
        },
        "vc_af_filter_threshold": {
          "type": "integer",
          "description": ""
        },
        "vc_af_call_threshold_mito": {
          "type": "integer",
          "description": ""
        },
        "vc_af_filter_threshold_mito": {
          "type": "integer",
          "description": ""
        },
        "vc_callability_normal_threshold": {
          "type": "integer",
          "description": ""
        },
        "vc_callability_tumor_threshold": {
          "type": "integer",
          "description": ""
        },
        "vc_clustered_event_penalty": {
          "type": "integer",
          "description": ""
        },
        "vc_decoy_contigs": {
          "type": "array",
          "items": {
            "type": "string"
          },
          "description": ""
        },
        "vc_depth_annotation_threshold": {
          "type": "integer",
          "description": ""
        },
        "vc_depth_filter_threshold": {
          "type": "integer",
          "description": ""
        },
        "vc_emit_ref_confidence": {
          "type": "string",
          "description": ""
        },
        "rna_vc_enable_homozygous_genotype": {
          "type": "boolean",
          "description": ""
        },
        "rna_vc_homozygous_genotype_af_threshold": {
          "type": "number",
          "description": ""
        },
        "vc_max_alternate_alleles": {
          "type": "integer",
          "description": ""
        },
        "vc_emit_zero_coverage_intervals": {
          "type": "boolean",
          "description": ""
        },
        "vc_mnv_emit_component_calls": {
          "type": "boolean",
          "description": ""
        },
        "vc_combine_phased_variants_distance": {
          "type": "integer",
          "description": ""
        },
        "vc_combine_phased_variants_max_vaf_delta": {
          "type": "number",
          "description": ""
        },
        "vc_combine_phased_variants_distance_snvs_only": {
          "type": "integer",
          "description": ""
        },
        "qc_detect_contamination": {
          "type": "boolean",
          "description": ""
        }
      },
      "required": []
    },
    "DragenCnvCallerOptions": {
      "type": "object",
      "properties": {
        "enable_cnv": {
          "type": "boolean",
          "description": ""
        },
        "cnv_bypass_contig_check": {
          "type": "boolean",
          "description": ""
        },
        "cnv_use_somatic_vc_baf": {
          "type": "boolean",
          "description": ""
        },
        "enable_hrd": {
          "type": "boolean",
          "description": ""
        },
        "hrd_input_ascn": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "hrd_input_tn": {
          "$ref": "#/definitions/File",
          "description": ""
        }
      },
      "required": []
    },
    "DragenMafConversionOptions": {
      "type": "object",
      "properties": {
        "enable_maf_output": {
          "type": "boolean",
          "description": ""
        },
        "maf_transcript_source": {
          "type": "string",
          "description": ""
        }
      },
      "required": []
    },
    "DragenSvCallerOptions": {
      "type": "object",
      "properties": {
        "enable_sv": {
          "type": "boolean",
          "description": ""
        },
        "sv_call_regions_bed": {
          "$ref": "#/definitions/File",
          "description": ""
        },
        "sv_filtered_contigs": {
          "type": "array",
          "items": {
            "type": "string"
          },
          "description": ""
        }
      },
      "required": []
    },
    "DragenNirvanaAnnotationOptions": {
      "type": "object",
      "properties": {
        "enable_variant_annotation": {
          "type": "boolean",
          "description": ""
        },
        "variant_annotation_data": {
          "type": "string",
          "description": ""
        },
        "variant_annotation_assembly": {
          "type": "string",
          "description": ""
        }
      },
      "required": []
    },
    "DragenTargetedCallerOptions": {
      "type": "object",
      "properties": {
        "enable_targeted": {
          "oneOf": [
            {
              "type": "boolean"
            },
            {
              "type": "array",
              "items": {
                "type": "string"
              }
            }
          ],
          "description": ""
        }
      },
      "required": []
    }
  },
  "description": "Auto-generated class implementation for https://w3id.org/cwl/cwl#WorkflowInputParameter",
  "type": "object",
  "properties": {
    "sequence_data": {
      "oneOf": [
        {
          "$ref": "#/definitions/FastqListRowsInput"
        },
        {
          "$ref": "#/definitions/BamInput"
        },
        {
          "$ref": "#/definitions/CramInput"
        }
      ],
      "description": "The sequence data to be aligned and called variants on.\nThis can either be a bam file, cram file or a list of fastq list row objects\n"
    },
    "tumor_sequence_data": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "oneOf": [
            {
              "$ref": "#/definitions/FastqListRowsInput"
            },
            {
              "$ref": "#/definitions/BamInput"
            },
            {
              "$ref": "#/definitions/CramInput"
            }
          ],
          "description": "The sequence data to be aligned and called variants on.\nThis can either be a bam file, cram file or a list of fastq list row objects\nOnly specify the tumor sequence data IF you want to run the somatic variant calling pipeline.\n"
        }
      ]
    },
    "reference": {
      "$ref": "#/definitions/DragenReference",
      "description": "The reference genome to be used for alignment and variant calling.\n"
    },
    "somatic_reference": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenReference",
          "description": "The somatic reference genome to be used for alignment and variant calling.\nThis is only used if the somatic reference is different from the normal reference.\n"
        }
      ]
    },
    "ora_reference": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/File",
          "description": "The ora reference used to decompress the input fastq files,\nrequired if any of the fastqs are ora-compressed\n"
        }
      ]
    },
    "sample_name": {
      "type": "string",
      "description": "The sample name to be used for alignment and variant calling.\nThis is used to name the output files\n"
    },
    "tumor_sample_name": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "type": "string",
          "description": "The tumor sample name to be used for alignment and variant calling.\nThis is used to name the output files\n"
        }
      ]
    },
    "alignment_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenWgtsAlignmentOptions",
          "description": "The options to be used for alignment.\nThis is a JSON object that contains the options to be used for alignment.\nThis is passed to the Dragen alignment tool.\n"
        }
      ]
    },
    "somatic_alignment_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenWgtsAlignmentOptions",
          "description": "The options to be used for alignment of the tumor sample.\nThis is a JSON object that contains the options to be used for alignment.\nThis is passed to the Dragen alignment tool.\nFor the somatic alignment, both alignment options and somatic alignment options are first merged before being provided to dragen\n"
        }
      ]
    },
    "snv_variant_caller_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenSnvVariantCallerOptions",
          "description": "The options to be used for variant calling.\nThis is a JSON object that contains the options to be used for variant calling.\nThis is passed to the Dragen variant calling tool.\n"
        }
      ]
    },
    "somatic_snv_variant_caller_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenSnvVariantCallerOptions",
          "description": "The options to be used for alignment of the normal sample.\nThis is a JSON object that contains the options to be used for alignment.\nThis is passed to the Dragen alignment tool.\nFor the somatic variant-caller, both variant-caller options and somatic variant-caller options are first merged before being provided to dragen\n"
        }
      ]
    },
    "cnv_caller_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenCnvCallerOptions",
          "description": "The options to be used for cnv calling.\nThis is a JSON object that contains the options to be used for cnv calling.\nThis is passed to the variant calling pipeline, make sure to add 'enable_cnv' to the cnv caller options\nAs it is not enabled by default\n"
        }
      ]
    },
    "somatic_cnv_caller_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenCnvCallerOptions",
          "description": "The options to be used for cnv calling in the somatic variant calling stage.\nThis is a JSON object that contains the options to be used for cnv calling.\nThis is passed to the variant calling pipeline, make sure to add 'enable_cnv' to the cnv caller options\nAs it is not enabled by default.\nFor the somatic cnv-caller, both cnv-caller options and somatic cnv-caller options are first merged before being provided to dragen\n"
        }
      ]
    },
    "maf_conversion_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenMafConversionOptions",
          "description": "The options to be used for maf conversion.\nThis is a JSON object that contains the options to be used for maf conversion.\nThis is passed to the variant calling pipeline, make sure to add 'enable_maf_output' to the maf conversion options\nAs it is not enabled by default.\n"
        }
      ]
    },
    "somatic_maf_conversion_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenMafConversionOptions",
          "description": "The options to be used for maf conversion in the somatic maf conversion stage.\nThis is a JSON object that contains the options to be used for maf conversion.\nThis is passed to the variant calling pipeline, make sure to add 'enable_maf_output' to the maf conversion options\nAs it is not enabled by default.\nFor the somatic maf conversion, both maf conversion options and somatic maf conversion options are first merged before being provided to dragen\n"
        }
      ]
    },
    "sv_caller_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenSvCallerOptions",
          "description": "The options to be used for sv calling in the variant calling stage.\nThis is a JSON object that contains the options to be used for sv calling.\nThis is passed to the variant calling pipeline, make sure to add 'enable_sv' to the sv caller options\nAs it is not enabled by default.\n"
        }
      ]
    },
    "somatic_sv_caller_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenSvCallerOptions",
          "description": "The options to be used for sv calling in the somatic variant calling stage.\nThis is a JSON object that contains the options to be used for sv calling.\nThis is passed to the variant calling pipeline, make sure to add 'enable_sv' to the sv caller options\nAs it is not enabled by default.\nFor the somatic sv caller, both sv caller options and somatic sv caller options are first merged before being provided to dragen\n"
        }
      ]
    },
    "nirvana_annotation_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenNirvanaAnnotationOptions",
          "description": "The options to be used for nirvana annotation.\nThis is a JSON object that contains the options to be used for nirvana annotation.\nThis is passed to the variant calling pipeline, make sure to add 'enable_variant_annotation' to the nirvana annotation options\nAs it is not enabled by default.\n"
        }
      ]
    },
    "somatic_nirvana_annotation_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenNirvanaAnnotationOptions",
          "description": "The options to be used for nirvana annotation.\nThis is a JSON object that contains the options to be used for nirvana annotation.\nThis is passed to the variant calling pipeline, make sure to add 'enable_variant_annotation' to the nirvana annotation options\nAs it is not enabled by default.\n"
        }
      ]
    },
    "targeted_caller_options": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DragenTargetedCallerOptions",
          "description": "The options to be used for targeted calling.\nThis is a JSON object that contains the options to be used for targeted calling.\nThis is passed to the variant calling pipeline, make sure to add 'enable_targeted_caller' to the targeted caller options\nAs it is not enabled by default.\n"
        }
      ]
    },
    "lic_instance_id_location": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "oneOf": [
            {
              "$ref": "#/definitions/File"
            },
            {
              "type": "string"
            }
          ],
          "description": "Path to the lic instance id location,\ndefault is '/opt/instance-identity',\nbut user can either provide an alternative location\nin the docker image or provide their own file.\n"
        }
      ]
    }
  },
  "required": [
    "sequence_data",
    "reference",
    "sample_name"
  ]
}
```

</details>
