### PR TITLE
Fix unclosed file in load_linked_file

### DIFF
--- a/cwl_utils/utils.py
+++ b/cwl_utils/utils.py
@@ -90,7 +90,7 @@ def load_linked_file(
     new_url = resolved_path(base_url, link)
 
     if new_url.scheme in ["file://", ""]:
-        contents = pathlib.Path(new_url.path).open().read()
+        contents = pathlib.Path(new_url.path).read_text()
     else:
         try:
             contents = (


### PR DESCRIPTION
We got warnings like these in our test suite:

```
     File "/home/dirac/diracos/lib/python3.11/site-packages/cwl_utils/utils.py", line 93, in load_linked_file
       contents = pathlib.Path(new_url.path).open().read()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ResourceWarning: unclosed file <_io.TextIOWrapper name='src/wms/tests/cwl/hello_world/container_example.cwl' mode='r' encoding='utf-8'>
```