### PR TITLE
Fix cwl-normalizer broken on ruamel.yaml 0.18+

### DIFF
--- a/src/cwl_utils/normalizer.py
+++ b/src/cwl_utils/normalizer.py
@@ -4,6 +4,7 @@
 """Normalize CWL documents to CWL v1.2, JSON style."""
 
 import argparse
+import json
 import logging
 import sys
 import tempfile
@@ -11,7 +12,7 @@ from collections.abc import MutableSequence
 from pathlib import Path
 
 from cwlupgrader import main as cwlupgrader
-from ruamel import yaml
+from ruamel.yaml import YAML
 from schema_salad.sourceline import add_lc_filename
 
 from cwl_utils import cwl_v1_2_expression_refactor
@@ -75,10 +76,12 @@ def main() -> None:
 def run(args: argparse.Namespace) -> int:
     """Primary processing loop."""
     imports: set[str] = set()
+    yaml = YAML(typ="rt")
+    yaml.preserve_quotes = True
     for document in args.inputs:
         _logger.info("Processing %s.", document)
         with open(document) as doc_handle:
-            result = yaml.main.round_trip_load(doc_handle, preserve_quotes=True)
+            result = yaml.load(doc_handle)
         add_lc_filename(result, document)
         version = result.get("cwlVersion", None)
         if version in ("draft-3", "cwl:draft-3", "v1.0", "v1.1"):
@@ -116,10 +119,12 @@ def run(args: argparse.Namespace) -> int:
         else:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 path = Path(tmpdirname) / Path(document).name
+                with open(path, "w") as handle:
+                    yaml.dump(result, handle)
                 packed = pack(str(path))
         output = Path(args.dir) / Path(document).name
         with output.open("w", encoding="utf-8") as output_filehandle:
-            output_filehandle.write(packed)
+            json.dump(packed, output_filehandle, indent=4)
     return 0
 
 

--- a/src/cwl_utils/tests/test_normalizer.py
+++ b/src/cwl_utils/tests/test_normalizer.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test the cwl-normalizer console script."""
+
+from pathlib import Path
+
+from cwl_utils.normalizer import parse_args, run
+
+from .util import get_data
+
+
+def test_normalizer_v1_1(tmp_path: Path) -> None:
+    """Normalize a v1.1 CWL document end-to-end."""
+    input_path = get_data("testdata/count-lines6-single-source-wf_v1_1.cwl")
+    args = parse_args([str(tmp_path), input_path])
+    assert run(args) == 0
+    assert (tmp_path / "count-lines6-single-source-wf_v1_1.cwl").is_file()


### PR DESCRIPTION
yaml.main.round_trip_load was removed in ruamel.yaml 0.18; use the YAML() instance API. Also restore the yaml.dump before pack() that was lost when cwltool deps were stripped (cf33726), and JSON-serialize the packed dict on write. Add a v1.1 regression test.