### PR TITLE
Pack/Normalize improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,19 @@ workflow steps (including any sub-workflows).
 
    cwl-graph-split --outdir optional/directory/path/to/save/outputs path_to_my_workflow.cwl
 
+Pack a CWL document
+~~~~~~~~~~~~~~~~~~~
+
+``cwl-pack`` packs a CWL document and all of its referenced documents into a
+single JSON document. Unlike ``cwl-normalizer``, ``cwl-pack`` does not upgrade
+the CWL version and does not refactor expressions; it is a thin CLI wrapper
+around ``cwl_utils.pack.pack()``.
+
+.. code:: bash
+
+   cwl-pack path_to_my_workflow.cwl
+   cwl-pack --outfile packed.json path_to_my_workflow.cwl
+
 Normalize a CWL document
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,9 @@ Included Utility Programs
 .. autoprogram:: cwl_utils.graph_split:arg_parser()
    :prog: cwl-graph-split
 
+.. autoprogram:: cwl_utils.pack_cli:arg_parser()
+   :prog: cwl-pack
+
 .. autoprogram:: cwl_utils.normalizer:arg_parser()
    :prog: cwl-normalizer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ cwl-cite-extract = "cwl_utils.cite_extract:main"
 cwl-docker-extract = "cwl_utils.docker_extract:main"
 cwl-expression-refactor = "cwl_utils.expression_refactor:main"
 cwl-graph-split = "cwl_utils.graph_split:main"
+cwl-pack = "cwl_utils.pack_cli:main"
 cwl-normalizer = "cwl_utils.normalizer:main"
 cwl-inputs-schema-gen = "cwl_utils.inputs_schema_gen:main"
 

--- a/src/cwl_utils/normalizer.py
+++ b/src/cwl_utils/normalizer.py
@@ -86,10 +86,13 @@ def run(args: argparse.Namespace) -> int:
         version = result.get("cwlVersion", None)
         if version in ("draft-3", "cwl:draft-3", "v1.0", "v1.1"):
             result = cwlupgrader.upgrade_document(result, args.dir, imports=imports)
+        elif version == "v1.2":
+            pass  # already at target version; no upgrade needed
         else:
             _logger.error(
                 "Sorry, %s in %s is not a supported CWL version by this tool.",
-                (version, document),
+                version,
+                document,
             )
             return -1
         uri = Path(document).resolve().as_uri()

--- a/src/cwl_utils/pack_cli.py
+++ b/src/cwl_utils/pack_cli.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Pack a CWL document into a single JSON document."""
+
+import argparse
+import json
+import sys
+
+from cwl_utils.pack import pack
+
+
+def arg_parser() -> argparse.ArgumentParser:
+    """Build the argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Pack a CWL document and its referenced documents into a "
+        "single JSON document. Does not upgrade the CWL version and does not "
+        "refactor expressions."
+    )
+    parser.add_argument("cwlfile", help="Input CWL document.")
+    parser.add_argument(
+        "-o",
+        "--outfile",
+        default=None,
+        help="Write packed JSON to this path instead of stdout.",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=4,
+        help="JSON indent width (default: 4).",
+    )
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Pack the input CWL document and write the result."""
+    packed = pack(args.cwlfile)
+    serialized = json.dumps(packed, indent=args.indent)
+    if args.outfile is None:
+        sys.stdout.write(serialized)
+        sys.stdout.write("\n")
+    else:
+        with open(args.outfile, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.write("\n")
+    return 0
+
+
+def main() -> int:
+    """Console entry point."""
+    return run(arg_parser().parse_args(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cwl_utils/tests/test_normalizer.py
+++ b/src/cwl_utils/tests/test_normalizer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Test the cwl-normalizer console script."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -23,7 +24,9 @@ def test_normalizer_v1_2(tmp_path: Path) -> None:
     input_path = get_data("testdata/count-lines6-single-source-wf_v1_2.cwl")
     args = parse_args([str(tmp_path), input_path])
     assert run(args) == 0
-    assert (tmp_path / "count-lines6-single-source-wf_v1_2.cwl").is_file()
+    output_path = tmp_path / "count-lines6-single-source-wf_v1_2.cwl"
+    assert output_path.is_file()
+    assert json.loads(output_path.read_text(encoding="utf-8"))["cwlVersion"] == "v1.2"
 
 
 def test_normalizer_unsupported_version(

--- a/src/cwl_utils/tests/test_normalizer.py
+++ b/src/cwl_utils/tests/test_normalizer.py
@@ -3,6 +3,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from cwl_utils.normalizer import parse_args, run
 
 from .util import get_data
@@ -14,3 +16,32 @@ def test_normalizer_v1_1(tmp_path: Path) -> None:
     args = parse_args([str(tmp_path), input_path])
     assert run(args) == 0
     assert (tmp_path / "count-lines6-single-source-wf_v1_1.cwl").is_file()
+
+
+def test_normalizer_v1_2(tmp_path: Path) -> None:
+    """Normalize a v1.2 CWL document end-to-end (no upgrade needed)."""
+    input_path = get_data("testdata/count-lines6-single-source-wf_v1_2.cwl")
+    args = parse_args([str(tmp_path), input_path])
+    assert run(args) == 0
+    assert (tmp_path / "count-lines6-single-source-wf_v1_2.cwl").is_file()
+
+
+def test_normalizer_unsupported_version(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unsupported cwlVersion returns non-zero and logs a readable error (no TypeError)."""
+    import logging
+
+    bogus = tmp_path / "bogus.cwl"
+    bogus.write_text(
+        "cwlVersion: v9.9\n"
+        "class: CommandLineTool\n"
+        "baseCommand: [echo]\n"
+        "inputs: []\n"
+        "outputs: []\n"
+    )
+    args = parse_args([str(tmp_path / "out"), str(bogus)])
+    (tmp_path / "out").mkdir()
+    with caplog.at_level(logging.ERROR, logger="cwl-normalizer"):
+        assert run(args) == -1
+    assert any("v9.9" in r.getMessage() for r in caplog.records)

--- a/src/cwl_utils/tests/test_pack_cli.py
+++ b/src/cwl_utils/tests/test_pack_cli.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test the cwl-pack console script."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cwl_utils.pack_cli import arg_parser, run
+
+from .util import get_data
+
+
+def test_pack_cli_stdout(capsys: pytest.CaptureFixture[str]) -> None:
+    """Packing to stdout produces the inlined CWL JSON document."""
+    input_path = get_data("testdata/remote-cwl/wf1.cwl")
+    args = arg_parser().parse_args([input_path])
+    assert run(args) == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed["class"] == "Workflow"
+    assert parsed["cwlVersion"] == "v1.2"
+    assert parsed["steps"][0]["run"]["class"] == "CommandLineTool"
+
+
+def test_pack_cli_outfile(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--outfile`` writes the packed JSON to disk."""
+    input_path = get_data("testdata/remote-cwl/wf1.cwl")
+    outfile = tmp_path / "packed.json"
+    args = arg_parser().parse_args([input_path, "--outfile", str(outfile)])
+    assert run(args) == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(outfile.read_text(encoding="utf-8"))
+    assert captured.out == ""
+    assert parsed["class"] == "Workflow"
+    assert parsed["cwlVersion"] == "v1.2"
+    assert parsed["steps"][0]["run"]["class"] == "CommandLineTool"


### PR DESCRIPTION
Fix bug in logging and make normalization on v1.2 a no-op instead of failing. Expose a cwl-pack CLI for packing without normalization.  