### PR TITLE
Add typed parsers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "packaging",
     "rdflib",
     "requests",
-    "schema-salad >= 8.10.20260810193251,<9",
+    "schema-salad @ git+https://github.com/common-workflow-language/schema_salad.git@refs/pull/993/head",
     "ruamel.yaml >= 0.17.6, < 0.20",
     "typing_extensions >= 4.10.0",
 ]
@@ -72,8 +72,12 @@ cwl-pack = "cwl_utils.pack_cli:main"
 cwl-normalizer = "cwl_utils.normalizer:main"
 cwl-inputs-schema-gen = "cwl_utils.inputs_schema_gen:main"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.pytest.ini_options]
 addopts = "-rsx -n auto --pyargs cwl_utils.tests"
+testpaths = ["src/cwl_utils/tests"]
 
 [tool.hatch.version]
 path = "src/cwl_utils/__meta__.py"

--- a/src/cwl_utils/cite_extract.py
+++ b/src/cwl_utils/cite_extract.py
@@ -33,7 +33,7 @@ def main() -> int:
 
 
 def extract_software_reqs(
-    process: cwl.Process,
+    process: cwl.Process | cwl.WorkflowStep,
 ) -> Iterator[cwl.SoftwareRequirement]:
     """Return an iterator over any SoftwareRequirements found in the given process."""
     if process.requirements:

--- a/src/cwl_utils/cwl_v1_0_expression_refactor.py
+++ b/src/cwl_utils/cwl_v1_0_expression_refactor.py
@@ -6,15 +6,14 @@
 import copy
 import hashlib
 import uuid
-from collections.abc import MutableSequence, Sequence
-from contextlib import suppress
+from collections.abc import Sequence
 from typing import Any, cast, Final
 
 from ruamel import yaml
 from schema_salad.metaschema import ArraySchema
 from schema_salad.runtime import save, LoadingOptions
 from schema_salad.sourceline import SourceLine
-from schema_salad.utils import json_dumps
+from schema_salad.utils import json_dumps, flatten
 
 import cwl_utils.expression_refactor
 import cwl_utils.parser
@@ -24,14 +23,15 @@ from cwl_utils.errors import JavascriptException, WorkflowException
 from cwl_utils.expression import do_eval, interpolate
 from cwl_utils.parser.utils import param_for_source_id
 from cwl_utils.types import (
-    CWLDirectoryType,
     CWLFileType,
     CWLObjectType,
     CWLOutputType,
     CWLParameterContext,
     CWLRuntimeParameterContext,
     is_file_or_directory,
+    is_sequence,
 )
+from cwl_utils.utils import get_step_uri
 
 _DEFAULT_CWL_VERSION: Final = "v1.0"
 
@@ -64,12 +64,12 @@ def escape_expression_field(contents: str) -> str:
 
 
 def clean_type_ids(
-    cwltype: ArraySchema | cwl.InputRecordSchema,
-) -> ArraySchema | cwl.InputRecordSchema:
+    cwltype: cwl.InputParameterType | cwl.CommandInputParameterType | None,
+) -> cwl.InputParameterType | cwl.CommandInputParameterType | None:
     """Simplify type identifiers."""
     result = copy.deepcopy(cwltype)
     if isinstance(result, ArraySchema):
-        if isinstance(result.items, MutableSequence):
+        if is_sequence(result.items):
             for item in result.items:
                 if hasattr(item, "id"):
                     item.id = item.id.split("#")[-1]
@@ -88,6 +88,105 @@ def clean_type_ids(
     return result
 
 
+def clt_input_schema_to_plain_input_schema(
+    input_type: cwl.CommandInputParameterType,
+) -> cwl.InputParameterType:
+    if is_sequence(input_type):
+        return cast(
+            cwl.InputParameterType,
+            flatten(
+                [clt_input_schema_to_plain_input_schema(item) for item in input_type]
+            ),
+        )
+    match input_type:
+        case cwl.CommandInputArraySchema():
+            i1 = copy.deepcopy(input_type)
+            i1.items = clt_input_schema_to_plain_input_schema(
+                cast(cwl.CommandInputParameterType, i1.items)
+            )
+            return cwl.InputArraySchema.fromDoc(
+                i1.save(),
+                i1.loadingOptions.baseuri,
+                i1.loadingOptions,
+            )
+        case cwl.CommandInputEnumSchema():
+            return cwl.InputEnumSchema.fromDoc(
+                input_type.save(),
+                input_type.loadingOptions.baseuri,
+                input_type.loadingOptions,
+            )
+        case cwl.CommandInputRecordSchema():
+            i2 = copy.deepcopy(input_type)
+            if i2.fields is not None:
+                new_fields = []
+                for f in i2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = clt_input_schema_to_plain_input_schema(
+                        cast(cwl.CommandInputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                i2.fields = new_fields
+            return cwl.InputRecordSchema.fromDoc(
+                i2.save(),
+                i2.loadingOptions.baseuri,
+                i2.loadingOptions,
+            )
+        case _:
+            return input_type
+
+
+def clt_output_schema_to_plain_output_schema(
+    output_type: cwl.CommandOutputParameterType,
+) -> cwl.OutputParameterType:
+    if is_sequence(output_type):
+        return cast(
+            cwl.OutputParameterType,
+            flatten(
+                [
+                    clt_output_schema_to_plain_output_schema(
+                        cast(cwl.CommandOutputParameterType, item)
+                    )
+                    for item in output_type
+                ]
+            ),
+        )
+    match output_type:
+        case cwl.CommandOutputArraySchema():
+            o1 = copy.deepcopy(output_type)
+            o1.items = clt_output_schema_to_plain_output_schema(
+                cast(cwl.CommandOutputParameterType, o1.items)
+            )
+            return cwl.OutputArraySchema.fromDoc(
+                o1.save(),
+                o1.loadingOptions.baseuri,
+                o1.loadingOptions,
+            )
+        case cwl.CommandOutputEnumSchema():
+            return cwl.OutputEnumSchema.fromDoc(
+                output_type.save(),
+                output_type.loadingOptions.baseuri,
+                output_type.loadingOptions,
+            )
+        case cwl.CommandOutputRecordSchema():
+            o2 = copy.deepcopy(output_type)
+            if o2.fields is not None:
+                new_fields = []
+                for f in o2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = clt_output_schema_to_plain_output_schema(
+                        cast(cwl.CommandOutputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                o2.fields = new_fields
+            return cwl.OutputRecordSchema.fromDoc(
+                o2.save(),
+                o2.loadingOptions.baseuri,
+                o2.loadingOptions,
+            )
+        case _:
+            return output_type
+
+
 def get_command_input_parameter(id_: str, type_: Any) -> cwl.CommandInputParameter:
     return cwl.CommandInputParameter(id=id_, type_=type_)
 
@@ -99,7 +198,7 @@ def get_command_line_binding(
 
 
 def get_expression(
-    string: str, inputs: CWLObjectType, self: CWLOutputType | None
+    string: Any, inputs: CWLObjectType, self: CWLOutputType | None
 ) -> str | None:
     """
     Find and return a normalized CWL expression, if any.
@@ -160,6 +259,117 @@ def get_inline_javascript_requirement(
     return cwl.InlineJavascriptRequirement(expression_lib)
 
 
+def plain_input_schema_to_clt_input_schema(
+    input_type: cwl.InputParameterType,
+) -> cwl.CommandInputParameterType:
+    if is_sequence(input_type):
+        return cast(
+            cwl.CommandInputParameterType,
+            flatten(
+                [plain_input_schema_to_clt_input_schema(item) for item in input_type]
+            ),
+        )
+    match input_type:
+        case (
+            cwl.CommandInputArraySchema()
+            | cwl.CommandInputEnumSchema()
+            | cwl.CommandInputRecordSchema()
+        ):
+            return input_type
+        case cwl.InputArraySchema():
+            i1 = copy.deepcopy(input_type)
+            i1.items = plain_input_schema_to_clt_input_schema(
+                cast(cwl.InputParameterType, i1.items)
+            )
+            return cwl.CommandInputArraySchema.fromDoc(
+                i1.save(),
+                i1.loadingOptions.baseuri,
+                i1.loadingOptions,
+            )
+        case cwl.InputEnumSchema():
+            return cwl.CommandInputEnumSchema.fromDoc(
+                input_type.save(),
+                input_type.loadingOptions.baseuri,
+                input_type.loadingOptions,
+            )
+        case cwl.InputRecordSchema():
+            i2 = copy.deepcopy(input_type)
+            if i2.fields is not None:
+                new_fields = []
+                for f in i2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = plain_input_schema_to_clt_input_schema(
+                        cast(cwl.InputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                i2.fields = new_fields
+            return cwl.CommandInputRecordSchema.fromDoc(
+                i2.save(),
+                i2.loadingOptions.baseuri,
+                i2.loadingOptions,
+            )
+        case _:
+            return input_type
+
+
+def plain_output_schema_to_clt_output_schema(
+    output_type: cwl.OutputParameterType,
+) -> cwl.CommandOutputParameterType:
+    if is_sequence(output_type):
+        return cast(
+            cwl.CommandOutputParameterType,
+            flatten(
+                [
+                    plain_output_schema_to_clt_output_schema(
+                        cast(cwl.OutputParameterType, item)
+                    )
+                    for item in output_type
+                ]
+            ),
+        )
+    match output_type:
+        case (
+            cwl.CommandOutputArraySchema()
+            | cwl.CommandOutputEnumSchema()
+            | cwl.CommandOutputRecordSchema()
+        ):
+            return output_type
+        case cwl.OutputArraySchema():
+            o1 = copy.deepcopy(output_type)
+            o1.items = plain_output_schema_to_clt_output_schema(
+                cast(cwl.OutputParameterType, o1.items)
+            )
+            return cwl.CommandOutputArraySchema.fromDoc(
+                o1.save(),
+                o1.loadingOptions.baseuri,
+                o1.loadingOptions,
+            )
+        case cwl.OutputEnumSchema():
+            return cwl.CommandOutputEnumSchema.fromDoc(
+                output_type.save(),
+                output_type.loadingOptions.baseuri,
+                output_type.loadingOptions,
+            )
+        case cwl.OutputRecordSchema():
+            o2 = copy.deepcopy(output_type)
+            if o2.fields is not None:
+                new_fields = []
+                for f in o2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = plain_output_schema_to_clt_output_schema(
+                        cast(cwl.OutputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                o2.fields = new_fields
+            return cwl.CommandOutputRecordSchema.fromDoc(
+                o2.save(),
+                o2.loadingOptions.baseuri,
+                o2.loadingOptions,
+            )
+        case _:
+            return output_type
+
+
 def etool_to_cltool(
     etool: cwl.ExpressionTool, expressionLib: list[str] | None = None
 ) -> cwl.CommandLineTool:
@@ -175,7 +385,11 @@ def etool_to_cltool(
                 doc=inp.doc,
                 format=inp.format,
                 default=inp.default,
-                type_=inp.type_,
+                type_=(
+                    plain_input_schema_to_clt_input_schema(inp.type_)
+                    if inp.type_ is not None
+                    else None
+                ),
                 extension_fields=inp.extension_fields,
                 loadingOptions=inp.loadingOptions,
             )
@@ -190,7 +404,11 @@ def etool_to_cltool(
                 streamable=outp.streamable,
                 doc=outp.doc,
                 format=outp.format,
-                type_=outp.type_,
+                type_=(
+                    plain_output_schema_to_clt_output_schema(outp.type_)
+                    if outp.type_ is not None
+                    else None
+                ),
                 extension_fields=outp.extension_fields,
                 loadingOptions=outp.loadingOptions,
             )
@@ -235,8 +453,11 @@ def traverse(
     inside: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]] | None = None,
 ) -> tuple[cwl.CommandLineTool | cwl.ExpressionTool | cwl.Workflow, bool]:
     """Convert the given process and any subprocesses."""
+    if context is None:
+        context = {}
     match process:
         case cwl.CommandLineTool() if not inside:
             process = expand_stream_shortcuts(process)
@@ -300,14 +521,18 @@ def traverse(
                 cwlVersion=process.cwlVersion,
             )
             result, modified = traverse_workflow(
-                workflow, replace_etool, skip_command_line1, skip_command_line2
+                workflow, replace_etool, skip_command_line1, skip_command_line2, context
             )
             if modified:
                 return result, True
             else:
                 return process, False
         case cwl.ExpressionTool() if replace_etool:
-            expression = get_expression(process.expression, empty_inputs(process), None)
+            expression = get_expression(
+                process.expression,
+                cwl_utils.expression_refactor.empty_inputs(process, context),
+                None,
+            )
             # Why call get_expression on an ExpressionTool?
             # It normalizes the form of $() CWL expressions into the ${} style
             if expression:
@@ -318,7 +543,7 @@ def traverse(
             return etool_to_cltool(process2), True
         case cwl.Workflow():
             return traverse_workflow(
-                process, replace_etool, skip_command_line1, skip_command_line2
+                process, replace_etool, skip_command_line1, skip_command_line2, context
             )
         case _:
             return process, False
@@ -331,7 +556,7 @@ def generate_etool_from_expr(
     self_type: None | (
         cwl.InputParameter
         | cwl.CommandInputParameter
-        | list[cwl.InputParameter | cwl.CommandInputParameter]
+        | Sequence[cwl.InputParameter | cwl.CommandInputParameter]
     ) = None,  # if the "self" input should be a different type than the "result" output
     extra_processes: (
         Sequence[cwl_utils.parser.Process | cwl_utils.parser.WorkflowStep] | None
@@ -342,12 +567,13 @@ def generate_etool_from_expr(
     if not no_inputs:
         if not self_type:
             self_type = target
-        if isinstance(self_type, list):
-            new_type: (
-                list[ArraySchema | cwl.InputRecordSchema]
-                | ArraySchema
-                | cwl.InputRecordSchema
-            ) = [clean_type_ids(t.type_) for t in self_type if t.type_]
+        if is_sequence(self_type):
+            new_type: cwl.InputParameterType | cwl.CommandInputParameterType | None = (
+                cast(
+                    cwl.InputParameterType | cwl.CommandInputParameterType,
+                    [clean_type_ids(t.type_) for t in self_type if t.type_],
+                )
+            )
         elif self_type.type_:
             new_type = clean_type_ids(self_type.type_)
         else:
@@ -355,27 +581,27 @@ def generate_etool_from_expr(
         inputs.append(
             cwl.InputParameter(
                 id="self",
-                label=self_type.label if not isinstance(self_type, list) else None,
+                label=self_type.label if not is_sequence(self_type) else None,
                 secondaryFiles=(
-                    self_type.secondaryFiles
-                    if not isinstance(self_type, list)
-                    else None
+                    self_type.secondaryFiles if not is_sequence(self_type) else None
                 ),
                 streamable=(
-                    self_type.streamable if not isinstance(self_type, list) else None
+                    self_type.streamable if not is_sequence(self_type) else None
                 ),
-                doc=self_type.doc if not isinstance(self_type, list) else None,
-                format=self_type.format if not isinstance(self_type, list) else None,
-                type_=new_type,
-                extension_fields=(
-                    self_type.extension_fields
-                    if not isinstance(self_type, list)
+                doc=self_type.doc if not is_sequence(self_type) else None,
+                format=self_type.format if not is_sequence(self_type) else None,
+                type_=(
+                    clt_input_schema_to_plain_input_schema(
+                        cast(cwl.CommandInputParameterType, new_type)
+                    )
+                    if new_type is not None
                     else None
+                ),
+                extension_fields=(
+                    self_type.extension_fields if not is_sequence(self_type) else None
                 ),
                 loadingOptions=(
-                    self_type.loadingOptions
-                    if not isinstance(self_type, list)
-                    else None
+                    self_type.loadingOptions if not is_sequence(self_type) else None
                 ),
             )
         )
@@ -387,8 +613,18 @@ def generate_etool_from_expr(
             secondaryFiles=target.secondaryFiles,
             streamable=target.streamable,
             doc=target.doc,
-            format=target.format,
-            type_=target.type_,
+            format=(
+                "\n".join(target.format)
+                if is_sequence(target.format)
+                else target.format
+            ),
+            type_=(
+                clt_output_schema_to_plain_output_schema(
+                    cast(cwl.CommandOutputParameterType, target.type_)
+                )
+                if target.type_ is not None
+                else None
+            ),
             extension_fields=target.extension_fields,
             loadingOptions=target.loadingOptions,
         )
@@ -423,7 +659,7 @@ def replace_expr_with_etool(
     name: str,
     workflow: cwl.Workflow,
     target: cwl.CommandInputParameter | cwl.InputParameter,
-    source: str | list[Any] | None,
+    source: str | Sequence[Any] | None,
     replace_etool: bool = False,
     extra_process: (
         cwl_utils.parser.Process | cwl_utils.parser.WorkflowStep | None
@@ -453,14 +689,15 @@ def replace_expr_with_etool(
     inps = []
     if source:
         inps.append(cwl.WorkflowStepInput(id="self", source=source))
-    workflow.steps.append(
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=inps,
             out=[cwl.WorkflowStepOutput("result")],
             run=final_tool,
-        )
-    )
+        ),
+    ]
 
 
 def replace_wf_input_ref_with_step_output(
@@ -474,89 +711,21 @@ def replace_wf_input_ref_with_step_output(
                     if inp.source:
                         if inp.source == name:
                             inp.source = target
-                        if isinstance(inp.source, MutableSequence):
-                            for index, source in enumerate(inp.source):
-                                if source == name:
-                                    inp.source[index] = target
+                        if is_sequence(inp.source):
+                            inp.source = [
+                                target if isource == name else isource
+                                for isource in inp.source
+                            ]
     if workflow.outputs:
         for outp in workflow.outputs:
             if outp.outputSource:
                 if outp.outputSource == name:
                     outp.outputSource = target
-                if isinstance(outp.outputSource, MutableSequence):
-                    for index, outputSource in enumerate(outp.outputSource):
-                        if outputSource == name:
-                            outp.outputSource[index] = target
-
-
-def empty_inputs(
-    process_or_step: (
-        cwl.CommandLineTool | cwl.WorkflowStep | cwl.ExpressionTool | cwl.Workflow
-    ),
-    parent: cwl.Workflow | None = None,
-) -> dict[str, Any]:
-    """Produce a mock input object for the given inputs."""
-    result = {}
-    if isinstance(process_or_step, cwl.Process):
-        for param in process_or_step.inputs:
-            result[param.id.split("#")[-1]] = example_input(param.type_)
-    else:
-        for param in process_or_step.in_:
-            param_id = param.id.split("/")[-1]
-            if param.source is None and param.valueFrom:
-                result[param_id] = example_input("string")
-            elif param.source is None and param.default:
-                result[param_id] = param.default
-            else:
-                with suppress(WorkflowException):
-                    result[param_id] = example_input(
-                        utils.type_for_source(process_or_step.run, param.source, parent)
-                    )
-    return result
-
-
-def example_input(some_type: Any) -> Any:
-    """Produce a fake input for the given type."""
-    # TODO: accept some sort of context object with local custom type definitions
-    if some_type == "Directory":
-        return CWLDirectoryType(
-            **{
-                "class": "Directory",
-                "location": "https://www.example.com/example",
-                "basename": "example",
-                "listing": [
-                    CWLFileType(
-                        **{
-                            "class": "File",
-                            "basename": "example.txt",
-                            "size": 23,
-                            "contents": "hoopla",
-                            "nameroot": "example",
-                            "nameext": "txt",
-                        }
-                    )
-                ],
-            }
-        )
-    if some_type == "File":
-        return CWLFileType(
-            **{
-                "class": "File",
-                "location": "https://www.example.com/example.txt",
-                "basename": "example.txt",
-                "size": 23,
-                "contents": "hoopla",
-                "nameroot": "example",
-                "nameext": "txt",
-            }
-        )
-    if some_type == "int":
-        return 23
-    if some_type == "string":
-        return "hoopla!"
-    if some_type == "boolean":
-        return True
-    return None
+                if is_sequence(outp.outputSource):
+                    outp.outputSource = [
+                        target if osource == name else osource
+                        for osource in outp.outputSource
+                    ]
 
 
 EMPTY_FILE = CWLFileType(
@@ -594,7 +763,7 @@ def process_CommandLineTool_output(ctool: cwl.CommandLineTool, outp_id: str) -> 
             ):
                 new_outp.type_ = cwl.OutputArraySchema(items="File", type_="array")
             elif isinstance(new_outp, cwl.CommandOutputParameter):
-                if new_outp.outputBinding:
+                if isinstance(new_outp.outputBinding, cwl.CommandOutputBinding):
                     new_outp.outputBinding.outputEval = None
                     new_outp.outputBinding.loadContents = None
                 new_outp.type_ = cwl.CommandOutputArraySchema(
@@ -609,11 +778,13 @@ def process_CommandLineTool_output(ctool: cwl.CommandLineTool, outp_id: str) -> 
 
 
 def process_workflow_inputs_and_outputs(
-    workflow: cwl.Workflow, replace_etool: bool
+    workflow: cwl.Workflow,
+    replace_etool: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Do any needed conversions on the given Workflow's inputs and outputs."""
     modified = False
-    inputs = empty_inputs(workflow)
+    inputs = cwl_utils.expression_refactor.empty_inputs(workflow, context)
     for index, param in enumerate(workflow.inputs):
         with SourceLine(workflow.inputs, index, WorkflowException):
             if param.format and get_expression(param.format, inputs, None):
@@ -629,7 +800,7 @@ def process_workflow_inputs_and_outputs(
                         "secondaryFiles",
                         raise_type=WorkflowException,
                     ).makeError(TOPLEVEL_SF_EXPR_ERROR.format(param.id.split("#")[-1]))
-                elif isinstance(param.secondaryFiles, MutableSequence):
+                elif is_sequence(param.secondaryFiles):
                     for index2, entry in enumerate(param.secondaryFiles):
                         if get_expression(entry, inputs, EMPTY_FILE):
                             raise SourceLine(
@@ -644,7 +815,9 @@ def process_workflow_inputs_and_outputs(
 
 
 def process_workflow_reqs_and_hints(
-    workflow: cwl.Workflow, replace_etool: bool
+    workflow: cwl.Workflow,
+    replace_etool: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """
     Convert any expressions in a workflow's reqs and hints.
@@ -659,7 +832,7 @@ def process_workflow_reqs_and_hints(
     #       ^ By refactoring replace_expr_etool to allow multiple inputs,
     #         and connecting all workflow inputs to the generated step
     modified = False
-    inputs = empty_inputs(workflow)
+    inputs = cwl_utils.expression_refactor.empty_inputs(workflow, context)
     generated_res_reqs: list[tuple[str, int | str]] = []
     generated_iwdr_reqs: list[tuple[str, int | str]] = []
     generated_envVar_reqs: list[tuple[str, int | str]] = []
@@ -678,13 +851,14 @@ def process_workflow_reqs_and_hints(
         for req in cast(list[cwl.ProcessRequirement], workflow.requirements):
             match req:
                 case cwl.EnvVarRequirement() if req.envDef:
+                    env_defs = list(req.envDef)
                     for index, envDef in enumerate(req.envDef):
                         if envDef.envValue:
                             expression = get_expression(envDef.envValue, inputs, None)
                             if expression:
                                 modified = True
                                 target = cwl.InputParameter(
-                                    id=None,
+                                    id="",
                                     type_="string",
                                 )
                                 etool_id = (
@@ -705,8 +879,9 @@ def process_workflow_reqs_and_hints(
                                     prop_reqs += (cwl.EnvVarRequirement,)
                                 newEnvDef = copy.deepcopy(envDef)
                                 newEnvDef.envValue = f"$(inputs._envDef{index})"
-                                envVarReq.envDef[index] = newEnvDef
+                                env_defs[index] = newEnvDef
                                 generated_envVar_reqs.append((etool_id, index))
+                    req.envDef = env_defs
                 case cwl.ResourceRequirement():
                     for attr in cwl.ResourceRequirement.attrs:
                         this_attr = getattr(req, attr, None)
@@ -714,7 +889,7 @@ def process_workflow_reqs_and_hints(
                             expression = get_expression(this_attr, inputs, None)
                             if expression:
                                 modified = True
-                                target = cwl.InputParameter(id=None, type_="long")
+                                target = cwl.InputParameter(id="", type_="long")
                                 etool_id = "_expression_workflow_ResourceRequirement_{}".format(
                                     attr
                                 )
@@ -739,7 +914,7 @@ def process_workflow_reqs_and_hints(
                         if expression:
                             modified = True
                             target = cwl.InputParameter(
-                                id=None,
+                                id="",
                                 type_=cwl.InputArraySchema(
                                     ["File", "Directory"], "array", None, None
                                 ),
@@ -760,12 +935,13 @@ def process_workflow_reqs_and_hints(
                             prop_reqs += (cwl.InitialWorkDirRequirement,)
                     else:
                         iwdr = copy.deepcopy(req)
+                        new_listing = list(iwdr.listing)
                         for index, entry in enumerate(req.listing):
                             expression = get_expression(entry, inputs, None)
                             if expression:
                                 modified = True
                                 target = cwl.InputParameter(
-                                    id=None,
+                                    id="",
                                     type_=cwl.InputArraySchema(
                                         ["File", "Directory"], "array", None, None
                                     ),
@@ -781,7 +957,7 @@ def process_workflow_reqs_and_hints(
                                     None,
                                     replace_etool,
                                 )
-                                iwdr.listing[index] = f"$(inputs._iwdr_listing_{index}"
+                                new_listing[index] = f"$(inputs._iwdr_listing_{index}"
                                 generated_iwdr_reqs.append((etool_id, index))
                             elif isinstance(entry, cwl.Dirent):
                                 if entry.entry:
@@ -801,7 +977,7 @@ def process_workflow_reqs_and_hints(
                                         modified = True
                                         if is_file_or_directory(expr_result):
                                             target = cwl.InputParameter(
-                                                id=None,
+                                                id="",
                                                 type_=expr_result["class"],
                                             )
                                             replace_expr_with_etool(
@@ -812,7 +988,7 @@ def process_workflow_reqs_and_hints(
                                                 None,
                                                 replace_etool,
                                             )
-                                            iwdr.listing[index] = (
+                                            new_listing[index] = (
                                                 "$(inputs._iwdr_listing_{}".format(
                                                     index
                                                 )
@@ -822,7 +998,7 @@ def process_workflow_reqs_and_hints(
                                             )
                                         elif isinstance(expr_result, str):
                                             target = cwl.InputParameter(
-                                                id=None,
+                                                id="",
                                                 type_=["File"],
                                             )
                                             if entry.entryname is None:
@@ -853,7 +1029,7 @@ def process_workflow_reqs_and_hints(
                                             None,
                                             replace_etool,
                                         )
-                                        iwdr.listing[index] = (
+                                        new_listing[index] = (
                                             f"$(inputs._iwdr_listing_{index}"
                                         )
                                         generated_iwdr_reqs.append((etool_id, index))
@@ -865,7 +1041,7 @@ def process_workflow_reqs_and_hints(
                                     if expression:
                                         modified = True
                                         target = cwl.InputParameter(
-                                            id=None,
+                                            id="",
                                             type_="string",
                                         )
                                         etool_id = "_expression_workflow_InitialWorkDirRequirement_{}".format(
@@ -879,16 +1055,19 @@ def process_workflow_reqs_and_hints(
                                             None,
                                             replace_etool,
                                         )
-                                        iwdr.listing[index] = (
+                                        new_listing[index] = (
                                             f"$(inputs._iwdr_listing_{index}"
                                         )
                                         generated_iwdr_reqs.append((etool_id, index))
+                        iwdr.listing = new_listing
                         if generated_iwdr_reqs:
                             prop_reqs += (cwl.InitialWorkDirRequirement,)
                         else:
                             iwdr = None
+    step_inputs: list[list[cwl.WorkflowStepInput]] = [[] * len(workflow.steps)]
+    step_requirements: list[list[cwl.ProcessRequirement]] = [[] * len(workflow.steps)]
     if envVarReq and workflow.steps:
-        for step in workflow.steps:
+        for index, step in enumerate(workflow.steps):
             if step.id.split("#")[-1].startswith("_expression_"):
                 continue
             if step.requirements:
@@ -897,17 +1076,17 @@ def process_workflow_reqs_and_hints(
                         continue
             else:
                 step.requirements = yaml.comments.CommentedSeq()
-            step.requirements.append(envVarReq)
-            for entry in generated_envVar_reqs:
-                step.in_.append(
+            step_requirements[index].append(envVarReq)
+            for entry2 in generated_envVar_reqs:
+                step_inputs[index].append(
                     cwl.WorkflowStepInput(
-                        id=f"_envDef{entry[1]}",
-                        source=f"{entry[0]}/result",
+                        id=f"_envDef{entry2[1]}",
+                        source=f"{entry2[0]}/result",
                     )
                 )
 
     if resourceReq and workflow.steps:
-        for step in workflow.steps:
+        for index, step in enumerate(workflow.steps):
             if step.id.split("#")[-1].startswith("_expression_"):
                 continue
             if step.requirements:
@@ -916,17 +1095,17 @@ def process_workflow_reqs_and_hints(
                         continue
             else:
                 step.requirements = yaml.comments.CommentedSeq()
-            step.requirements.append(resourceReq)
-            for entry in generated_res_reqs:
-                step.in_.append(
+            step_requirements[index].append(resourceReq)
+            for entry3 in generated_res_reqs:
+                step_inputs[index].append(
                     cwl.WorkflowStepInput(
-                        id=f"_{entry[1]}",
-                        source=f"{entry[0]}/result",
+                        id=f"_{entry3[1]}",
+                        source=f"{entry3[0]}/result",
                     )
                 )
 
     if iwdr and workflow.steps:
-        for step in workflow.steps:
+        for index, step in enumerate(workflow.steps):
             if step.id.split("#")[-1].startswith("_expression_"):
                 continue
             if step.requirements:
@@ -935,25 +1114,35 @@ def process_workflow_reqs_and_hints(
                         continue
             else:
                 step.requirements = yaml.comments.CommentedSeq()
-            step.requirements.append(iwdr)
+            step_requirements[index].append(iwdr)
             if generated_iwdr_reqs:
-                for entry in generated_iwdr_reqs:
-                    step.in_.append(
+                for entry4 in generated_iwdr_reqs:
+                    step_inputs[index].append(
                         cwl.WorkflowStepInput(
                             id=f"_iwdr_listing_{index}",
-                            source=f"{entry[0]}/result",
+                            source=f"{entry4[0]}/result",
                         )
                     )
             else:
-                step.in_.append(
+                step_inputs[index].append(
                     cwl.WorkflowStepInput(
                         id="_iwdr_listing",
                         source="_expression_workflow_InitialWorkDirRequirement/result",
                     )
                 )
+    for step, step_ins, step_reqs in zip(
+        workflow.steps, step_inputs, step_requirements
+    ):
+        if step_ins:
+            step.in_ = [*step.in_, *step_ins]
+        if step_reqs:
+            step.requirements = [
+                *cast(Sequence[cwl.ProcessRequirement], step.requirements),
+                *step_reqs,
+            ]
 
     if workflow.requirements:
-        workflow.requirements[:] = [
+        workflow.requirements = [
             x for x in workflow.requirements if not isinstance(x, prop_reqs)
         ]
     return modified
@@ -962,10 +1151,12 @@ def process_workflow_reqs_and_hints(
 def process_level_reqs(
     process: cwl_utils.parser.Process,
     step: cwl.WorkflowStep,
+    target_process: cwl_utils.parser.Process,
     parent: cwl.Workflow,
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Convert expressions inside a process into new adjacent steps."""
     # This is for reqs inside a Process (CommandLineTool, ExpressionTool)
@@ -980,22 +1171,23 @@ def process_level_reqs(
     if not process.requirements:
         return False
     modified = False
-    target_process = step.run
-    inputs = cwl_utils.expression_refactor.empty_inputs(process, _DEFAULT_CWL_VERSION)
+    inputs = cwl_utils.expression_refactor.empty_inputs(process, context)
     generated_res_reqs: list[tuple[str, str]] = []
     generated_iwdr_reqs: list[tuple[str, int | str, Any]] = []
     generated_envVar_reqs: list[tuple[str, int | str]] = []
     if not step.id:
         return False
     step_name = step.id.split("#", 1)[-1]
-    for req_index, req in enumerate(process.requirements):
+    for req in process.requirements:
         if isinstance(req, cwl_utils.parser.EnvVarRequirement) and req.envDef:
-            for env_index, envDef in enumerate(req.envDef):
+            for env_index, envDef in enumerate(
+                cast(Sequence[cwl_utils.parser.EnvironmentDef], req.envDef)
+            ):
                 if envDef.envValue:
                     expression = get_expression(envDef.envValue, inputs, None)
                     if expression:
                         modified = True
-                        target = cwl.InputParameter(id=None, type_="string")
+                        target = cwl.InputParameter(id="", type_="string")
                         etool_id = "_expression_{}_EnvVarRequirement_{}".format(
                             step_name, env_index
                         )
@@ -1008,9 +1200,7 @@ def process_level_reqs(
                             replace_etool,
                             process,
                         )
-                        target_process.requirements[req_index][
-                            env_index
-                        ].envValue = f"$(inputs._envDef{env_index})"
+                        envDef.envValue = f"$(inputs._envDef{env_index})"
                         generated_envVar_reqs.append((etool_id, env_index))
         elif isinstance(req, cwl_utils.parser.ResourceRequirement):
             for attr in cwl.ResourceRequirement.attrs:
@@ -1019,7 +1209,7 @@ def process_level_reqs(
                     expression = get_expression(this_attr, inputs, None)
                     if expression:
                         modified = True
-                        target = cwl.InputParameter(id=None, type_="long")
+                        target = cwl.InputParameter(id="", type_="long")
                         etool_id = "_expression_{}_ResourceRequirement_{}".format(
                             step_name, attr
                         )
@@ -1029,10 +1219,11 @@ def process_level_reqs(
                             parent,
                             target,
                             step,
+                            target_process,
                             replace_etool,
                         )
                         setattr(
-                            target_process.requirements[req_index],
+                            req,
                             attr,
                             f"$(inputs._{attr})",
                         )
@@ -1050,7 +1241,7 @@ def process_level_reqs(
                     target_type = cwl.InputArraySchema(
                         ["File", "Directory"], "array", None, None
                     )
-                    target = cwl.InputParameter(id=None, type_=target_type)
+                    target = cwl.InputParameter(id="", type_=target_type)
                     etool_id = "_expression_{}_InitialWorkDirRequirement".format(
                         step_name
                     )
@@ -1063,15 +1254,14 @@ def process_level_reqs(
                         replace_etool,
                         process,
                     )
-                    target_process.requirements[req_index].listing = (
-                        "$(inputs._iwdr_listing)",
-                    )
-                    step.in_.append(
+                    req.listing = ("$(inputs._iwdr_listing)",)
+                    step.in_ = [
+                        *step.in_,
                         cwl.WorkflowStepInput(
                             id="_iwdr_listing",
                             source=f"{etool_id}/result",
-                        )
-                    )
+                        ),
+                    ]
                     cwl_utils.expression_refactor.add_input_to_process(
                         target_process,
                         _DEFAULT_CWL_VERSION,
@@ -1088,7 +1278,7 @@ def process_level_reqs(
                             ["File", "Directory"], "array", None, None
                         )
                         target = cwl.InputParameter(
-                            id=None,
+                            id="",
                             type_=target_type,
                         )
                         etool_id = "_expression_{}_InitialWorkDirRequirement_{}".format(
@@ -1103,9 +1293,9 @@ def process_level_reqs(
                             replace_etool,
                             process,
                         )
-                        target_process.requirements[req_index].listing[
-                            listing_index
-                        ] = f"$(inputs._iwdr_listing_{listing_index}"
+                        req.listing[listing_index] = (
+                            f"$(inputs._iwdr_listing_{listing_index}"
+                        )
                         generated_iwdr_reqs.append(
                             (etool_id, listing_index, target_type)
                         )
@@ -1143,7 +1333,7 @@ return result; }"""
                                     new_expression = expression
                                 d_target_type = ["File", "Directory"]
                                 target = cwl.InputParameter(
-                                    id=None,
+                                    id="",
                                     type_=d_target_type,
                                 )
                                 etool_id = "_expression_{}_InitialWorkDirRequirement_{}".format(
@@ -1156,11 +1346,10 @@ return result; }"""
                                     parent,
                                     target,
                                     step,
+                                    target_process,
                                     replace_etool,
                                 )
-                                target_process.requirements[req_index].listing[
-                                    listing_index
-                                ].entry = "$(inputs._iwdr_listing_{})".format(
+                                entry.entry = "$(inputs._iwdr_listing_{})".format(
                                     listing_index
                                 )
                                 generated_iwdr_reqs.append(
@@ -1171,7 +1360,7 @@ return result; }"""
                             if expression:
                                 modified = True
                                 target = cwl.InputParameter(
-                                    id=None,
+                                    id="",
                                     type_="string",
                                 )
                                 etool_id = "_expression_{}_InitialWorkDirRequirement_{}".format(
@@ -1186,32 +1375,36 @@ return result; }"""
                                     replace_etool,
                                     process,
                                 )
-                                target_process.requirements[req_index].listing[
-                                    listing_index
-                                ].entryname = "$(inputs._iwdr_listing_{})".format(
+                                entry.entryname = "$(inputs._iwdr_listing_{})".format(
                                     listing_index
                                 )
                                 generated_iwdr_reqs.append(
                                     (etool_id, listing_index, "string")
                                 )
-    for entry in generated_envVar_reqs:
-        name = f"_envDef{entry[1]}"
-        step.in_.append(cwl.WorkflowStepInput(id=name, source=f"{entry[0]}/result"))
+    step_inputs = []
+    for entry2 in generated_envVar_reqs:
+        name = f"_envDef{entry2[1]}"
+        step_inputs.append(cwl.WorkflowStepInput(id=name, source=f"{entry2[0]}/result"))
         cwl_utils.expression_refactor.add_input_to_process(
             target_process, _DEFAULT_CWL_VERSION, name, "string", process.loadingOptions
         )
-    for entry in generated_res_reqs:
-        name = f"_{entry[1]}"
-        step.in_.append(cwl.WorkflowStepInput(id=name, source=f"{entry[0]}/result"))
+    for entry3 in generated_res_reqs:
+        name = f"_{entry3[1]}"
+        step_inputs.append(cwl.WorkflowStepInput(id=name, source=f"{entry3[0]}/result"))
         cwl_utils.expression_refactor.add_input_to_process(
             target_process, _DEFAULT_CWL_VERSION, name, "long", process.loadingOptions
         )
-    for entry in generated_iwdr_reqs:
-        name = f"_iwdr_listing_{entry[1]}"
-        step.in_.append(cwl.WorkflowStepInput(id=name, source=f"{entry[0]}/result"))
+    for entry4 in generated_iwdr_reqs:
+        name = f"_iwdr_listing_{entry4[1]}"
+        step_inputs.append(cwl.WorkflowStepInput(id=name, source=f"{entry4[0]}/result"))
         cwl_utils.expression_refactor.add_input_to_process(
-            target_process, _DEFAULT_CWL_VERSION, name, entry[2], process.loadingOptions
+            target_process,
+            _DEFAULT_CWL_VERSION,
+            name,
+            entry4[2],
+            process.loadingOptions,
         )
+    step.in_ = [*step.in_, *step_inputs]
     return modified
 
 
@@ -1233,19 +1426,21 @@ def traverse_CommandLineTool(
     clt: cwl_utils.parser.CommandLineTool,
     parent: cwl.Workflow,
     step: cwl.WorkflowStep,
+    target_clt: cwl_utils.parser.CommandLineTool,
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Extract any CWL Expressions within the given CommandLineTool into sibling steps."""
     modified = False
-    # don't modify clt, modify step.run
-    target_clt = step.run
-    inputs = cwl_utils.expression_refactor.empty_inputs(clt, _DEFAULT_CWL_VERSION)
+    inputs = cwl_utils.expression_refactor.empty_inputs(clt, context)
     if not step.id:
         return False
     step_id = step.id.split("#")[-1]
+    clt_inputs, step_inputs = [], []
     if clt.arguments and not skip_command_line1:
+        arguments = list(clt.arguments)
         for index, arg in enumerate(clt.arguments):
             if isinstance(arg, str):
                 expression = get_expression(arg, inputs, None)
@@ -1254,27 +1449,32 @@ def traverse_CommandLineTool(
                     inp_id = f"_arguments_{index}"
                     etool_id = f"_expression_{step_id}{inp_id}"
                     target_type = "Any"
-                    target = cwl.InputParameter(id=None, type_=target_type)
+                    target = cwl.InputParameter(id="", type_=target_type)
                     replace_step_clt_expr_with_etool(
-                        expression, etool_id, parent, target, step, replace_etool
+                        expression,
+                        etool_id,
+                        parent,
+                        target,
+                        step,
+                        target_clt,
+                        replace_etool,
+                        context,
                     )
-                    target_clt.arguments[index] = (
+                    arguments[index] = (
                         cwl_utils.expression_refactor.get_command_line_binding(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             valueFrom=f"$(inputs.{inp_id})",
                         )
                     )
-                    target_clt.inputs.append(
+                    clt_inputs.append(
                         cwl_utils.expression_refactor.get_command_input_parameter(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             inp_id,
                             target_type,
                         )
                     )
-                    step.in_.append(
-                        cwl.WorkflowStepInput(
-                            f"{etool_id}/result", None, inp_id, None, None
-                        )
+                    step_inputs.append(
+                        cwl.WorkflowStepInput(id=f"{etool_id}/result", source=inp_id)
                     )
                     cwl_utils.expression_refactor.remove_JSReq(
                         target_clt, skip_command_line1
@@ -1286,26 +1486,34 @@ def traverse_CommandLineTool(
                     inp_id = f"_arguments_{index}"
                     etool_id = f"_expression_{step_id}{inp_id}"
                     target_type = "Any"
-                    target = cwl.InputParameter(id=None, type_=target_type)
+                    target = cwl.InputParameter(id="", type_=target_type)
                     replace_step_clt_expr_with_etool(
-                        expression, etool_id, parent, target, step, replace_etool
+                        expression,
+                        etool_id,
+                        parent,
+                        target,
+                        step,
+                        target_clt,
+                        replace_etool,
+                        context,
                     )
-                    target_clt.arguments[index].valueFrom = "$(inputs.{})".format(
-                        inp_id
-                    )
-                    target_clt.inputs.append(
+                    cast(
+                        cwl_utils.parser.CommandLineBinding, arguments[index]
+                    ).valueFrom = "$(inputs.{})".format(inp_id)
+                    clt_inputs.append(
                         cwl_utils.expression_refactor.get_command_input_parameter(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             inp_id,
                             target_type,
                         )
                     )
-                    step.in_.append(
-                        cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
+                    step_inputs.append(
+                        cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result"),
                     )
                     cwl_utils.expression_refactor.remove_JSReq(
                         target_clt, skip_command_line1
                     )
+        target_clt.arguments = arguments
     for streamtype in "stdout", "stderr":  # add 'stdin' for v1.1 version
         stream_value = getattr(clt, streamtype)
         if stream_value:
@@ -1315,25 +1523,34 @@ def traverse_CommandLineTool(
                 inp_id = f"_{streamtype}"
                 etool_id = f"_expression_{step_id}{inp_id}"
                 target_type = "string"
-                target = cwl.InputParameter(id=None, type_=target_type)
+                target = cwl.InputParameter(id="", type_=target_type)
                 replace_step_clt_expr_with_etool(
-                    expression, etool_id, parent, target, step, replace_etool
+                    expression,
+                    etool_id,
+                    parent,
+                    target,
+                    step,
+                    target_clt,
+                    replace_etool,
+                    context,
                 )
                 setattr(target_clt, streamtype, f"$(inputs.{inp_id})")
-                target_clt.inputs.append(
+                clt_inputs.append(
                     cwl_utils.expression_refactor.get_command_input_parameter(
                         target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                         inp_id,
                         target_type,
                     )
                 )
-                step.in_.append(
+                step_inputs.append(
                     cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
                 )
     for inp in clt.inputs:
         if not skip_command_line1 and inp.inputBinding and inp.inputBinding.valueFrom:
             expression = get_expression(
-                inp.inputBinding.valueFrom, inputs, example_input(inp.type_)
+                inp.inputBinding.valueFrom,
+                inputs,
+                cwl_utils.expression_refactor.example_input(inp.type_),
             )
             if expression:
                 modified = True
@@ -1341,17 +1558,27 @@ def traverse_CommandLineTool(
                 inp_id = f"_{self_id}_valueFrom"
                 etool_id = f"_expression_{step_id}{inp_id}"
                 replace_step_clt_expr_with_etool(
-                    expression, etool_id, parent, inp, step, replace_etool, self_id
+                    expression,
+                    etool_id,
+                    parent,
+                    inp,
+                    step,
+                    target_clt,
+                    replace_etool,
+                    context,
+                    self_id,
                 )
                 inp.inputBinding.valueFrom = f"$(inputs.{inp_id})"
-                target_clt.inputs.append(
+                clt_inputs.append(
                     cwl_utils.expression_refactor.get_command_input_parameter(
                         target_clt.cwlVersion or _DEFAULT_CWL_VERSION, inp_id, inp.type_
                     )
                 )
-                step.in_.append(
+                step_inputs.append(
                     cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
                 )
+    target_clt.inputs = [*target_clt.inputs, *clt_inputs]
+    step.in_ = [*step.in_, *step_inputs]
     for outp in clt.outputs:
         if outp.outputBinding:
             if outp.outputBinding.glob:
@@ -1360,20 +1587,30 @@ def traverse_CommandLineTool(
                     modified = True
                     inp_id = "_{}_glob".format(outp.id.split("#")[-1])
                     etool_id = f"_expression_{step_id}{inp_id}"
-                    glob_target_type = ["string", ArraySchema("string", "array")]
-                    target = cwl.InputParameter(id=None, type_=glob_target_type)
+                    glob_target_type: list[str | cwl.InputArraySchema] = [
+                        "string",
+                        cwl.InputArraySchema(items="string", type_="array"),
+                    ]
+                    target = cwl.InputParameter(id="", type_=glob_target_type)
                     replace_step_clt_expr_with_etool(
-                        expression, etool_id, parent, target, step, replace_etool
+                        expression,
+                        etool_id,
+                        parent,
+                        target,
+                        step,
+                        target_clt,
+                        replace_etool,
+                        context,
                     )
                     outp.outputBinding.glob = f"$(inputs.{inp_id})"
-                    target_clt.inputs.append(
+                    clt_inputs.append(
                         cwl_utils.expression_refactor.get_command_input_parameter(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             inp_id,
                             glob_target_type,
                         )
                     )
-                    step.in_.append(
+                    step_inputs.append(
                         cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
                     )
             if outp.outputBinding.outputEval and not skip_command_line2:
@@ -1396,27 +1633,28 @@ def traverse_CommandLineTool(
                     inp_id = f"_{outp_id}_outputEval"
                     etool_id = f"expression{inp_id}"
                     sub_wf_outputs = cltool_step_outputs_to_workflow_outputs(
-                        step, etool_id, outp_id
+                        step, target_clt, etool_id, outp_id
                     )
                     self_type = cwl.InputParameter(
-                        id=None,
+                        id="",
                         type_=cwl.InputArraySchema("File", "array", None, None),
                     )
                     etool = generate_etool_from_expr(
                         expression, outp, False, self_type, [clt, step, parent]
                     )
                     if outp.outputBinding.loadContents:
-                        etool.inputs[0].type_.inputBinding = (
+                        etool.inputs[0].inputBinding = (
                             cwl_utils.expression_refactor.get_command_line_binding(
                                 etool.cwlVersion or _DEFAULT_CWL_VERSION,
                                 loadContents=True,
                             )
                         )
-                    etool.inputs.extend(
-                        cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
+                    etool.inputs = [
+                        *etool.inputs,
+                        *cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
                             clt, _DEFAULT_CWL_VERSION
-                        )
-                    )
+                        ),
+                    ]
                     sub_wf_inputs = (
                         cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
                             clt, _DEFAULT_CWL_VERSION
@@ -1425,19 +1663,21 @@ def traverse_CommandLineTool(
                     orig_step_inputs = copy.deepcopy(step.in_)
                     for orig_step_input in orig_step_inputs:
                         orig_step_input.id = orig_step_input.id.split("/")[-1]
-                        if isinstance(orig_step_input.source, MutableSequence):
-                            for index, source in enumerate(orig_step_input.source):
-                                orig_step_input.source[index] = source.split("#")[-1]
-                        else:
+                        if is_sequence(orig_step_input.source):
+                            orig_step_input.source = [
+                                source.split("#")[-1]
+                                for source in orig_step_input.source
+                            ]
+                        elif orig_step_input.source is not None:
                             orig_step_input.source = orig_step_input.source.split("#")[
                                 -1
                             ]
-                    orig_step_inputs[:] = [
+                    orig_step_inputs = [
                         x for x in orig_step_inputs if not x.id.startswith("_")
                     ]
-                    for inp in orig_step_inputs:
-                        inp.source = inp.id
-                        inp.linkMerge = None
+                    for inp2 in orig_step_inputs:
+                        inp2.source = inp2.id
+                        inp2.linkMerge = None
                     final_etool: (
                         cwl_utils.parser.CommandLineTool
                         | cwl_utils.parser.ExpressionTool
@@ -1461,25 +1701,25 @@ def traverse_CommandLineTool(
                         step
                     )  # a deepcopy would be convenient, but params2.cwl gives it problems
                     new_clt_step.id = new_clt_step.id.split("#")[-1]
-                    new_clt_step.run = copy.copy(step.run)
-                    new_clt_step.run.id = None
+                    new_clt = copy.copy(target_clt)
+                    new_clt.id = ""
                     cwl_utils.expression_refactor.remove_JSReq(
-                        new_clt_step.run, skip_command_line1
+                        new_clt, skip_command_line1
                     )
                     cwl_utils.expression_refactor.process_CommandLineTool_output(
-                        new_clt_step.run, _DEFAULT_CWL_VERSION, outp_id
+                        new_clt, _DEFAULT_CWL_VERSION, outp_id
                     )
                     new_clt_step.in_ = copy.deepcopy(step.in_)
-                    for inp in new_clt_step.in_:
-                        inp.id = inp.id.split("/")[-1]
-                        inp.source = inp.id
-                        inp.linkMerge = None
-                    for index, out in enumerate(new_clt_step.out):
-                        new_clt_step.out[index] = out.split("/")[-1]
-                    for tool_inp in new_clt_step.run.inputs:
+                    for inp3 in new_clt_step.in_:
+                        inp3.id = inp3.id.split("/")[-1]
+                        inp3.source = inp3.id
+                        inp3.linkMerge = None
+                    new_clt_step.out = [out.split("/")[-1] for out in new_clt_step.out]
+                    for tool_inp in new_clt.inputs:
                         tool_inp.id = tool_inp.id.split("#")[-1]
-                    for tool_out in new_clt_step.run.outputs:
+                    for tool_out in new_clt.outputs:
                         tool_out.id = tool_out.id.split("#")[-1]
+                    new_clt_step.run = new_clt
                     sub_wf_steps = [new_clt_step, etool_step]
                     sub_workflow = cwl.Workflow(
                         inputs=sub_wf_inputs,
@@ -1506,9 +1746,10 @@ def traverse_CommandLineTool(
                             if isinstance(req, cwl.SubworkflowFeatureRequirement):
                                 has_sub_wf_req = True
                         if not has_sub_wf_req:
-                            parent.requirements.append(
-                                cwl.SubworkflowFeatureRequirement()
-                            )
+                            parent.requirements = [
+                                *parent.requirements,
+                                cwl.SubworkflowFeatureRequirement(),
+                            ]
     return modified
 
 
@@ -1537,9 +1778,10 @@ def rename_step_source(workflow: cwl.Workflow, old: str, new: str) -> None:
                         if source_id == old:
                             inp.source = new
                     else:
-                        for index, source in enumerate(inp.source):
-                            if simplify_step_id(source) == old:
-                                inp.source[index] = new
+                        inp.source = [
+                            new if simplify_step_id(source) == old else source
+                            for source in inp.source
+                        ]
 
 
 def replace_step_clt_expr_with_etool(
@@ -1548,12 +1790,14 @@ def replace_step_clt_expr_with_etool(
     workflow: cwl.Workflow,
     target: cwl.InputParameter,
     step: cwl.WorkflowStep,
+    clt: cwl_utils.parser.CommandLineTool,
     replace_etool: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
     self_name: str | None = None,
 ) -> None:
     """Convert a step level CWL Expression to a sibling expression step."""
     etool_inputs = cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
-        step.run, _DEFAULT_CWL_VERSION
+        clt, _DEFAULT_CWL_VERSION
     )
     temp_etool = cwl_utils.expression_refactor.generate_etool_from_expr2(
         expr,
@@ -1561,7 +1805,7 @@ def replace_step_clt_expr_with_etool(
         target,
         etool_inputs,
         self_name,
-        step.run,
+        clt,
         [workflow],
     )
     etool: cwl_utils.parser.CommandLineTool | cwl_utils.parser.ExpressionTool
@@ -1577,15 +1821,21 @@ def replace_step_clt_expr_with_etool(
     wf_step_inputs = copy.deepcopy(step.in_)
     for wf_step_input in wf_step_inputs:
         wf_step_input.id = wf_step_input.id.split("/")[-1]
-    wf_step_inputs[:] = [x for x in wf_step_inputs if not x.id.startswith("_")]
-    workflow.steps.append(
+    wf_step_inputs = [x for x in wf_step_inputs if not x.id.startswith("_")]
+    if isinstance(step.run, str):
+        context[get_step_uri(step)] = (etool, True)
+        step_run: str | cwl.Process = step.run
+    else:
+        step_run = cast(cwl.Process, etool)
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=wf_step_inputs,
             out=[cwl.WorkflowStepOutput("result")],
-            run=etool,
-        )
-    )
+            run=step_run,
+        ),
+    ]
 
 
 def replace_clt_hintreq_expr_with_etool(
@@ -1594,21 +1844,25 @@ def replace_clt_hintreq_expr_with_etool(
     workflow: cwl.Workflow,
     target: cwl.InputParameter,
     step: cwl.WorkflowStep,
+    process: cwl_utils.parser.Process,
     replace_etool: bool,
     self_name: str | None = None,
 ) -> None:
     """Factor out an expression inside a CommandLineTool req or hint into a sibling step."""
     # Same as replace_step_clt_expr_with_etool or different?
-    etool_inputs = cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
-        step.run, _DEFAULT_CWL_VERSION
-    )
+    if isinstance(process, cwl_utils.parser.CommandLineTool):
+        etool_inputs = cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
+            process, _DEFAULT_CWL_VERSION
+        )
+    else:
+        etool_inputs = copy.deepcopy(process.inputs)
     temp_etool = cwl_utils.expression_refactor.generate_etool_from_expr2(
         expr,
         _DEFAULT_CWL_VERSION,
         target,
         etool_inputs,
         self_name,
-        step.run,
+        process,
         [workflow],
     )
     etool: cwl_utils.parser.CommandLineTool | cwl_utils.parser.ExpressionTool
@@ -1624,22 +1878,23 @@ def replace_clt_hintreq_expr_with_etool(
     wf_step_inputs = copy.deepcopy(step.in_)
     for wf_step_input in wf_step_inputs:
         wf_step_input.id = wf_step_input.id.split("/")[-1]
-    wf_step_inputs[:] = [x for x in wf_step_inputs if not x.id.startswith("_")]
-    workflow.steps.append(
+    wf_step_inputs = [x for x in wf_step_inputs if not x.id.startswith("_")]
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=wf_step_inputs,
             out=[cwl.WorkflowStepOutput("result")],
             run=etool,
-        )
-    )
+        ),
+    ]
 
 
 def cltool_inputs_to_etool_inputs(
     tool: cwl.CommandLineTool,
 ) -> list[cwl.InputParameter]:
     """Copy CommandLineTool input objects into the equivalent ExpressionTool input objects."""
-    inputs = yaml.comments.CommentedSeq()
+    inputs: list[cwl.WorkflowInputParameter] = []
     if tool.inputs:
         for clt_inp in tool.inputs:
             clt_inp_id = clt_inp.id.split("#")[-1].split("/")[-1]
@@ -1653,7 +1908,11 @@ def cltool_inputs_to_etool_inputs(
                         doc=clt_inp.doc,
                         format=clt_inp.format,
                         default=clt_inp.default,
-                        type_=clt_inp.type_,
+                        type_=(
+                            clt_input_schema_to_plain_input_schema(clt_inp.type_)
+                            if clt_inp.type_ is not None
+                            else None
+                        ),
                         extension_fields=clt_inp.extension_fields,
                         loadingOptions=clt_inp.loadingOptions,
                     )
@@ -1662,7 +1921,10 @@ def cltool_inputs_to_etool_inputs(
 
 
 def cltool_step_outputs_to_workflow_outputs(
-    cltool_step: cwl.WorkflowStep, etool_step_id: str, etool_out_id: str
+    cltool_step: cwl.WorkflowStep,
+    cltool: cwl_utils.parser.CommandLineTool,
+    etool_step_id: str,
+    etool_out_id: str,
 ) -> list[cwl.OutputParameter]:
     """
     Copy CommandLineTool outputs into the equivalent Workflow output parameters.
@@ -1674,8 +1936,8 @@ def cltool_step_outputs_to_workflow_outputs(
     if not cltool_step.id:
         raise WorkflowException(f"Missing step id from {cltool_step}.")
     default_step_id = cltool_step.id.split("#")[-1]
-    if cltool_step.run.outputs:
-        for clt_out in cltool_step.run.outputs:
+    if cltool.outputs:
+        for clt_out in cltool.outputs:
             clt_out_id = clt_out.id.split("#")[-1].split("/")[-1]
             if clt_out_id == etool_out_id:
                 outputSource = f"{etool_step_id}/result"
@@ -1702,14 +1964,14 @@ def cltool_step_outputs_to_workflow_outputs(
 def generate_etool_from_expr2(
     expr: str,
     target: cwl.InputParameter,
-    inputs: Sequence[cwl.InputParameter | cwl.CommandOutputParameter],
+    inputs: Sequence[cwl.InputParameter],
     expression_lib: list[str] | None,
-    hints: Sequence[Any],
+    hints: Sequence[Any | cwl.ProcessRequirement],
     requirements: Sequence[cwl.ProcessRequirement],
     self_name: str | None = None,
 ) -> cwl.ExpressionTool:
     """Generate an ExpressionTool to achieve the same result as the given expression."""
-    outputs = yaml.comments.CommentedSeq()
+    outputs: list[cwl.ExpressionToolOutputParameter] = []
     outputs.append(
         cwl.ExpressionToolOutputParameter(
             id="result",
@@ -1717,8 +1979,18 @@ def generate_etool_from_expr2(
             secondaryFiles=target.secondaryFiles,
             streamable=target.streamable,
             doc=target.doc,
-            format=target.format,
-            type_=target.type_,
+            format=(
+                "\n".join(target.format)
+                if is_sequence(target.format)
+                else target.format
+            ),
+            type_=(
+                clt_output_schema_to_plain_output_schema(
+                    cast(cwl.CommandOutputParameterType, target.type_)
+                )
+                if target.type_ is not None
+                else None
+            ),
         )
     )
     expression = "${"
@@ -1738,6 +2010,7 @@ def generate_etool_from_expr2(
         expression=expression,
         requirements=[cwl.InlineJavascriptRequirement(expression_lib)]
         + [r for r in requirements],
+        hints=hints,
         cwlVersion=_DEFAULT_CWL_VERSION,
     )
 
@@ -1745,29 +2018,31 @@ def generate_etool_from_expr2(
 def traverse_step(
     step: cwl.WorkflowStep,
     parent: cwl.Workflow,
+    process: cwl_utils.parser.Process,
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Process the given WorkflowStep."""
     modified = False
-    inputs = empty_inputs(step, parent)
+    inputs = cwl_utils.expression_refactor.empty_inputs(step, context, parent)
     if not step.id:
         return False
     step_id = step.id.split("#")[-1]
-    original_process = copy.deepcopy(step.run)
+    original_process = copy.deepcopy(process)
     original_step_ins = copy.deepcopy(step.in_)
     for inp in step.in_:
         if inp.valueFrom:
             if not inp.source:
                 self = None
             else:
-                if isinstance(inp.source, MutableSequence):
+                if is_sequence(inp.source):
                     self = []
                     for source in inp.source:
                         if not step.scatter:
                             self.append(
-                                example_input(
+                                cwl_utils.expression_refactor.example_input(
                                     utils.type_for_source(parent, source.split("#")[-1])
                                 )
                             )
@@ -1775,45 +2050,61 @@ def traverse_step(
                             scattered_source_type = utils.type_for_source(
                                 parent, source
                             )
-                            if isinstance(scattered_source_type, list):
+                            if is_sequence(scattered_source_type):
                                 for stype in scattered_source_type:
-                                    self.append(example_input(stype.type_))
+                                    self.append(
+                                        cwl_utils.expression_refactor.example_input(
+                                            stype.type_
+                                        )
+                                    )
                             else:
-                                self.append(example_input(scattered_source_type.type_))
+                                self.append(
+                                    cwl_utils.expression_refactor.example_input(
+                                        scattered_source_type.type_
+                                    )
+                                )
                 else:
                     if not step.scatter:
-                        self = example_input(
+                        self = cwl_utils.expression_refactor.example_input(
                             utils.type_for_source(parent, inp.source.split("#")[-1])
                         )
                     else:
                         scattered_source_type2 = utils.type_for_source(
                             parent, inp.source
                         )
-                        if isinstance(scattered_source_type2, list):
-                            self = example_input(scattered_source_type2[0].type_)
+                        if is_sequence(scattered_source_type2):
+                            self = cwl_utils.expression_refactor.example_input(
+                                scattered_source_type2[0].type_
+                            )
                         else:
-                            self = example_input(scattered_source_type2.type_)
+                            self = cwl_utils.expression_refactor.example_input(
+                                scattered_source_type2.type_
+                            )
             expression = get_expression(inp.valueFrom, inputs, self)
             if expression:
                 modified = True
                 etool_id = "_expression_{}_{}".format(step_id, inp.id.split("/")[-1])
                 target = cwl_utils.expression_refactor.get_input_for_id(
-                    inp.id, original_process
+                    inp.id, original_process, context
                 )
                 if not target:
                     raise WorkflowException("target not found")
                 input_source_id = None
                 if inp.source:
-                    if isinstance(inp.source, MutableSequence):
+                    if is_sequence(inp.source):
                         input_source_id = []
                         source_types: list[cwl.InputParameter] = []
                         for source in inp.source:
                             source_id = source.split("#")[-1]
                             input_source_id.append(source_id)
-                            temp_type = utils.type_for_source(
-                                step.run, source_id, parent
+                            temp_type = cwl_utils.parser.utils.type_for_source(
+                                process,
+                                process.cwlVersion or _DEFAULT_CWL_VERSION,
+                                source_id,
+                                parent,
+                                loaded_steps={k: v[0] for k, v in context.items()},
                             )
-                            if isinstance(temp_type, list):
+                            if is_sequence(temp_type):
                                 for ttype in temp_type:
                                     if ttype not in source_types:
                                         source_types.append(ttype)
@@ -1824,7 +2115,7 @@ def traverse_step(
                         input_source_id = inp.source.split("#")[-1]
                 # target.id = target.id.split('#')[-1]
                 if isinstance(original_process, cwl_utils.parser.ExpressionTool):
-                    reqs: list[cwl.ProcessRequirement] = []
+                    reqs: list[cwl_utils.parser.ProcessRequirement] = []
                     if original_process.hints:
                         reqs.extend(original_process.hints)
                     if original_process.requirements:
@@ -1835,16 +2126,17 @@ def traverse_step(
                         ):
                             break
                     else:
-                        if not step.run.requirements:
-                            step.run.requirements = []
+                        if not process.requirements:
+                            process.requirements = []
                         expr_lib = cwl_utils.expression_refactor.find_expressionLib(
                             [parent]
                         )
-                        step.run.requirements.append(
+                        process.requirements = [
+                            *process.requirements,
                             cwl_utils.expression_refactor.get_inline_javascript_requirement(
-                                step.run, _DEFAULT_CWL_VERSION, expr_lib
-                            )
-                        )
+                                original_process, _DEFAULT_CWL_VERSION, expr_lib
+                            ),
+                        ]
                 replace_step_valueFrom_expr_with_etool(
                     expression,
                     etool_id,
@@ -1863,10 +2155,12 @@ def traverse_step(
     process_modified = process_level_reqs(
         original_process,
         step,
+        process,
         parent,
         replace_etool,
         skip_command_line1,
         skip_command_line2,
+        context,
     )
     if process_modified:
         modified = True
@@ -1875,9 +2169,11 @@ def traverse_step(
             original_process,
             parent,
             step,
+            cast(cwl_utils.parser.CommandLineTool, process),
             replace_etool,
             skip_command_line1,
             skip_command_line2,
+            context,
         )
         if clt_modified:
             modified = True
@@ -1885,12 +2181,8 @@ def traverse_step(
 
 
 def workflow_step_to_InputParameters(
-    step_ins: list[cwl.WorkflowStepInput], parent: cwl.Workflow, except_in_id: str
-) -> list[
-    cwl_utils.parser.CommandInputParameter
-    | cwl_utils.parser.CommandOutputParameter
-    | cwl_utils.parser.WorkflowInputParameter
-]:
+    step_ins: Sequence[cwl.WorkflowStepInput], parent: cwl.Workflow, except_in_id: str
+) -> list[cwl_utils.parser.WorkflowInputParameter]:
     """Create InputParameters to match the given WorkflowStep inputs."""
     params = []
     for inp in step_ins:
@@ -1899,7 +2191,7 @@ def workflow_step_to_InputParameters(
         inp_id = inp.id.split("#")[-1].split("/")[-1]
         if inp.source and inp_id != except_in_id:
             param = copy.deepcopy(param_for_source_id(parent, sourcenames=inp.source))
-            if isinstance(param, MutableSequence):
+            if is_sequence(param):
                 for p in param:
                     if not p.type_:
                         raise WorkflowException(
@@ -1931,7 +2223,7 @@ def replace_step_valueFrom_expr_with_etool(
     step: cwl.WorkflowStep,
     step_inp: cwl.WorkflowStepInput,
     original_process: cwl_utils.parser.Process,
-    original_step_ins: list[cwl.WorkflowStepInput],
+    original_step_ins: Sequence[cwl.WorkflowStepInput],
     source: str | list[str] | None,
     replace_etool: bool,
 ) -> None:
@@ -1970,7 +2262,7 @@ def replace_step_valueFrom_expr_with_etool(
         )
     else:
         etool = temp_etool
-    wf_step_inputs = copy.deepcopy(original_step_ins)
+    wf_step_inputs = list(original_step_ins)
     if source:
         wf_step_inputs.append(cwl.WorkflowStepInput(id="self", source=step_inp.source))
     for wf_step_input in wf_step_inputs:
@@ -1978,12 +2270,13 @@ def replace_step_valueFrom_expr_with_etool(
         if wf_step_input.valueFrom:
             wf_step_input.valueFrom = None
         if wf_step_input.source:
-            if isinstance(wf_step_input.source, MutableSequence):
-                for index, inp_source in enumerate(wf_step_input.source):
-                    wf_step_input.source[index] = inp_source.split("#")[-1]
+            if is_sequence(wf_step_input.source):
+                wf_step_input.source = [
+                    inp_source.split("#")[-1] for inp_source in wf_step_input.source
+                ]
             else:
                 wf_step_input.source = wf_step_input.source.split("#")[-1]
-    wf_step_inputs[:] = [
+    wf_step_inputs = [
         x
         for x in wf_step_inputs
         if x.id and not (x.id.startswith("_") or x.id.endswith(step_inp_id))
@@ -1991,15 +2284,15 @@ def replace_step_valueFrom_expr_with_etool(
     scatter = copy.deepcopy(step.scatter)
     if isinstance(scatter, str):
         scatter = [scatter]
-    if isinstance(scatter, MutableSequence):
-        for index, entry in enumerate(scatter):
-            scatter[index] = entry.split("/")[-1]
+    if is_sequence(scatter):
+        scatter = [entry.split("/")[-1] for entry in scatter]
     if scatter and step_inp_id in scatter:
         scatter = ["self"]
     # do we still need to scatter?
     else:
         scatter = None
-    workflow.steps.append(
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=wf_step_inputs,
@@ -2007,8 +2300,8 @@ def replace_step_valueFrom_expr_with_etool(
             run=etool,
             scatter=scatter,
             scatterMethod=step.scatterMethod,
-        )
-    )
+        ),
+    ]
 
 
 def traverse_workflow(
@@ -2016,32 +2309,41 @@ def traverse_workflow(
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> tuple[cwl.Workflow, bool]:
     """Traverse a workflow, processing each step."""
+    processes: list[cwl_utils.parser.Process] = []
     modified = False
     for index, step in enumerate(workflow.steps):
         if isinstance(step.run, cwl.ExpressionTool) and replace_etool:
             workflow.steps[index].run = etool_to_cltool(step.run)
             modified = True
         else:
-            step_modified = cwl_utils.expression_refactor.load_step(
-                step, replace_etool, skip_command_line1, skip_command_line2
+            process, step_modified = cwl_utils.expression_refactor.load_step(
+                step, replace_etool, skip_command_line1, skip_command_line2, context
             )
+            processes.append(process)
             if step_modified:
                 modified = True
-    for step in workflow.steps:
+    for index, step in enumerate(workflow.steps):
         if not step.id.startswith("_expression"):
             step_modified = traverse_step(
-                step, workflow, replace_etool, skip_command_line1, skip_command_line2
+                step,
+                workflow,
+                processes[index],
+                replace_etool,
+                skip_command_line1,
+                skip_command_line2,
+                context,
             )
             if step_modified:
                 modified = True
-    if process_workflow_inputs_and_outputs(workflow, replace_etool):
+    if process_workflow_inputs_and_outputs(workflow, replace_etool, context):
         modified = True
-    if process_workflow_reqs_and_hints(workflow, replace_etool):
+    if process_workflow_reqs_and_hints(workflow, replace_etool, context):
         modified = True
     if workflow.requirements:
-        workflow.requirements[:] = [
+        workflow.requirements = [
             x
             for x in workflow.requirements
             if not isinstance(

--- a/src/cwl_utils/cwl_v1_1_expression_refactor.py
+++ b/src/cwl_utils/cwl_v1_1_expression_refactor.py
@@ -6,15 +6,14 @@
 import copy
 import hashlib
 import uuid
-from collections.abc import MutableSequence, Sequence
-from contextlib import suppress
+from collections.abc import Sequence
 from typing import Any, cast, Final
 
 from ruamel import yaml
 from schema_salad.metaschema import ArraySchema
 from schema_salad.runtime import save, LoadingOptions
 from schema_salad.sourceline import SourceLine
-from schema_salad.utils import json_dumps
+from schema_salad.utils import json_dumps, flatten
 
 import cwl_utils.expression_refactor
 import cwl_utils.parser
@@ -24,14 +23,15 @@ from cwl_utils.errors import JavascriptException, WorkflowException
 from cwl_utils.expression import do_eval, interpolate
 from cwl_utils.parser.utils import param_for_source_id
 from cwl_utils.types import (
-    CWLDirectoryType,
     CWLFileType,
     CWLObjectType,
     CWLOutputType,
     CWLParameterContext,
     CWLRuntimeParameterContext,
     is_file_or_directory,
+    is_sequence,
 )
+from cwl_utils.utils import get_step_uri
 
 _DEFAULT_CWL_VERSION: Final = "v1.1"
 
@@ -64,12 +64,12 @@ def escape_expression_field(contents: str) -> str:
 
 
 def clean_type_ids(
-    cwltype: ArraySchema | cwl.InputRecordSchema,
-) -> ArraySchema | cwl.InputRecordSchema:
+    cwltype: cwl.InputParameterType | cwl.CommandInputParameterType,
+) -> cwl.InputParameterType | cwl.CommandInputParameterType:
     """Simplify type identifiers."""
     result = copy.deepcopy(cwltype)
     if isinstance(result, ArraySchema):
-        if isinstance(result.items, MutableSequence):
+        if is_sequence(result.items):
             for item in result.items:
                 if hasattr(item, "id"):
                     item.id = item.id.split("#")[-1]
@@ -88,6 +88,105 @@ def clean_type_ids(
     return result
 
 
+def clt_input_schema_to_plain_input_schema(
+    input_type: cwl.CommandInputParameterType,
+) -> cwl.InputParameterType:
+    if is_sequence(input_type):
+        return cast(
+            cwl.InputParameterType,
+            flatten(
+                [clt_input_schema_to_plain_input_schema(item) for item in input_type]
+            ),
+        )
+    match input_type:
+        case cwl.CommandInputArraySchema():
+            i1 = copy.deepcopy(input_type)
+            i1.items = clt_input_schema_to_plain_input_schema(
+                cast(cwl.CommandInputParameterType, i1.items)
+            )
+            return cwl.InputArraySchema.fromDoc(
+                i1.save(),
+                i1.loadingOptions.baseuri,
+                i1.loadingOptions,
+            )
+        case cwl.CommandInputEnumSchema():
+            return cwl.InputEnumSchema.fromDoc(
+                input_type.save(),
+                input_type.loadingOptions.baseuri,
+                input_type.loadingOptions,
+            )
+        case cwl.CommandInputRecordSchema():
+            i2 = copy.deepcopy(input_type)
+            if i2.fields is not None:
+                new_fields = []
+                for f in i2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = clt_input_schema_to_plain_input_schema(
+                        cast(cwl.CommandInputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                i2.fields = new_fields
+            return cwl.InputRecordSchema.fromDoc(
+                i2.save(),
+                i2.loadingOptions.baseuri,
+                i2.loadingOptions,
+            )
+        case _:
+            return input_type
+
+
+def clt_output_schema_to_plain_output_schema(
+    output_type: cwl.CommandOutputParameterType,
+) -> cwl.OutputParameterType:
+    if is_sequence(output_type):
+        return cast(
+            cwl.OutputParameterType,
+            flatten(
+                [
+                    clt_output_schema_to_plain_output_schema(
+                        cast(cwl.CommandOutputParameterType, item)
+                    )
+                    for item in output_type
+                ]
+            ),
+        )
+    match output_type:
+        case cwl.CommandOutputArraySchema():
+            o1 = copy.deepcopy(output_type)
+            o1.items = clt_output_schema_to_plain_output_schema(
+                cast(cwl.CommandOutputParameterType, o1.items)
+            )
+            return cwl.OutputArraySchema.fromDoc(
+                o1.save(),
+                o1.loadingOptions.baseuri,
+                o1.loadingOptions,
+            )
+        case cwl.CommandOutputEnumSchema():
+            return cwl.OutputEnumSchema.fromDoc(
+                output_type.save(),
+                output_type.loadingOptions.baseuri,
+                output_type.loadingOptions,
+            )
+        case cwl.CommandOutputRecordSchema():
+            o2 = copy.deepcopy(output_type)
+            if o2.fields is not None:
+                new_fields = []
+                for f in o2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = clt_output_schema_to_plain_output_schema(
+                        cast(cwl.CommandOutputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                o2.fields = new_fields
+            return cwl.OutputRecordSchema.fromDoc(
+                o2.save(),
+                o2.loadingOptions.baseuri,
+                o2.loadingOptions,
+            )
+        case _:
+            return output_type
+
+
 def get_command_input_parameter(id_: str, type_: Any) -> cwl.CommandInputParameter:
     return cwl.CommandInputParameter(id=id_, type_=type_)
 
@@ -99,7 +198,7 @@ def get_command_line_binding(
 
 
 def get_expression(
-    string: str, inputs: CWLObjectType, self: CWLOutputType | None
+    string: Any, inputs: CWLObjectType, self: CWLOutputType | None
 ) -> str | None:
     """
     Find and return a normalized CWL expression, if any.
@@ -160,6 +259,117 @@ def get_inline_javascript_requirement(
     return cwl.InlineJavascriptRequirement(expression_lib)
 
 
+def plain_input_schema_to_clt_input_schema(
+    input_type: cwl.InputParameterType,
+) -> cwl.CommandInputParameterType:
+    if is_sequence(input_type):
+        return cast(
+            cwl.CommandInputParameterType,
+            flatten(
+                [plain_input_schema_to_clt_input_schema(item) for item in input_type]
+            ),
+        )
+    match input_type:
+        case (
+            cwl.CommandInputArraySchema()
+            | cwl.CommandInputEnumSchema()
+            | cwl.CommandInputRecordSchema()
+        ):
+            return input_type
+        case cwl.InputArraySchema():
+            i1 = copy.deepcopy(input_type)
+            i1.items = plain_input_schema_to_clt_input_schema(
+                cast(cwl.InputParameterType, i1.items)
+            )
+            return cwl.CommandInputArraySchema.fromDoc(
+                i1.save(),
+                i1.loadingOptions.baseuri,
+                i1.loadingOptions,
+            )
+        case cwl.InputEnumSchema():
+            return cwl.CommandInputEnumSchema.fromDoc(
+                input_type.save(),
+                input_type.loadingOptions.baseuri,
+                input_type.loadingOptions,
+            )
+        case cwl.InputRecordSchema():
+            i2 = copy.deepcopy(input_type)
+            if i2.fields is not None:
+                new_fields = []
+                for f in i2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = plain_input_schema_to_clt_input_schema(
+                        cast(cwl.InputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                i2.fields = new_fields
+            return cwl.CommandInputRecordSchema.fromDoc(
+                i2.save(),
+                i2.loadingOptions.baseuri,
+                i2.loadingOptions,
+            )
+        case _:
+            return input_type
+
+
+def plain_output_schema_to_clt_output_schema(
+    output_type: cwl.OutputParameterType,
+) -> cwl.CommandOutputParameterType:
+    if is_sequence(output_type):
+        return cast(
+            cwl.CommandOutputParameterType,
+            flatten(
+                [
+                    plain_output_schema_to_clt_output_schema(
+                        cast(cwl.OutputParameterType, item)
+                    )
+                    for item in output_type
+                ]
+            ),
+        )
+    match output_type:
+        case (
+            cwl.CommandOutputArraySchema()
+            | cwl.CommandOutputEnumSchema()
+            | cwl.CommandOutputRecordSchema()
+        ):
+            return output_type
+        case cwl.OutputArraySchema():
+            o1 = copy.deepcopy(output_type)
+            o1.items = plain_output_schema_to_clt_output_schema(
+                cast(cwl.OutputParameterType, o1.items)
+            )
+            return cwl.CommandOutputArraySchema.fromDoc(
+                o1.save(),
+                o1.loadingOptions.baseuri,
+                o1.loadingOptions,
+            )
+        case cwl.OutputEnumSchema():
+            return cwl.CommandOutputEnumSchema.fromDoc(
+                output_type.save(),
+                output_type.loadingOptions.baseuri,
+                output_type.loadingOptions,
+            )
+        case cwl.OutputRecordSchema():
+            o2 = copy.deepcopy(output_type)
+            if o2.fields is not None:
+                new_fields = []
+                for f in o2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = plain_output_schema_to_clt_output_schema(
+                        cast(cwl.OutputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                o2.fields = new_fields
+            return cwl.CommandOutputRecordSchema.fromDoc(
+                o2.save(),
+                o2.loadingOptions.baseuri,
+                o2.loadingOptions,
+            )
+        case _:
+            return output_type
+
+
 def etool_to_cltool(
     etool: cwl.ExpressionTool, expressionLib: list[str] | None = None
 ) -> cwl.CommandLineTool:
@@ -175,7 +385,7 @@ def etool_to_cltool(
                 doc=inp.doc,
                 format=inp.format,
                 default=inp.default,
-                type_=inp.type_,
+                type_=plain_input_schema_to_clt_input_schema(inp.type_),
                 extension_fields=inp.extension_fields,
                 loadingOptions=inp.loadingOptions,
             )
@@ -190,7 +400,7 @@ def etool_to_cltool(
                 streamable=outp.streamable,
                 doc=outp.doc,
                 format=outp.format,
-                type_=outp.type_,
+                type_=plain_output_schema_to_clt_output_schema(outp.type_),
                 extension_fields=outp.extension_fields,
                 loadingOptions=outp.loadingOptions,
             )
@@ -235,8 +445,11 @@ def traverse(
     inside: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]] | None = None,
 ) -> tuple[cwl.CommandLineTool | cwl.ExpressionTool | cwl.Workflow, bool]:
     """Convert the given process and any subprocesses."""
+    if context is None:
+        context = {}
     match process:
         case cwl.CommandLineTool() if not inside:
             process = expand_stream_shortcuts(process)
@@ -300,14 +513,18 @@ def traverse(
                 cwlVersion=process.cwlVersion,
             )
             result, modified = traverse_workflow(
-                workflow, replace_etool, skip_command_line1, skip_command_line2
+                workflow, replace_etool, skip_command_line1, skip_command_line2, context
             )
             if modified:
                 return result, True
             else:
                 return process, False
         case cwl.ExpressionTool() if replace_etool:
-            expression = get_expression(process.expression, empty_inputs(process), None)
+            expression = get_expression(
+                process.expression,
+                cwl_utils.expression_refactor.empty_inputs(process, context),
+                None,
+            )
             # Why call get_expression on an ExpressionTool?
             # It normalizes the form of $() CWL expressions into the ${} style
             if expression:
@@ -318,7 +535,7 @@ def traverse(
             return etool_to_cltool(process2), True
         case cwl.Workflow():
             return traverse_workflow(
-                process, replace_etool, skip_command_line1, skip_command_line2
+                process, replace_etool, skip_command_line1, skip_command_line2, context
             )
         case _:
             return process, False
@@ -331,7 +548,7 @@ def generate_etool_from_expr(
     self_type: None | (
         cwl.WorkflowInputParameter
         | cwl.CommandInputParameter
-        | list[cwl.WorkflowInputParameter | cwl.CommandInputParameter]
+        | Sequence[cwl.WorkflowInputParameter | cwl.CommandInputParameter]
     ) = None,  # if the "self" input should be a different type than the "result" output
     extra_processes: (
         Sequence[cwl_utils.parser.Process | cwl_utils.parser.WorkflowStep] | None
@@ -342,38 +559,33 @@ def generate_etool_from_expr(
     if not no_inputs:
         if not self_type:
             self_type = target
-        if isinstance(self_type, list):
-            new_type: (
-                list[ArraySchema | cwl.InputRecordSchema]
-                | ArraySchema
-                | cwl.InputRecordSchema
-            ) = [clean_type_ids(t.type_) for t in self_type]
+        if is_sequence(self_type):
+            new_type: cwl.InputParameterType | cwl.CommandInputParameterType = cast(
+                cwl.InputParameterType | cwl.CommandInputParameterType,
+                [clean_type_ids(t.type_) for t in self_type if t.type_],
+            )
         else:
             new_type = clean_type_ids(self_type.type_)
         inputs.append(
             cwl.WorkflowInputParameter(
                 id="self",
-                label=self_type.label if not isinstance(self_type, list) else None,
+                label=self_type.label if not is_sequence(self_type) else None,
                 secondaryFiles=(
-                    self_type.secondaryFiles
-                    if not isinstance(self_type, list)
-                    else None
+                    self_type.secondaryFiles if not is_sequence(self_type) else None
                 ),
                 streamable=(
-                    self_type.streamable if not isinstance(self_type, list) else None
+                    self_type.streamable if not is_sequence(self_type) else None
                 ),
-                doc=self_type.doc if not isinstance(self_type, list) else None,
-                format=self_type.format if not isinstance(self_type, list) else None,
-                type_=new_type,
+                doc=self_type.doc if not is_sequence(self_type) else None,
+                format=self_type.format if not is_sequence(self_type) else None,
+                type_=clt_input_schema_to_plain_input_schema(
+                    cast(cwl.CommandInputParameterType, new_type)
+                ),
                 extension_fields=(
-                    self_type.extension_fields
-                    if not isinstance(self_type, list)
-                    else None
+                    self_type.extension_fields if not is_sequence(self_type) else None
                 ),
                 loadingOptions=(
-                    self_type.loadingOptions
-                    if not isinstance(self_type, list)
-                    else None
+                    self_type.loadingOptions if not is_sequence(self_type) else None
                 ),
             )
         )
@@ -385,8 +597,16 @@ def generate_etool_from_expr(
             secondaryFiles=target.secondaryFiles,
             streamable=target.streamable,
             doc=target.doc,
-            format=target.format,
-            type_=target.type_,
+            format=(
+                "\n".join(target.format)
+                if is_sequence(target.format)
+                else target.format
+            ),
+            type_=(
+                clt_output_schema_to_plain_output_schema(
+                    cast(cwl.CommandOutputParameterType, target.type_)
+                )
+            ),
             extension_fields=target.extension_fields,
             loadingOptions=target.loadingOptions,
         )
@@ -421,7 +641,7 @@ def replace_expr_with_etool(
     name: str,
     workflow: cwl.Workflow,
     target: cwl.CommandInputParameter | cwl.WorkflowInputParameter,
-    source: str | list[Any] | None,
+    source: str | Sequence[Any] | None,
     replace_etool: bool = False,
     extra_process: (
         cwl_utils.parser.Process | cwl_utils.parser.WorkflowStep | None
@@ -451,14 +671,15 @@ def replace_expr_with_etool(
     inps = []
     if source:
         inps.append(cwl.WorkflowStepInput(id="self", source=source))
-    workflow.steps.append(
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=inps,
             out=[cwl.WorkflowStepOutput("result")],
             run=final_tool,
-        )
-    )
+        ),
+    ]
 
 
 def replace_wf_input_ref_with_step_output(
@@ -472,89 +693,21 @@ def replace_wf_input_ref_with_step_output(
                     if inp.source:
                         if inp.source == name:
                             inp.source = target
-                        if isinstance(inp.source, MutableSequence):
-                            for index, source in enumerate(inp.source):
-                                if source == name:
-                                    inp.source[index] = target
+                        if is_sequence(inp.source):
+                            inp.source = [
+                                target if isource == name else isource
+                                for isource in inp.source
+                            ]
     if workflow.outputs:
         for outp in workflow.outputs:
             if outp.outputSource:
                 if outp.outputSource == name:
                     outp.outputSource = target
-                if isinstance(outp.outputSource, MutableSequence):
-                    for index, outputSource in enumerate(outp.outputSource):
-                        if outputSource == name:
-                            outp.outputSource[index] = target
-
-
-def empty_inputs(
-    process_or_step: (
-        cwl.CommandLineTool | cwl.WorkflowStep | cwl.ExpressionTool | cwl.Workflow
-    ),
-    parent: cwl.Workflow | None = None,
-) -> dict[str, Any]:
-    """Produce a mock input object for the given inputs."""
-    result = {}
-    if isinstance(process_or_step, cwl.Process):
-        for param in process_or_step.inputs:
-            result[param.id.split("#")[-1]] = example_input(param.type_)
-    else:
-        for param in process_or_step.in_:
-            param_id = param.id.split("/")[-1]
-            if param.source is None and param.valueFrom:
-                result[param_id] = example_input("string")
-            elif param.source is None and param.default:
-                result[param_id] = param.default
-            else:
-                with suppress(WorkflowException):
-                    result[param_id] = example_input(
-                        utils.type_for_source(process_or_step.run, param.source, parent)
-                    )
-    return result
-
-
-def example_input(some_type: Any) -> Any:
-    """Produce a fake input for the given type."""
-    # TODO: accept some sort of context object with local custom type definitions
-    if some_type == "Directory":
-        return CWLDirectoryType(
-            **{
-                "class": "Directory",
-                "location": "https://www.example.com/example",
-                "basename": "example",
-                "listing": [
-                    CWLFileType(
-                        **{
-                            "class": "File",
-                            "basename": "example.txt",
-                            "size": 23,
-                            "contents": "hoopla",
-                            "nameroot": "example",
-                            "nameext": "txt",
-                        }
-                    )
-                ],
-            }
-        )
-    if some_type == "File":
-        return CWLFileType(
-            **{
-                "class": "File",
-                "location": "https://www.example.com/example.txt",
-                "basename": "example.txt",
-                "size": 23,
-                "contents": "hoopla",
-                "nameroot": "example",
-                "nameext": "txt",
-            }
-        )
-    if some_type == "int":
-        return 23
-    if some_type == "string":
-        return "hoopla!"
-    if some_type == "boolean":
-        return True
-    return None
+                if is_sequence(outp.outputSource):
+                    outp.outputSource = [
+                        target if osource == name else osource
+                        for osource in outp.outputSource
+                    ]
 
 
 EMPTY_FILE = CWLFileType(
@@ -592,7 +745,7 @@ def process_CommandLineTool_output(ctool: cwl.CommandLineTool, outp_id: str) -> 
             ):
                 new_outp.type_ = cwl.OutputArraySchema(items="File", type_="array")
             elif isinstance(new_outp, cwl.CommandOutputParameter):
-                if new_outp.outputBinding:
+                if isinstance(new_outp.outputBinding, cwl.CommandOutputBinding):
                     new_outp.outputBinding.outputEval = None
                     new_outp.outputBinding.loadContents = None
                 new_outp.type_ = cwl.CommandOutputArraySchema(
@@ -607,11 +760,13 @@ def process_CommandLineTool_output(ctool: cwl.CommandLineTool, outp_id: str) -> 
 
 
 def process_workflow_inputs_and_outputs(
-    workflow: cwl.Workflow, replace_etool: bool
+    workflow: cwl.Workflow,
+    replace_etool: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Do any needed conversions on the given Workflow's inputs and outputs."""
     modified = False
-    inputs = empty_inputs(workflow)
+    inputs = cwl_utils.expression_refactor.empty_inputs(workflow, context)
     for index, param in enumerate(workflow.inputs):
         with SourceLine(workflow.inputs, index, WorkflowException):
             if param.format and get_expression(param.format, inputs, None):
@@ -629,7 +784,7 @@ def process_workflow_inputs_and_outputs(
                         "secondaryFiles",
                         raise_type=WorkflowException,
                     ).makeError(TOPLEVEL_SF_EXPR_ERROR.format(param.id.split("#")[-1]))
-                elif isinstance(param.secondaryFiles, MutableSequence):
+                elif is_sequence(param.secondaryFiles):
                     for index2, entry in enumerate(param.secondaryFiles):
                         if get_expression(entry.pattern, inputs, EMPTY_FILE):
                             raise SourceLine(
@@ -644,7 +799,9 @@ def process_workflow_inputs_and_outputs(
 
 
 def process_workflow_reqs_and_hints(
-    workflow: cwl.Workflow, replace_etool: bool
+    workflow: cwl.Workflow,
+    replace_etool: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """
     Convert any expressions in a workflow's reqs and hints.
@@ -659,7 +816,7 @@ def process_workflow_reqs_and_hints(
     #       ^ By refactoring replace_expr_etool to allow multiple inputs,
     #         and connecting all workflow inputs to the generated step
     modified = False
-    inputs = empty_inputs(workflow)
+    inputs = cwl_utils.expression_refactor.empty_inputs(workflow, context)
     generated_res_reqs: list[tuple[str, int | str]] = []
     generated_iwdr_reqs: list[tuple[str, int | str]] = []
     generated_envVar_reqs: list[tuple[str, int | str]] = []
@@ -678,13 +835,14 @@ def process_workflow_reqs_and_hints(
         for req in cast(list[cwl.ProcessRequirement], workflow.requirements):
             match req:
                 case cwl.EnvVarRequirement() if req.envDef:
+                    env_defs = list(req.envDef)
                     for index, envDef in enumerate(req.envDef):
                         if envDef.envValue:
                             expression = get_expression(envDef.envValue, inputs, None)
                             if expression:
                                 modified = True
                                 target = cwl.WorkflowInputParameter(
-                                    id=None,
+                                    id="",
                                     type_="string",
                                 )
                                 etool_id = (
@@ -705,8 +863,9 @@ def process_workflow_reqs_and_hints(
                                     prop_reqs += (cwl.EnvVarRequirement,)
                                 newEnvDef = copy.deepcopy(envDef)
                                 newEnvDef.envValue = f"$(inputs._envDef{index})"
-                                envVarReq.envDef[index] = newEnvDef
+                                env_defs[index] = newEnvDef
                                 generated_envVar_reqs.append((etool_id, index))
+                    req.envDef = env_defs
                 case cwl.ResourceRequirement():
                     for attr in cwl.ResourceRequirement.attrs:
                         this_attr = getattr(req, attr, None)
@@ -714,9 +873,7 @@ def process_workflow_reqs_and_hints(
                             expression = get_expression(this_attr, inputs, None)
                             if expression:
                                 modified = True
-                                target = cwl.WorkflowInputParameter(
-                                    id=None, type_="long"
-                                )
+                                target = cwl.WorkflowInputParameter(id="", type_="long")
                                 etool_id = "_expression_workflow_ResourceRequirement_{}".format(
                                     attr
                                 )
@@ -741,7 +898,7 @@ def process_workflow_reqs_and_hints(
                         if expression:
                             modified = True
                             target = cwl.WorkflowInputParameter(
-                                id=None,
+                                id="",
                                 type_=cwl.InputArraySchema(
                                     ["File", "Directory"], "array", None, None
                                 ),
@@ -762,12 +919,13 @@ def process_workflow_reqs_and_hints(
                             prop_reqs += (cwl.InitialWorkDirRequirement,)
                     else:
                         iwdr = copy.deepcopy(req)
+                        new_listing = list(iwdr.listing)
                         for index, entry in enumerate(req.listing):
                             expression = get_expression(entry, inputs, None)
                             if expression:
                                 modified = True
                                 target = cwl.WorkflowInputParameter(
-                                    id=None,
+                                    id="",
                                     type_=cwl.InputArraySchema(
                                         ["File", "Directory"], "array", None, None
                                     ),
@@ -783,7 +941,7 @@ def process_workflow_reqs_and_hints(
                                     None,
                                     replace_etool,
                                 )
-                                iwdr.listing[index] = f"$(inputs._iwdr_listing_{index}"
+                                new_listing[index] = f"$(inputs._iwdr_listing_{index}"
                                 generated_iwdr_reqs.append((etool_id, index))
                             elif isinstance(entry, cwl.Dirent):
                                 if entry.entry:
@@ -803,7 +961,7 @@ def process_workflow_reqs_and_hints(
                                         modified = True
                                         if is_file_or_directory(expr_result):
                                             target = cwl.WorkflowInputParameter(
-                                                id=None,
+                                                id="",
                                                 type_=expr_result["class"],
                                             )
                                             replace_expr_with_etool(
@@ -814,7 +972,7 @@ def process_workflow_reqs_and_hints(
                                                 None,
                                                 replace_etool,
                                             )
-                                            iwdr.listing[index] = (
+                                            new_listing[index] = (
                                                 "$(inputs._iwdr_listing_{}".format(
                                                     index
                                                 )
@@ -824,7 +982,7 @@ def process_workflow_reqs_and_hints(
                                             )
                                         elif isinstance(expr_result, str):
                                             target = cwl.WorkflowInputParameter(
-                                                id=None,
+                                                id="",
                                                 type_=["File"],
                                             )
                                             if entry.entryname is None:
@@ -855,7 +1013,7 @@ def process_workflow_reqs_and_hints(
                                             None,
                                             replace_etool,
                                         )
-                                        iwdr.listing[index] = (
+                                        new_listing[index] = (
                                             f"$(inputs._iwdr_listing_{index}"
                                         )
                                         generated_iwdr_reqs.append((etool_id, index))
@@ -867,7 +1025,7 @@ def process_workflow_reqs_and_hints(
                                     if expression:
                                         modified = True
                                         target = cwl.WorkflowInputParameter(
-                                            id=None,
+                                            id="",
                                             type_="string",
                                         )
                                         etool_id = "_expression_workflow_InitialWorkDirRequirement_{}".format(
@@ -881,16 +1039,19 @@ def process_workflow_reqs_and_hints(
                                             None,
                                             replace_etool,
                                         )
-                                        iwdr.listing[index] = (
+                                        new_listing[index] = (
                                             f"$(inputs._iwdr_listing_{index}"
                                         )
                                         generated_iwdr_reqs.append((etool_id, index))
+                        iwdr.listing = new_listing
                         if generated_iwdr_reqs:
                             prop_reqs += (cwl.InitialWorkDirRequirement,)
                         else:
                             iwdr = None
+    step_inputs: list[list[cwl.WorkflowStepInput]] = [[] * len(workflow.steps)]
+    step_requirements: list[list[cwl.ProcessRequirement]] = [[] * len(workflow.steps)]
     if envVarReq and workflow.steps:
-        for step in workflow.steps:
+        for index, step in enumerate(workflow.steps):
             if step.id.split("#")[-1].startswith("_expression_"):
                 continue
             if step.requirements:
@@ -899,17 +1060,17 @@ def process_workflow_reqs_and_hints(
                         continue
             else:
                 step.requirements = yaml.comments.CommentedSeq()
-            step.requirements.append(envVarReq)
-            for entry in generated_envVar_reqs:
-                step.in_.append(
+            step_requirements[index].append(envVarReq)
+            for entry2 in generated_envVar_reqs:
+                step_inputs[index].append(
                     cwl.WorkflowStepInput(
-                        id=f"_envDef{entry[1]}",
-                        source=f"{entry[0]}/result",
+                        id=f"_envDef{entry2[1]}",
+                        source=f"{entry2[0]}/result",
                     )
                 )
 
     if resourceReq and workflow.steps:
-        for step in workflow.steps:
+        for index, step in enumerate(workflow.steps):
             if step.id.split("#")[-1].startswith("_expression_"):
                 continue
             if step.requirements:
@@ -918,17 +1079,17 @@ def process_workflow_reqs_and_hints(
                         continue
             else:
                 step.requirements = yaml.comments.CommentedSeq()
-            step.requirements.append(resourceReq)
-            for entry in generated_res_reqs:
-                step.in_.append(
+            step_requirements[index].append(resourceReq)
+            for entry3 in generated_res_reqs:
+                step_inputs[index].append(
                     cwl.WorkflowStepInput(
-                        id=f"_{entry[1]}",
-                        source=f"{entry[0]}/result",
+                        id=f"_{entry3[1]}",
+                        source=f"{entry3[0]}/result",
                     )
                 )
 
     if iwdr and workflow.steps:
-        for step in workflow.steps:
+        for index, step in enumerate(workflow.steps):
             if step.id.split("#")[-1].startswith("_expression_"):
                 continue
             if step.requirements:
@@ -937,37 +1098,49 @@ def process_workflow_reqs_and_hints(
                         continue
             else:
                 step.requirements = yaml.comments.CommentedSeq()
-            step.requirements.append(iwdr)
+            step_requirements[index].append(iwdr)
             if generated_iwdr_reqs:
-                for entry in generated_iwdr_reqs:
-                    step.in_.append(
+                for entry4 in generated_iwdr_reqs:
+                    step_inputs[index].append(
                         cwl.WorkflowStepInput(
                             id=f"_iwdr_listing_{index}",
-                            source=f"{entry[0]}/result",
+                            source=f"{entry4[0]}/result",
                         )
                     )
             else:
-                step.in_.append(
+                step_inputs[index].append(
                     cwl.WorkflowStepInput(
                         id="_iwdr_listing",
                         source="_expression_workflow_InitialWorkDirRequirement/result",
                     )
                 )
+    for step, step_ins, step_reqs in zip(
+        workflow.steps, step_inputs, step_requirements
+    ):
+        if step_ins:
+            step.in_ = [*step.in_, *step_ins]
+        if step_reqs:
+            step.requirements = [
+                *cast(Sequence[cwl.ProcessRequirement], step.requirements),
+                *step_reqs,
+            ]
 
     if workflow.requirements:
-        workflow.requirements[:] = [
+        workflow.requirements = [
             x for x in workflow.requirements if not isinstance(x, prop_reqs)
         ]
     return modified
 
 
 def process_level_reqs(
-    process: cwl.CommandLineTool,
+    process: cwl_utils.parser.Process,
     step: cwl.WorkflowStep,
+    target_process: cwl_utils.parser.Process,
     parent: cwl.Workflow,
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Convert expressions inside a process into new adjacent steps."""
     # This is for reqs inside a Process (CommandLineTool, ExpressionTool)
@@ -982,7 +1155,6 @@ def process_level_reqs(
     if not process.requirements:
         return False
     modified = False
-    target_process = step.run
     inputs = cwl_utils.expression_refactor.empty_inputs(process, "v1.1")
     generated_res_reqs: list[tuple[str, str]] = []
     generated_iwdr_reqs: list[tuple[str, int | str, Any]] = []
@@ -990,14 +1162,14 @@ def process_level_reqs(
     if not step.id:
         return False
     step_name = step.id.split("#", 1)[-1]
-    for req_index, req in enumerate(process.requirements):
+    for req in process.requirements:
         if isinstance(req, cwl_utils.parser.EnvVarRequirement) and req.envDef:
             for env_index, envDef in enumerate(req.envDef):
                 if envDef.envValue:
                     expression = get_expression(envDef.envValue, inputs, None)
                     if expression:
                         modified = True
-                        target = cwl.WorkflowInputParameter(id=None, type_="string")
+                        target = cwl.WorkflowInputParameter(id="", type_="string")
                         etool_id = "_expression_{}_EnvVarRequirement_{}".format(
                             step_name, env_index
                         )
@@ -1010,9 +1182,7 @@ def process_level_reqs(
                             replace_etool,
                             process,
                         )
-                        target_process.requirements[req_index][
-                            env_index
-                        ].envValue = f"$(inputs._envDef{env_index})"
+                        envDef.envValue = f"$(inputs._envDef{env_index})"
                         generated_envVar_reqs.append((etool_id, env_index))
         elif isinstance(req, cwl_utils.parser.ResourceRequirement):
             for attr in cwl.ResourceRequirement.attrs:
@@ -1021,7 +1191,7 @@ def process_level_reqs(
                     expression = get_expression(this_attr, inputs, None)
                     if expression:
                         modified = True
-                        target = cwl.WorkflowInputParameter(id=None, type_="long")
+                        target = cwl.WorkflowInputParameter(id="", type_="long")
                         etool_id = "_expression_{}_ResourceRequirement_{}".format(
                             step_name, attr
                         )
@@ -1031,10 +1201,11 @@ def process_level_reqs(
                             parent,
                             target,
                             step,
+                            target_process,
                             replace_etool,
                         )
                         setattr(
-                            target_process.requirements[req_index],
+                            req,
                             attr,
                             f"$(inputs._{attr})",
                         )
@@ -1052,7 +1223,7 @@ def process_level_reqs(
                     target_type = cwl.InputArraySchema(
                         ["File", "Directory"], "array", None, None
                     )
-                    target = cwl.WorkflowInputParameter(id=None, type_=target_type)
+                    target = cwl.WorkflowInputParameter(id="", type_=target_type)
                     etool_id = "_expression_{}_InitialWorkDirRequirement".format(
                         step_name
                     )
@@ -1065,15 +1236,14 @@ def process_level_reqs(
                         replace_etool,
                         process,
                     )
-                    target_process.requirements[req_index].listing = (
-                        "$(inputs._iwdr_listing)",
-                    )
-                    step.in_.append(
+                    req.listing = ("$(inputs._iwdr_listing)",)
+                    step.in_ = [
+                        *step.in_,
                         cwl.WorkflowStepInput(
                             id="_iwdr_listing",
                             source=f"{etool_id}/result",
-                        )
-                    )
+                        ),
+                    ]
                     cwl_utils.expression_refactor.add_input_to_process(
                         target_process,
                         "v1.1",
@@ -1090,7 +1260,7 @@ def process_level_reqs(
                             ["File", "Directory"], "array", None, None
                         )
                         target = cwl.WorkflowInputParameter(
-                            id=None,
+                            id="",
                             type_=target_type,
                         )
                         etool_id = "_expression_{}_InitialWorkDirRequirement_{}".format(
@@ -1105,9 +1275,9 @@ def process_level_reqs(
                             replace_etool,
                             process,
                         )
-                        target_process.requirements[req_index].listing[
-                            listing_index
-                        ] = f"$(inputs._iwdr_listing_{listing_index}"
+                        req.listing[listing_index] = (
+                            f"$(inputs._iwdr_listing_{listing_index}"
+                        )
                         generated_iwdr_reqs.append(
                             (etool_id, listing_index, target_type)
                         )
@@ -1145,7 +1315,7 @@ return result; }"""
                                     new_expression = expression
                                 d_target_type = ["File", "Directory"]
                                 target = cwl.WorkflowInputParameter(
-                                    id=None,
+                                    id="",
                                     type_=d_target_type,
                                 )
                                 etool_id = "_expression_{}_InitialWorkDirRequirement_{}".format(
@@ -1158,11 +1328,10 @@ return result; }"""
                                     parent,
                                     target,
                                     step,
+                                    step.run,
                                     replace_etool,
                                 )
-                                target_process.requirements[req_index].listing[
-                                    listing_index
-                                ].entry = "$(inputs._iwdr_listing_{})".format(
+                                entry.entry = "$(inputs._iwdr_listing_{})".format(
                                     listing_index
                                 )
                                 generated_iwdr_reqs.append(
@@ -1173,7 +1342,7 @@ return result; }"""
                             if expression:
                                 modified = True
                                 target = cwl.WorkflowInputParameter(
-                                    id=None,
+                                    id="",
                                     type_="string",
                                 )
                                 etool_id = "_expression_{}_InitialWorkDirRequirement_{}".format(
@@ -1188,32 +1357,36 @@ return result; }"""
                                     replace_etool,
                                     process,
                                 )
-                                target_process.requirements[req_index].listing[
-                                    listing_index
-                                ].entryname = "$(inputs._iwdr_listing_{})".format(
+                                entry.entryname = "$(inputs._iwdr_listing_{})".format(
                                     listing_index
                                 )
                                 generated_iwdr_reqs.append(
                                     (etool_id, listing_index, "string")
                                 )
-    for entry in generated_envVar_reqs:
-        name = f"_envDef{entry[1]}"
-        step.in_.append(cwl.WorkflowStepInput(id=name, source=f"{entry[0]}/result"))
+    step_inputs = []
+    for entry2 in generated_envVar_reqs:
+        name = f"_envDef{entry2[1]}"
+        step_inputs.append(cwl.WorkflowStepInput(id=name, source=f"{entry2[0]}/result"))
         cwl_utils.expression_refactor.add_input_to_process(
             target_process, _DEFAULT_CWL_VERSION, name, "string", process.loadingOptions
         )
-    for entry in generated_res_reqs:
-        name = f"_{entry[1]}"
-        step.in_.append(cwl.WorkflowStepInput(id=name, source=f"{entry[0]}/result"))
+    for entry3 in generated_res_reqs:
+        name = f"_{entry3[1]}"
+        step_inputs.append(cwl.WorkflowStepInput(id=name, source=f"{entry3[0]}/result"))
         cwl_utils.expression_refactor.add_input_to_process(
             target_process, _DEFAULT_CWL_VERSION, name, "long", process.loadingOptions
         )
-    for entry in generated_iwdr_reqs:
-        name = f"_iwdr_listing_{entry[1]}"
-        step.in_.append(cwl.WorkflowStepInput(id=name, source=f"{entry[0]}/result"))
+    for entry4 in generated_iwdr_reqs:
+        name = f"_iwdr_listing_{entry4[1]}"
+        step_inputs.append(cwl.WorkflowStepInput(id=name, source=f"{entry4[0]}/result"))
         cwl_utils.expression_refactor.add_input_to_process(
-            target_process, _DEFAULT_CWL_VERSION, name, entry[2], process.loadingOptions
+            target_process,
+            _DEFAULT_CWL_VERSION,
+            name,
+            entry4[2],
+            process.loadingOptions,
         )
+    step.in_ = [*step.in_, *step_inputs]
     return modified
 
 
@@ -1235,19 +1408,21 @@ def traverse_CommandLineTool(
     clt: cwl_utils.parser.CommandLineTool,
     parent: cwl.Workflow,
     step: cwl.WorkflowStep,
+    target_clt: cwl_utils.parser.CommandLineTool,
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Extract any CWL Expressions within the given CommandLineTool into sibling steps."""
     modified = False
-    # don't modify clt, modify step.run
-    target_clt = step.run
     inputs = cwl_utils.expression_refactor.empty_inputs(clt, _DEFAULT_CWL_VERSION)
     if not step.id:
         return False
     step_id = step.id.split("#")[-1]
+    clt_inputs, step_inputs = [], []
     if clt.arguments and not skip_command_line1:
+        arguments = list(clt.arguments)
         for index, arg in enumerate(clt.arguments):
             if isinstance(arg, str):
                 expression = get_expression(arg, inputs, None)
@@ -1256,58 +1431,71 @@ def traverse_CommandLineTool(
                     inp_id = f"_arguments_{index}"
                     etool_id = f"_expression_{step_id}{inp_id}"
                     target_type = "Any"
-                    target = cwl.WorkflowInputParameter(id=None, type_=target_type)
+                    target = cwl.WorkflowInputParameter(id="", type_=target_type)
                     replace_step_clt_expr_with_etool(
-                        expression, etool_id, parent, target, step, replace_etool
+                        expression,
+                        etool_id,
+                        parent,
+                        target,
+                        step,
+                        target_clt,
+                        replace_etool,
+                        context,
                     )
-                    target_clt.arguments[index] = (
+                    arguments[index] = (
                         cwl_utils.expression_refactor.get_command_line_binding(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             valueFrom=f"$(inputs.{inp_id})",
                         )
                     )
-                    target_clt.inputs.append(
+                    clt_inputs.append(
                         cwl_utils.expression_refactor.get_command_input_parameter(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             inp_id,
                             target_type,
                         )
                     )
-                    step.in_.append(
-                        cwl.WorkflowStepInput(
-                            f"{etool_id}/result", None, inp_id, None, None
-                        )
+                    step_inputs.append(
+                        cwl.WorkflowStepInput(id=f"{etool_id}/result", source=inp_id)
                     )
                     cwl_utils.expression_refactor.remove_JSReq(
                         target_clt, skip_command_line1
                     )
-            elif isinstance(arg, cwl.CommandLineBinding) and arg.valueFrom:
+            elif isinstance(arg, cwl_utils.parser.CommandLineBinding) and arg.valueFrom:
                 expression = get_expression(arg.valueFrom, inputs, None)
                 if expression:
                     modified = True
                     inp_id = f"_arguments_{index}"
                     etool_id = f"_expression_{step_id}{inp_id}"
                     target_type = "Any"
-                    target = cwl.WorkflowInputParameter(id=None, type_=target_type)
+                    target = cwl.WorkflowInputParameter(id="", type_=target_type)
                     replace_step_clt_expr_with_etool(
-                        expression, etool_id, parent, target, step, replace_etool
+                        expression,
+                        etool_id,
+                        parent,
+                        target,
+                        step,
+                        target_clt,
+                        replace_etool,
+                        context,
                     )
-                    target_clt.arguments[index].valueFrom = "$(inputs.{})".format(
-                        inp_id
-                    )
-                    target_clt.inputs.append(
+                    cast(
+                        cwl_utils.parser.CommandLineBinding, arguments[index]
+                    ).valueFrom = "$(inputs.{})".format(inp_id)
+                    clt_inputs.append(
                         cwl_utils.expression_refactor.get_command_input_parameter(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             inp_id,
                             target_type,
                         )
                     )
-                    step.in_.append(
-                        cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
+                    step_inputs.append(
+                        cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result"),
                     )
                     cwl_utils.expression_refactor.remove_JSReq(
                         target_clt, skip_command_line1
                     )
+        target_clt.arguments = arguments
     for streamtype in "stdout", "stderr":  # add 'stdin' for v1.1 version
         stream_value = getattr(clt, streamtype)
         if stream_value:
@@ -1317,25 +1505,34 @@ def traverse_CommandLineTool(
                 inp_id = f"_{streamtype}"
                 etool_id = f"_expression_{step_id}{inp_id}"
                 target_type = "string"
-                target = cwl.WorkflowInputParameter(id=None, type_=target_type)
+                target = cwl.WorkflowInputParameter(id="", type_=target_type)
                 replace_step_clt_expr_with_etool(
-                    expression, etool_id, parent, target, step, replace_etool
+                    expression,
+                    etool_id,
+                    parent,
+                    target,
+                    step,
+                    target_clt,
+                    replace_etool,
+                    context,
                 )
                 setattr(target_clt, streamtype, f"$(inputs.{inp_id})")
-                target_clt.inputs.append(
+                clt_inputs.append(
                     cwl_utils.expression_refactor.get_command_input_parameter(
                         target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                         inp_id,
                         target_type,
                     )
                 )
-                step.in_.append(
+                step_inputs.append(
                     cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
                 )
     for inp in clt.inputs:
         if not skip_command_line1 and inp.inputBinding and inp.inputBinding.valueFrom:
             expression = get_expression(
-                inp.inputBinding.valueFrom, inputs, example_input(inp.type_)
+                inp.inputBinding.valueFrom,
+                inputs,
+                cwl_utils.expression_refactor.example_input(inp.type_),
             )
             if expression:
                 modified = True
@@ -1343,17 +1540,27 @@ def traverse_CommandLineTool(
                 inp_id = f"_{self_id}_valueFrom"
                 etool_id = f"_expression_{step_id}{inp_id}"
                 replace_step_clt_expr_with_etool(
-                    expression, etool_id, parent, inp, step, replace_etool, self_id
+                    expression,
+                    etool_id,
+                    parent,
+                    inp,
+                    step,
+                    target_clt,
+                    replace_etool,
+                    context,
+                    self_id,
                 )
                 inp.inputBinding.valueFrom = f"$(inputs.{inp_id})"
-                target_clt.inputs.append(
+                clt_inputs.append(
                     cwl_utils.expression_refactor.get_command_input_parameter(
                         target_clt.cwlVersion or _DEFAULT_CWL_VERSION, inp_id, inp.type_
                     )
                 )
-                step.in_.append(
+                step_inputs.append(
                     cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
                 )
+    target_clt.inputs = [*target_clt.inputs, *clt_inputs]
+    step.in_ = [*step.in_, *step_inputs]
     for outp in clt.outputs:
         if outp.outputBinding:
             if outp.outputBinding.glob:
@@ -1362,20 +1569,30 @@ def traverse_CommandLineTool(
                     modified = True
                     inp_id = "_{}_glob".format(outp.id.split("#")[-1])
                     etool_id = f"_expression_{step_id}{inp_id}"
-                    glob_target_type = ["string", ArraySchema("string", "array")]
-                    target = cwl.WorkflowInputParameter(id=None, type_=glob_target_type)
+                    glob_target_type: list[str | cwl.InputArraySchema] = [
+                        "string",
+                        cwl.InputArraySchema(items="string", type_="array"),
+                    ]
+                    target = cwl.WorkflowInputParameter(id="", type_=glob_target_type)
                     replace_step_clt_expr_with_etool(
-                        expression, etool_id, parent, target, step, replace_etool
+                        expression,
+                        etool_id,
+                        parent,
+                        target,
+                        step,
+                        target_clt,
+                        replace_etool,
+                        context,
                     )
                     outp.outputBinding.glob = f"$(inputs.{inp_id})"
-                    target_clt.inputs.append(
+                    clt_inputs.append(
                         cwl_utils.expression_refactor.get_command_input_parameter(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             inp_id,
                             glob_target_type,
                         )
                     )
-                    step.in_.append(
+                    step_inputs.append(
                         cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
                     )
             if outp.outputBinding.outputEval and not skip_command_line2:
@@ -1398,27 +1615,28 @@ def traverse_CommandLineTool(
                     inp_id = f"_{outp_id}_outputEval"
                     etool_id = f"expression{inp_id}"
                     sub_wf_outputs = cltool_step_outputs_to_workflow_outputs(
-                        step, etool_id, outp_id
+                        step, target_clt, etool_id, outp_id
                     )
                     self_type = cwl.WorkflowInputParameter(
-                        id=None,
+                        id="",
                         type_=cwl.InputArraySchema("File", "array", None, None),
                     )
                     etool = generate_etool_from_expr(
                         expression, outp, False, self_type, [clt, step, parent]
                     )
                     if outp.outputBinding.loadContents:
-                        etool.inputs[0].type_.inputBinding = (
+                        etool.inputs[0].inputBinding = (
                             cwl_utils.expression_refactor.get_command_line_binding(
                                 etool.cwlVersion or _DEFAULT_CWL_VERSION,
                                 loadContents=True,
                             )
                         )
-                    etool.inputs.extend(
-                        cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
+                    etool.inputs = [
+                        *etool.inputs,
+                        *cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
                             clt, _DEFAULT_CWL_VERSION
-                        )
-                    )
+                        ),
+                    ]
                     sub_wf_inputs = (
                         cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
                             clt, _DEFAULT_CWL_VERSION
@@ -1427,19 +1645,21 @@ def traverse_CommandLineTool(
                     orig_step_inputs = copy.deepcopy(step.in_)
                     for orig_step_input in orig_step_inputs:
                         orig_step_input.id = orig_step_input.id.split("/")[-1]
-                        if isinstance(orig_step_input.source, MutableSequence):
-                            for index, source in enumerate(orig_step_input.source):
-                                orig_step_input.source[index] = source.split("#")[-1]
+                        if is_sequence(orig_step_input.source):
+                            orig_step_input.source = [
+                                source.split("#")[-1]
+                                for source in orig_step_input.source
+                            ]
                         else:
                             orig_step_input.source = orig_step_input.source.split("#")[
                                 -1
                             ]
-                    orig_step_inputs[:] = [
+                    orig_step_inputs = [
                         x for x in orig_step_inputs if not x.id.startswith("_")
                     ]
-                    for inp in orig_step_inputs:
-                        inp.source = inp.id
-                        inp.linkMerge = None
+                    for inp2 in orig_step_inputs:
+                        inp2.source = inp2.id
+                        inp2.linkMerge = None
                     final_etool: (
                         cwl_utils.parser.CommandLineTool
                         | cwl_utils.parser.ExpressionTool
@@ -1463,25 +1683,25 @@ def traverse_CommandLineTool(
                         step
                     )  # a deepcopy would be convenient, but params2.cwl gives it problems
                     new_clt_step.id = new_clt_step.id.split("#")[-1]
-                    new_clt_step.run = copy.copy(step.run)
-                    new_clt_step.run.id = None
+                    new_clt = copy.copy(target_clt)
+                    new_clt.id = ""
                     cwl_utils.expression_refactor.remove_JSReq(
-                        new_clt_step.run, skip_command_line1
+                        new_clt, skip_command_line1
                     )
                     cwl_utils.expression_refactor.process_CommandLineTool_output(
-                        new_clt_step.run, _DEFAULT_CWL_VERSION, outp_id
+                        new_clt, _DEFAULT_CWL_VERSION, outp_id
                     )
                     new_clt_step.in_ = copy.deepcopy(step.in_)
-                    for inp in new_clt_step.in_:
-                        inp.id = inp.id.split("/")[-1]
-                        inp.source = inp.id
-                        inp.linkMerge = None
-                    for index, out in enumerate(new_clt_step.out):
-                        new_clt_step.out[index] = out.split("/")[-1]
-                    for tool_inp in new_clt_step.run.inputs:
+                    for inp3 in new_clt_step.in_:
+                        inp3.id = inp3.id.split("/")[-1]
+                        inp3.source = inp3.id
+                        inp3.linkMerge = None
+                    new_clt_step.out = [out.split("/")[-1] for out in new_clt_step.out]
+                    for tool_inp in new_clt.inputs:
                         tool_inp.id = tool_inp.id.split("#")[-1]
-                    for tool_out in new_clt_step.run.outputs:
+                    for tool_out in new_clt.outputs:
                         tool_out.id = tool_out.id.split("#")[-1]
+                    new_clt_step.run = new_clt
                     sub_wf_steps = [new_clt_step, etool_step]
                     sub_workflow = cwl.Workflow(
                         inputs=sub_wf_inputs,
@@ -1508,9 +1728,10 @@ def traverse_CommandLineTool(
                             if isinstance(req, cwl.SubworkflowFeatureRequirement):
                                 has_sub_wf_req = True
                         if not has_sub_wf_req:
-                            parent.requirements.append(
-                                cwl.SubworkflowFeatureRequirement()
-                            )
+                            parent.requirements = [
+                                *parent.requirements,
+                                cwl.SubworkflowFeatureRequirement(),
+                            ]
     return modified
 
 
@@ -1539,9 +1760,10 @@ def rename_step_source(workflow: cwl.Workflow, old: str, new: str) -> None:
                         if source_id == old:
                             inp.source = new
                     else:
-                        for index, source in enumerate(inp.source):
-                            if simplify_step_id(source) == old:
-                                inp.source[index] = new
+                        inp.source = [
+                            new if simplify_step_id(source) == old else source
+                            for source in inp.source
+                        ]
 
 
 def replace_step_clt_expr_with_etool(
@@ -1550,12 +1772,14 @@ def replace_step_clt_expr_with_etool(
     workflow: cwl.Workflow,
     target: cwl.WorkflowInputParameter,
     step: cwl.WorkflowStep,
+    clt: cwl_utils.parser.CommandLineTool,
     replace_etool: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
     self_name: str | None = None,
 ) -> None:
     """Convert a step level CWL Expression to a sibling expression step."""
     etool_inputs = cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
-        step.run, _DEFAULT_CWL_VERSION
+        clt, _DEFAULT_CWL_VERSION
     )
     temp_etool = cwl_utils.expression_refactor.generate_etool_from_expr2(
         expr,
@@ -1563,7 +1787,7 @@ def replace_step_clt_expr_with_etool(
         target,
         etool_inputs,
         self_name,
-        step.run,
+        clt,
         [workflow],
     )
     etool: cwl_utils.parser.CommandLineTool | cwl_utils.parser.ExpressionTool
@@ -1579,15 +1803,21 @@ def replace_step_clt_expr_with_etool(
     wf_step_inputs = copy.deepcopy(step.in_)
     for wf_step_input in wf_step_inputs:
         wf_step_input.id = wf_step_input.id.split("/")[-1]
-    wf_step_inputs[:] = [x for x in wf_step_inputs if not x.id.startswith("_")]
-    workflow.steps.append(
+    wf_step_inputs = [x for x in wf_step_inputs if not x.id.startswith("_")]
+    if isinstance(step.run, str):
+        context[get_step_uri(step)] = (etool, True)
+        step_run: str | cwl.Process = step.run
+    else:
+        step_run = cast(cwl.Process, etool)
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=wf_step_inputs,
             out=[cwl.WorkflowStepOutput("result")],
-            run=etool,
-        )
-    )
+            run=step_run,
+        ),
+    ]
 
 
 def replace_clt_hintreq_expr_with_etool(
@@ -1596,21 +1826,25 @@ def replace_clt_hintreq_expr_with_etool(
     workflow: cwl.Workflow,
     target: cwl.WorkflowInputParameter,
     step: cwl.WorkflowStep,
+    process: cwl_utils.parser.Process,
     replace_etool: bool,
     self_name: str | None = None,
 ) -> None:
     """Factor out an expression inside a CommandLineTool req or hint into a sibling step."""
     # Same as replace_step_clt_expr_with_etool or different?
-    etool_inputs = cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
-        step.run, _DEFAULT_CWL_VERSION
-    )
+    if isinstance(process, cwl_utils.parser.CommandLineTool):
+        etool_inputs = cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
+            process, _DEFAULT_CWL_VERSION
+        )
+    else:
+        etool_inputs = copy.deepcopy(process.inputs)
     temp_etool = cwl_utils.expression_refactor.generate_etool_from_expr2(
         expr,
         _DEFAULT_CWL_VERSION,
         target,
         etool_inputs,
         self_name,
-        step.run,
+        process,
         [workflow],
     )
     etool: cwl_utils.parser.CommandLineTool | cwl_utils.parser.ExpressionTool
@@ -1626,22 +1860,23 @@ def replace_clt_hintreq_expr_with_etool(
     wf_step_inputs = copy.deepcopy(step.in_)
     for wf_step_input in wf_step_inputs:
         wf_step_input.id = wf_step_input.id.split("/")[-1]
-    wf_step_inputs[:] = [x for x in wf_step_inputs if not x.id.startswith("_")]
-    workflow.steps.append(
+    wf_step_inputs = [x for x in wf_step_inputs if not x.id.startswith("_")]
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=wf_step_inputs,
             out=[cwl.WorkflowStepOutput("result")],
             run=etool,
-        )
-    )
+        ),
+    ]
 
 
 def cltool_inputs_to_etool_inputs(
     tool: cwl.CommandLineTool,
 ) -> list[cwl.WorkflowInputParameter]:
     """Copy CommandLineTool input objects into the equivalent ExpressionTool input objects."""
-    inputs = yaml.comments.CommentedSeq()
+    inputs: list[cwl.WorkflowInputParameter] = []
     if tool.inputs:
         for clt_inp in tool.inputs:
             clt_inp_id = clt_inp.id.split("#")[-1].split("/")[-1]
@@ -1655,7 +1890,7 @@ def cltool_inputs_to_etool_inputs(
                         doc=clt_inp.doc,
                         format=clt_inp.format,
                         default=clt_inp.default,
-                        type_=clt_inp.type_,
+                        type_=clt_input_schema_to_plain_input_schema(clt_inp.type_),
                         extension_fields=clt_inp.extension_fields,
                         loadingOptions=clt_inp.loadingOptions,
                     )
@@ -1664,7 +1899,10 @@ def cltool_inputs_to_etool_inputs(
 
 
 def cltool_step_outputs_to_workflow_outputs(
-    cltool_step: cwl.WorkflowStep, etool_step_id: str, etool_out_id: str
+    cltool_step: cwl.WorkflowStep,
+    cltool: cwl_utils.parser.CommandLineTool,
+    etool_step_id: str,
+    etool_out_id: str,
 ) -> list[cwl.OutputParameter]:
     """
     Copy CommandLineTool outputs into the equivalent Workflow output parameters.
@@ -1676,8 +1914,8 @@ def cltool_step_outputs_to_workflow_outputs(
     if not cltool_step.id:
         raise WorkflowException(f"Missing step id from {cltool_step}.")
     default_step_id = cltool_step.id.split("#")[-1]
-    if cltool_step.run.outputs:
-        for clt_out in cltool_step.run.outputs:
+    if cltool.outputs:
+        for clt_out in cltool.outputs:
             clt_out_id = clt_out.id.split("#")[-1].split("/")[-1]
             if clt_out_id == etool_out_id:
                 outputSource = f"{etool_step_id}/result"
@@ -1704,18 +1942,14 @@ def cltool_step_outputs_to_workflow_outputs(
 def generate_etool_from_expr2(
     expr: str,
     target: cwl.CommandInputParameter | cwl.WorkflowInputParameter,
-    inputs: Sequence[
-        cwl.CommandInputParameter
-        | cwl.CommandOutputParameter
-        | cwl.WorkflowInputParameter
-    ],
+    inputs: Sequence[cwl.WorkflowInputParameter],
     expression_lib: list[str] | None,
-    hints: Sequence[Any],
+    hints: Sequence[Any | cwl.ProcessRequirement],
     requirements: Sequence[cwl.ProcessRequirement],
     self_name: str | None = None,
 ) -> cwl.ExpressionTool:
     """Generate an ExpressionTool to achieve the same result as the given expression."""
-    outputs = yaml.comments.CommentedSeq()
+    outputs: list[cwl.ExpressionToolOutputParameter] = []
     outputs.append(
         cwl.ExpressionToolOutputParameter(
             id="result",
@@ -1723,8 +1957,16 @@ def generate_etool_from_expr2(
             secondaryFiles=target.secondaryFiles,
             streamable=target.streamable,
             doc=target.doc,
-            format=target.format,
-            type_=target.type_,
+            format=(
+                "\n".join(target.format)
+                if is_sequence(target.format)
+                else target.format
+            ),
+            type_=(
+                clt_output_schema_to_plain_output_schema(
+                    cast(cwl.CommandOutputParameterType, target.type_)
+                )
+            ),
         )
     )
     expression = "${"
@@ -1744,6 +1986,7 @@ def generate_etool_from_expr2(
         expression=expression,
         requirements=[cwl.InlineJavascriptRequirement(expression_lib)]
         + [r for r in requirements],
+        hints=hints,
         cwlVersion=_DEFAULT_CWL_VERSION,
     )
 
@@ -1751,29 +1994,31 @@ def generate_etool_from_expr2(
 def traverse_step(
     step: cwl.WorkflowStep,
     parent: cwl.Workflow,
+    process: cwl_utils.parser.Process,
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Process the given WorkflowStep."""
     modified = False
-    inputs = empty_inputs(step, parent)
+    inputs = cwl_utils.expression_refactor.empty_inputs(step, context, parent)
     if not step.id:
         return False
     step_id = step.id.split("#")[-1]
-    original_process = copy.deepcopy(step.run)
+    original_process = copy.deepcopy(process)
     original_step_ins = copy.deepcopy(step.in_)
     for inp in step.in_:
         if inp.valueFrom:
             if not inp.source:
                 self = None
             else:
-                if isinstance(inp.source, MutableSequence):
+                if is_sequence(inp.source):
                     self = []
                     for source in inp.source:
                         if not step.scatter:
                             self.append(
-                                example_input(
+                                cwl_utils.expression_refactor.example_input(
                                     utils.type_for_source(parent, source.split("#")[-1])
                                 )
                             )
@@ -1781,45 +2026,61 @@ def traverse_step(
                             scattered_source_type = utils.type_for_source(
                                 parent, source
                             )
-                            if isinstance(scattered_source_type, list):
+                            if is_sequence(scattered_source_type):
                                 for stype in scattered_source_type:
-                                    self.append(example_input(stype.type_))
+                                    self.append(
+                                        cwl_utils.expression_refactor.example_input(
+                                            stype.type_
+                                        )
+                                    )
                             else:
-                                self.append(example_input(scattered_source_type.type_))
+                                self.append(
+                                    cwl_utils.expression_refactor.example_input(
+                                        scattered_source_type.type_
+                                    )
+                                )
                 else:
                     if not step.scatter:
-                        self = example_input(
+                        self = cwl_utils.expression_refactor.example_input(
                             utils.type_for_source(parent, inp.source.split("#")[-1])
                         )
                     else:
                         scattered_source_type2 = utils.type_for_source(
                             parent, inp.source
                         )
-                        if isinstance(scattered_source_type2, list):
-                            self = example_input(scattered_source_type2[0].type_)
+                        if is_sequence(scattered_source_type2):
+                            self = cwl_utils.expression_refactor.example_input(
+                                scattered_source_type2[0].type_
+                            )
                         else:
-                            self = example_input(scattered_source_type2.type_)
+                            self = cwl_utils.expression_refactor.example_input(
+                                scattered_source_type2.type_
+                            )
             expression = get_expression(inp.valueFrom, inputs, self)
             if expression:
                 modified = True
                 etool_id = "_expression_{}_{}".format(step_id, inp.id.split("/")[-1])
                 target = cwl_utils.expression_refactor.get_input_for_id(
-                    inp.id, original_process
+                    inp.id, original_process, context
                 )
                 if not target:
                     raise WorkflowException("target not found")
                 input_source_id = None
                 if inp.source:
-                    if isinstance(inp.source, MutableSequence):
+                    if is_sequence(inp.source):
                         input_source_id = []
                         source_types: list[cwl_utils.parser.WorkflowInputParameter] = []
                         for source in inp.source:
                             source_id = source.split("#")[-1]
                             input_source_id.append(source_id)
-                            temp_type = utils.type_for_source(
-                                step.run, source_id, parent
+                            temp_type = cwl_utils.parser.utils.type_for_source(
+                                process,
+                                process.cwlVersion or _DEFAULT_CWL_VERSION,
+                                source_id,
+                                parent,
+                                loaded_steps={k: v[0] for k, v in context.items()},
                             )
-                            if isinstance(temp_type, list):
+                            if is_sequence(temp_type):
                                 for ttype in temp_type:
                                     if ttype not in source_types:
                                         source_types.append(ttype)
@@ -1830,7 +2091,7 @@ def traverse_step(
                         input_source_id = inp.source.split("#")[-1]
                 # target.id = target.id.split('#')[-1]
                 if isinstance(original_process, cwl_utils.parser.ExpressionTool):
-                    reqs: list[cwl.ProcessRequirement] = []
+                    reqs: list[cwl_utils.parser.ProcessRequirement] = []
                     if original_process.hints:
                         reqs.extend(original_process.hints)
                     if original_process.requirements:
@@ -1841,16 +2102,17 @@ def traverse_step(
                         ):
                             break
                     else:
-                        if not step.run.requirements:
-                            step.run.requirements = []
+                        if not process.requirements:
+                            process.requirements = []
                         expr_lib = cwl_utils.expression_refactor.find_expressionLib(
                             [parent]
                         )
-                        step.run.requirements.append(
+                        process.requirements = [
+                            *process.requirements,
                             cwl_utils.expression_refactor.get_inline_javascript_requirement(
-                                step.run, _DEFAULT_CWL_VERSION, expr_lib
-                            )
-                        )
+                                original_process, _DEFAULT_CWL_VERSION, expr_lib
+                            ),
+                        ]
                 replace_step_valueFrom_expr_with_etool(
                     expression,
                     etool_id,
@@ -1869,10 +2131,12 @@ def traverse_step(
     process_modified = process_level_reqs(
         original_process,
         step,
+        process,
         parent,
         replace_etool,
         skip_command_line1,
         skip_command_line2,
+        context,
     )
     if process_modified:
         modified = True
@@ -1881,9 +2145,11 @@ def traverse_step(
             original_process,
             parent,
             step,
+            cast(cwl_utils.parser.CommandLineTool, process),
             replace_etool,
             skip_command_line1,
             skip_command_line2,
+            context,
         )
         if clt_modified:
             modified = True
@@ -1891,12 +2157,8 @@ def traverse_step(
 
 
 def workflow_step_to_WorkflowInputParameters(
-    step_ins: list[cwl.WorkflowStepInput], parent: cwl.Workflow, except_in_id: str
-) -> MutableSequence[
-    cwl_utils.parser.CommandInputParameter
-    | cwl_utils.parser.CommandOutputParameter
-    | cwl_utils.parser.WorkflowInputParameter
-]:
+    step_ins: Sequence[cwl.WorkflowStepInput], parent: cwl.Workflow, except_in_id: str
+) -> list[cwl_utils.parser.WorkflowInputParameter]:
     """Create WorkflowInputParameters to match the given WorkflowStep inputs."""
     params = []
     for inp in step_ins:
@@ -1905,7 +2167,7 @@ def workflow_step_to_WorkflowInputParameters(
         inp_id = inp.id.split("#")[-1].split("/")[-1]
         if inp.source and inp_id != except_in_id:
             param = copy.deepcopy(param_for_source_id(parent, sourcenames=inp.source))
-            if isinstance(param, MutableSequence):
+            if is_sequence(param):
                 for p in param:
                     p.id = inp_id
                     p.type_ = clean_type_ids(
@@ -1933,7 +2195,7 @@ def replace_step_valueFrom_expr_with_etool(
     step: cwl.WorkflowStep,
     step_inp: cwl.WorkflowStepInput,
     original_process: cwl_utils.parser.Process,
-    original_step_ins: list[cwl.WorkflowStepInput],
+    original_step_ins: Sequence[cwl.WorkflowStepInput],
     source: str | list[str] | None,
     replace_etool: bool,
 ) -> None:
@@ -1982,9 +2244,10 @@ def replace_step_valueFrom_expr_with_etool(
         if wf_step_input.valueFrom:
             wf_step_input.valueFrom = None
         if wf_step_input.source:
-            if isinstance(wf_step_input.source, MutableSequence):
-                for index, inp_source in enumerate(wf_step_input.source):
-                    wf_step_input.source[index] = inp_source.split("#")[-1]
+            if is_sequence(wf_step_input.source):
+                wf_step_input.source = [
+                    inp_source.split("#")[-1] for inp_source in wf_step_input.source
+                ]
             else:
                 wf_step_input.source = wf_step_input.source.split("#")[-1]
     wf_step_inputs[:] = [
@@ -1995,15 +2258,15 @@ def replace_step_valueFrom_expr_with_etool(
     scatter = copy.deepcopy(step.scatter)
     if isinstance(scatter, str):
         scatter = [scatter]
-    if isinstance(scatter, MutableSequence):
-        for index, entry in enumerate(scatter):
-            scatter[index] = entry.split("/")[-1]
+    if is_sequence(scatter):
+        scatter = [entry.split("/")[-1] for entry in scatter]
     if scatter and step_inp_id in scatter:
         scatter = ["self"]
     # do we still need to scatter?
     else:
         scatter = None
-    workflow.steps.append(
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=wf_step_inputs,
@@ -2011,8 +2274,8 @@ def replace_step_valueFrom_expr_with_etool(
             run=etool,
             scatter=scatter,
             scatterMethod=step.scatterMethod,
-        )
-    )
+        ),
+    ]
 
 
 def traverse_workflow(
@@ -2020,32 +2283,41 @@ def traverse_workflow(
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> tuple[cwl.Workflow, bool]:
     """Traverse a workflow, processing each step."""
+    processes: list[cwl_utils.parser.Process] = []
     modified = False
     for index, step in enumerate(workflow.steps):
         if isinstance(step.run, cwl.ExpressionTool) and replace_etool:
             workflow.steps[index].run = etool_to_cltool(step.run)
             modified = True
         else:
-            step_modified = cwl_utils.expression_refactor.load_step(
-                step, replace_etool, skip_command_line1, skip_command_line2
+            process, step_modified = cwl_utils.expression_refactor.load_step(
+                step, replace_etool, skip_command_line1, skip_command_line2, context
             )
+            processes.append(process)
             if step_modified:
                 modified = True
-    for step in workflow.steps:
+    for index, step in enumerate(workflow.steps):
         if not step.id.startswith("_expression"):
             step_modified = traverse_step(
-                step, workflow, replace_etool, skip_command_line1, skip_command_line2
+                step,
+                workflow,
+                processes[index],
+                replace_etool,
+                skip_command_line1,
+                skip_command_line2,
+                context,
             )
             if step_modified:
                 modified = True
-    if process_workflow_inputs_and_outputs(workflow, replace_etool):
+    if process_workflow_inputs_and_outputs(workflow, replace_etool, context):
         modified = True
-    if process_workflow_reqs_and_hints(workflow, replace_etool):
+    if process_workflow_reqs_and_hints(workflow, replace_etool, context):
         modified = True
     if workflow.requirements:
-        workflow.requirements[:] = [
+        workflow.requirements = [
             x
             for x in workflow.requirements
             if not isinstance(

--- a/src/cwl_utils/cwl_v1_2_expression_refactor.py
+++ b/src/cwl_utils/cwl_v1_2_expression_refactor.py
@@ -6,15 +6,14 @@
 import copy
 import hashlib
 import uuid
-from collections.abc import Mapping, MutableSequence, Sequence
-from contextlib import suppress
+from collections.abc import Sequence
 from typing import Any, cast, Final
 
 from ruamel import yaml
 from schema_salad.metaschema import ArraySchema
 from schema_salad.runtime import save, LoadingOptions
 from schema_salad.sourceline import SourceLine
-from schema_salad.utils import json_dumps
+from schema_salad.utils import json_dumps, flatten
 
 import cwl_utils.expression_refactor
 import cwl_utils.parser
@@ -24,13 +23,15 @@ from cwl_utils.errors import JavascriptException, WorkflowException
 from cwl_utils.expression import do_eval, interpolate
 from cwl_utils.parser.utils import param_for_source_id
 from cwl_utils.types import (
-    CWLDirectoryType,
     CWLFileType,
     CWLObjectType,
     CWLOutputType,
     CWLParameterContext,
     CWLRuntimeParameterContext,
+    is_sequence,
+    is_file_or_directory,
 )
+from cwl_utils.utils import get_step_uri
 
 _DEFAULT_CWL_VERSION: Final = "v1.2"
 
@@ -63,12 +64,12 @@ def escape_expression_field(contents: str) -> str:
 
 
 def clean_type_ids(
-    cwltype: ArraySchema | cwl.InputRecordSchema,
-) -> ArraySchema | cwl.InputRecordSchema:
+    cwltype: cwl.InputParameterType | cwl.CommandInputParameterType,
+) -> cwl.InputParameterType | cwl.CommandInputParameterType:
     """Simplify type identifiers."""
     result = copy.deepcopy(cwltype)
     if isinstance(result, ArraySchema):
-        if isinstance(result.items, MutableSequence):
+        if is_sequence(result.items):
             for item in result.items:
                 if hasattr(item, "id"):
                     item.id = item.id.split("#")[-1]
@@ -87,6 +88,105 @@ def clean_type_ids(
     return result
 
 
+def clt_input_schema_to_plain_input_schema(
+    input_type: cwl.CommandInputParameterType,
+) -> cwl.InputParameterType:
+    if is_sequence(input_type):
+        return cast(
+            cwl.InputParameterType,
+            flatten(
+                [clt_input_schema_to_plain_input_schema(item) for item in input_type]
+            ),
+        )
+    match input_type:
+        case cwl.CommandInputArraySchema():
+            i1 = copy.deepcopy(input_type)
+            i1.items = clt_input_schema_to_plain_input_schema(
+                cast(cwl.CommandInputParameterType, i1.items)
+            )
+            return cwl.InputArraySchema.fromDoc(
+                i1.save(),
+                i1.loadingOptions.baseuri,
+                i1.loadingOptions,
+            )
+        case cwl.CommandInputEnumSchema():
+            return cwl.InputEnumSchema.fromDoc(
+                input_type.save(),
+                input_type.loadingOptions.baseuri,
+                input_type.loadingOptions,
+            )
+        case cwl.CommandInputRecordSchema():
+            i2 = copy.deepcopy(input_type)
+            if i2.fields is not None:
+                new_fields = []
+                for f in i2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = clt_input_schema_to_plain_input_schema(
+                        cast(cwl.CommandInputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                i2.fields = new_fields
+            return cwl.InputRecordSchema.fromDoc(
+                i2.save(),
+                i2.loadingOptions.baseuri,
+                i2.loadingOptions,
+            )
+        case _:
+            return input_type
+
+
+def clt_output_schema_to_plain_output_schema(
+    output_type: cwl.CommandOutputParameterType,
+) -> cwl.OutputParameterType:
+    if is_sequence(output_type):
+        return cast(
+            cwl.OutputParameterType,
+            flatten(
+                [
+                    clt_output_schema_to_plain_output_schema(
+                        cast(cwl.CommandOutputParameterType, item)
+                    )
+                    for item in output_type
+                ]
+            ),
+        )
+    match output_type:
+        case cwl.CommandOutputArraySchema():
+            o1 = copy.deepcopy(output_type)
+            o1.items = clt_output_schema_to_plain_output_schema(
+                cast(cwl.CommandOutputParameterType, o1.items)
+            )
+            return cwl.OutputArraySchema.fromDoc(
+                o1.save(),
+                o1.loadingOptions.baseuri,
+                o1.loadingOptions,
+            )
+        case cwl.CommandOutputEnumSchema():
+            return cwl.OutputEnumSchema.fromDoc(
+                output_type.save(),
+                output_type.loadingOptions.baseuri,
+                output_type.loadingOptions,
+            )
+        case cwl.CommandOutputRecordSchema():
+            o2 = copy.deepcopy(output_type)
+            if o2.fields is not None:
+                new_fields = []
+                for f in o2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = clt_output_schema_to_plain_output_schema(
+                        cast(cwl.CommandOutputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                o2.fields = new_fields
+            return cwl.OutputRecordSchema.fromDoc(
+                o2.save(),
+                o2.loadingOptions.baseuri,
+                o2.loadingOptions,
+            )
+        case _:
+            return output_type
+
+
 def get_command_input_parameter(id_: str, type_: Any) -> cwl.CommandInputParameter:
     return cwl.CommandInputParameter(id=id_, type_=type_)
 
@@ -98,7 +198,7 @@ def get_command_line_binding(
 
 
 def get_expression(
-    string: str, inputs: CWLObjectType, self: CWLOutputType | None
+    string: Any, inputs: CWLObjectType, self: CWLOutputType | None
 ) -> str | None:
     """
     Find and return a normalized CWL expression, if any.
@@ -159,6 +259,117 @@ def get_inline_javascript_requirement(
     return cwl.InlineJavascriptRequirement(expression_lib)
 
 
+def plain_input_schema_to_clt_input_schema(
+    input_type: cwl.InputParameterType,
+) -> cwl.CommandInputParameterType:
+    if is_sequence(input_type):
+        return cast(
+            cwl.CommandInputParameterType,
+            flatten(
+                [plain_input_schema_to_clt_input_schema(item) for item in input_type]
+            ),
+        )
+    match input_type:
+        case (
+            cwl.CommandInputArraySchema()
+            | cwl.CommandInputEnumSchema()
+            | cwl.CommandInputRecordSchema()
+        ):
+            return input_type
+        case cwl.InputArraySchema():
+            i1 = copy.deepcopy(input_type)
+            i1.items = plain_input_schema_to_clt_input_schema(
+                cast(cwl.InputParameterType, i1.items)
+            )
+            return cwl.CommandInputArraySchema.fromDoc(
+                i1.save(),
+                i1.loadingOptions.baseuri,
+                i1.loadingOptions,
+            )
+        case cwl.InputEnumSchema():
+            return cwl.CommandInputEnumSchema.fromDoc(
+                input_type.save(),
+                input_type.loadingOptions.baseuri,
+                input_type.loadingOptions,
+            )
+        case cwl.InputRecordSchema():
+            i2 = copy.deepcopy(input_type)
+            if i2.fields is not None:
+                new_fields = []
+                for f in i2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = plain_input_schema_to_clt_input_schema(
+                        cast(cwl.InputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                i2.fields = new_fields
+            return cwl.CommandInputRecordSchema.fromDoc(
+                i2.save(),
+                i2.loadingOptions.baseuri,
+                i2.loadingOptions,
+            )
+        case _:
+            return input_type
+
+
+def plain_output_schema_to_clt_output_schema(
+    output_type: cwl.OutputParameterType,
+) -> cwl.CommandOutputParameterType:
+    if is_sequence(output_type):
+        return cast(
+            cwl.CommandOutputParameterType,
+            flatten(
+                [
+                    plain_output_schema_to_clt_output_schema(
+                        cast(cwl.OutputParameterType, item)
+                    )
+                    for item in output_type
+                ]
+            ),
+        )
+    match output_type:
+        case (
+            cwl.CommandOutputArraySchema()
+            | cwl.CommandOutputEnumSchema()
+            | cwl.CommandOutputRecordSchema()
+        ):
+            return output_type
+        case cwl.OutputArraySchema():
+            o1 = copy.deepcopy(output_type)
+            o1.items = plain_output_schema_to_clt_output_schema(
+                cast(cwl.OutputParameterType, o1.items)
+            )
+            return cwl.CommandOutputArraySchema.fromDoc(
+                o1.save(),
+                o1.loadingOptions.baseuri,
+                o1.loadingOptions,
+            )
+        case cwl.OutputEnumSchema():
+            return cwl.CommandOutputEnumSchema.fromDoc(
+                output_type.save(),
+                output_type.loadingOptions.baseuri,
+                output_type.loadingOptions,
+            )
+        case cwl.OutputRecordSchema():
+            o2 = copy.deepcopy(output_type)
+            if o2.fields is not None:
+                new_fields = []
+                for f in o2.fields:
+                    f1 = copy.deepcopy(f)
+                    f1.type_ = plain_output_schema_to_clt_output_schema(
+                        cast(cwl.OutputParameterType, f1.type_)
+                    )
+                    new_fields.append(f1)
+                o2.fields = new_fields
+            return cwl.CommandOutputRecordSchema.fromDoc(
+                o2.save(),
+                o2.loadingOptions.baseuri,
+                o2.loadingOptions,
+            )
+        case _:
+            return output_type
+
+
 def etool_to_cltool(
     etool: cwl.ExpressionTool, expressionLib: list[str] | None = None
 ) -> cwl.CommandLineTool:
@@ -174,7 +385,7 @@ def etool_to_cltool(
                 doc=inp.doc,
                 format=inp.format,
                 default=inp.default,
-                type_=inp.type_,
+                type_=plain_input_schema_to_clt_input_schema(inp.type_),
                 extension_fields=inp.extension_fields,
                 loadingOptions=inp.loadingOptions,
             )
@@ -189,7 +400,7 @@ def etool_to_cltool(
                 streamable=outp.streamable,
                 doc=outp.doc,
                 format=outp.format,
-                type_=outp.type_,
+                type_=plain_output_schema_to_clt_output_schema(outp.type_),
                 extension_fields=outp.extension_fields,
                 loadingOptions=outp.loadingOptions,
             )
@@ -234,10 +445,13 @@ def traverse(
     inside: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]] | None = None,
 ) -> tuple[
     cwl.CommandLineTool | cwl.ExpressionTool | cwl.Workflow | cwl.Operation, bool
 ]:
     """Convert the given process and any subprocesses."""
+    if context is None:
+        context = {}
     match process:
         case cwl.CommandLineTool() if not inside:
             process = expand_stream_shortcuts(process)
@@ -301,14 +515,18 @@ def traverse(
                 cwlVersion=process.cwlVersion,
             )
             result, modified = traverse_workflow(
-                workflow, replace_etool, skip_command_line1, skip_command_line2
+                workflow, replace_etool, skip_command_line1, skip_command_line2, context
             )
             if modified:
                 return result, True
             else:
                 return process, False
         case cwl.ExpressionTool() if replace_etool:
-            expression = get_expression(process.expression, empty_inputs(process), None)
+            expression = get_expression(
+                process.expression,
+                cwl_utils.expression_refactor.empty_inputs(process, context),
+                None,
+            )
             # Why call get_expression on an ExpressionTool?
             # It normalizes the form of $() CWL expressions into the ${} style
             if expression:
@@ -319,7 +537,7 @@ def traverse(
             return etool_to_cltool(process2), True
         case cwl.Workflow():
             return traverse_workflow(
-                process, replace_etool, skip_command_line1, skip_command_line2
+                process, replace_etool, skip_command_line1, skip_command_line2, context
             )
         case _:
             return process, False
@@ -332,7 +550,7 @@ def generate_etool_from_expr(
     self_type: None | (
         cwl.WorkflowInputParameter
         | cwl.CommandInputParameter
-        | list[cwl.WorkflowInputParameter | cwl.CommandInputParameter]
+        | Sequence[cwl.WorkflowInputParameter | cwl.CommandInputParameter]
     ) = None,  # if the "self" input should be a different type than the "result" output
     extra_processes: (
         Sequence[cwl_utils.parser.Process | cwl_utils.parser.WorkflowStep] | None
@@ -343,38 +561,33 @@ def generate_etool_from_expr(
     if not no_inputs:
         if not self_type:
             self_type = target
-        if isinstance(self_type, list):
-            new_type: (
-                list[ArraySchema | cwl.InputRecordSchema]
-                | ArraySchema
-                | cwl.InputRecordSchema
-            ) = [clean_type_ids(t.type_) for t in self_type]
+        if is_sequence(self_type):
+            new_type: cwl.InputParameterType | cwl.CommandInputParameterType = cast(
+                cwl.InputParameterType | cwl.CommandInputParameterType,
+                [clean_type_ids(t.type_) for t in self_type if t.type_],
+            )
         else:
             new_type = clean_type_ids(self_type.type_)
         inputs.append(
             cwl.WorkflowInputParameter(
                 id="self",
-                label=self_type.label if not isinstance(self_type, list) else None,
+                label=self_type.label if not is_sequence(self_type) else None,
                 secondaryFiles=(
-                    self_type.secondaryFiles
-                    if not isinstance(self_type, list)
-                    else None
+                    self_type.secondaryFiles if not is_sequence(self_type) else None
                 ),
                 streamable=(
-                    self_type.streamable if not isinstance(self_type, list) else None
+                    self_type.streamable if not is_sequence(self_type) else None
                 ),
-                doc=self_type.doc if not isinstance(self_type, list) else None,
-                format=self_type.format if not isinstance(self_type, list) else None,
-                type_=new_type,
+                doc=self_type.doc if not is_sequence(self_type) else None,
+                format=self_type.format if not is_sequence(self_type) else None,
+                type_=clt_input_schema_to_plain_input_schema(
+                    cast(cwl.CommandInputParameterType, new_type)
+                ),
                 extension_fields=(
-                    self_type.extension_fields
-                    if not isinstance(self_type, list)
-                    else None
+                    self_type.extension_fields if not is_sequence(self_type) else None
                 ),
                 loadingOptions=(
-                    self_type.loadingOptions
-                    if not isinstance(self_type, list)
-                    else None
+                    self_type.loadingOptions if not is_sequence(self_type) else None
                 ),
             )
         )
@@ -386,8 +599,16 @@ def generate_etool_from_expr(
             secondaryFiles=target.secondaryFiles,
             streamable=target.streamable,
             doc=target.doc,
-            format=target.format,
-            type_=target.type_,
+            format=(
+                "\n".join(target.format)
+                if is_sequence(target.format)
+                else target.format
+            ),
+            type_=(
+                clt_output_schema_to_plain_output_schema(
+                    cast(cwl.CommandOutputParameterType, target.type_)
+                )
+            ),
             extension_fields=target.extension_fields,
             loadingOptions=target.loadingOptions,
         )
@@ -422,7 +643,7 @@ def replace_expr_with_etool(
     name: str,
     workflow: cwl.Workflow,
     target: cwl.CommandInputParameter | cwl.WorkflowInputParameter,
-    source: str | list[Any] | None,
+    source: str | Sequence[Any] | None,
     replace_etool: bool = False,
     extra_process: (
         cwl_utils.parser.Process | cwl_utils.parser.WorkflowStep | None
@@ -452,14 +673,15 @@ def replace_expr_with_etool(
     inps = []
     if source:
         inps.append(cwl.WorkflowStepInput(id="self", source=source))
-    workflow.steps.append(
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=inps,
             out=[cwl.WorkflowStepOutput("result")],
             run=final_tool,
-        )
-    )
+        ),
+    ]
 
 
 def replace_wf_input_ref_with_step_output(
@@ -473,93 +695,21 @@ def replace_wf_input_ref_with_step_output(
                     if inp.source:
                         if inp.source == name:
                             inp.source = target
-                        if isinstance(inp.source, MutableSequence):
-                            for index, source in enumerate(inp.source):
-                                if source == name:
-                                    inp.source[index] = target
+                        if is_sequence(inp.source):
+                            inp.source = [
+                                target if isource == name else isource
+                                for isource in inp.source
+                            ]
     if workflow.outputs:
         for outp in workflow.outputs:
             if outp.outputSource:
                 if outp.outputSource == name:
                     outp.outputSource = target
-                if isinstance(outp.outputSource, MutableSequence):
-                    for index, outputSource in enumerate(outp.outputSource):
-                        if outputSource == name:
-                            outp.outputSource[index] = target
-
-
-def empty_inputs(
-    process_or_step: (
-        cwl.CommandLineTool
-        | cwl.WorkflowStep
-        | cwl.ExpressionTool
-        | cwl.Workflow
-        | cwl.Operation
-    ),
-    parent: cwl.Workflow | None = None,
-) -> dict[str, Any]:
-    """Produce a mock input object for the given inputs."""
-    result = {}
-    if isinstance(process_or_step, cwl.Process):
-        for param in process_or_step.inputs:
-            result[param.id.split("#")[-1]] = example_input(param.type_)
-    else:
-        for param in process_or_step.in_:
-            param_id = param.id.split("/")[-1]
-            if param.source is None and param.valueFrom:
-                result[param_id] = example_input("string")
-            elif param.source is None and param.default:
-                result[param_id] = param.default
-            else:
-                with suppress(WorkflowException):
-                    result[param_id] = example_input(
-                        utils.type_for_source(process_or_step.run, param.source, parent)
-                    )
-    return result
-
-
-def example_input(some_type: Any) -> Any:
-    """Produce a fake input for the given type."""
-    # TODO: accept some sort of context object with local custom type definitions
-    if some_type == "Directory":
-        return CWLDirectoryType(
-            **{
-                "class": "Directory",
-                "location": "https://www.example.com/example",
-                "basename": "example",
-                "listing": [
-                    CWLFileType(
-                        **{
-                            "class": "File",
-                            "basename": "example.txt",
-                            "size": 23,
-                            "contents": "hoopla",
-                            "nameroot": "example",
-                            "nameext": "txt",
-                        }
-                    )
-                ],
-            }
-        )
-    if some_type == "File":
-        return CWLFileType(
-            **{
-                "class": "File",
-                "location": "https://www.example.com/example.txt",
-                "basename": "example.txt",
-                "size": 23,
-                "contents": "hoopla",
-                "nameroot": "example",
-                "nameext": "txt",
-            }
-        )
-    if some_type == "int":
-        return 23
-    if some_type == "string":
-        return "hoopla!"
-    if some_type == "boolean":
-        return True
-    return None
+                if is_sequence(outp.outputSource):
+                    outp.outputSource = [
+                        target if osource == name else osource
+                        for osource in outp.outputSource
+                    ]
 
 
 EMPTY_FILE = CWLFileType(
@@ -641,7 +791,7 @@ def process_CommandLineTool_output(ctool: cwl.CommandLineTool, outp_id: str) -> 
             ):
                 new_outp.type_ = cwl.OutputArraySchema(items="File", type_="array")
             elif isinstance(new_outp, cwl.CommandOutputParameter):
-                if new_outp.outputBinding:
+                if isinstance(new_outp.outputBinding, cwl.CommandOutputBinding):
                     new_outp.outputBinding.outputEval = None
                     new_outp.outputBinding.loadContents = None
                 new_outp.type_ = cwl.CommandOutputArraySchema(
@@ -656,11 +806,13 @@ def process_CommandLineTool_output(ctool: cwl.CommandLineTool, outp_id: str) -> 
 
 
 def process_workflow_inputs_and_outputs(
-    workflow: cwl.Workflow, replace_etool: bool
+    workflow: cwl.Workflow,
+    replace_etool: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Do any needed conversions on the given Workflow's inputs and outputs."""
     modified = False
-    inputs = empty_inputs(workflow)
+    inputs = cwl_utils.expression_refactor.empty_inputs(workflow, context)
     for index, param in enumerate(workflow.inputs):
         with SourceLine(workflow.inputs, index, WorkflowException):
             if param.format and get_expression(param.format, inputs, None):
@@ -678,7 +830,7 @@ def process_workflow_inputs_and_outputs(
                         "secondaryFiles",
                         raise_type=WorkflowException,
                     ).makeError(TOPLEVEL_SF_EXPR_ERROR.format(param.id.split("#")[-1]))
-                elif isinstance(param.secondaryFiles, MutableSequence):
+                elif is_sequence(param.secondaryFiles):
                     for index2, entry in enumerate(param.secondaryFiles):
                         if get_expression(entry.pattern, inputs, EMPTY_FILE):
                             raise SourceLine(
@@ -709,26 +861,24 @@ def process_workflow_inputs_and_outputs(
                 target_type = copy.deepcopy(param2.type_)
                 if isinstance(target_type, cwl.OutputArraySchema):
                     target_type.name = ""
-                target = cwl.WorkflowInputParameter(id=None, type_=target_type)
-                if not isinstance(param2.outputSource, list):
+                target = cwl.WorkflowInputParameter(id="", type_=target_type)
+                if not is_sequence(param2.outputSource):
                     sources = param2.outputSource.split("#")[-1]
                 else:
                     sources = [s.split("#")[-1] for s in param2.outputSource]
                 source_type_items = utils.type_for_source(workflow, sources)
                 if isinstance(source_type_items, ArraySchema):
-                    if isinstance(source_type_items.items, list):
+                    if is_sequence(source_type_items.items):
                         if "null" not in source_type_items.items:
-                            source_type_items.items.append("null")
+                            source_type_items.items = [*source_type_items.items, "null"]
                     elif source_type_items.items != "null":
                         source_type_items.items = ["null", source_type_items.items]
-                elif isinstance(source_type_items, list):
+                elif is_sequence(source_type_items):
                     if "null" not in source_type_items:
-                        source_type_items.append("null")
+                        source_type_items = [*source_type_items, "null"]
                 elif source_type_items != "null":
                     source_type_items = ["null", source_type_items]
-                source_type = cwl.CommandInputParameter(
-                    id=None, type_=source_type_items
-                )
+                source_type = cwl.CommandInputParameter(id="", type_=source_type_items)
                 replace_expr_with_etool(
                     expression,
                     etool_id,
@@ -746,7 +896,9 @@ def process_workflow_inputs_and_outputs(
 
 
 def process_workflow_reqs_and_hints(
-    workflow: cwl.Workflow, replace_etool: bool
+    workflow: cwl.Workflow,
+    replace_etool: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """
     Convert any expressions in a workflow's reqs and hints.
@@ -761,7 +913,7 @@ def process_workflow_reqs_and_hints(
     #       ^ By refactoring replace_expr_etool to allow multiple inputs,
     #         and connecting all workflow inputs to the generated step
     modified = False
-    inputs = empty_inputs(workflow)
+    inputs = cwl_utils.expression_refactor.empty_inputs(workflow, context)
     generated_res_reqs: list[tuple[str, int | str]] = []
     generated_iwdr_reqs: list[tuple[str, int | str]] = []
     generated_envVar_reqs: list[tuple[str, int | str]] = []
@@ -780,13 +932,14 @@ def process_workflow_reqs_and_hints(
         for req in cast(list[cwl.ProcessRequirement], workflow.requirements):
             match req:
                 case cwl.EnvVarRequirement() if req.envDef:
+                    env_defs = list(req.envDef)
                     for index, envDef in enumerate(req.envDef):
                         if envDef.envValue:
                             expression = get_expression(envDef.envValue, inputs, None)
                             if expression:
                                 modified = True
                                 target = cwl.WorkflowInputParameter(
-                                    id=None,
+                                    id="",
                                     type_="string",
                                 )
                                 etool_id = (
@@ -807,8 +960,9 @@ def process_workflow_reqs_and_hints(
                                     prop_reqs += (cwl.EnvVarRequirement,)
                                 newEnvDef = copy.deepcopy(envDef)
                                 newEnvDef.envValue = f"$(inputs._envDef{index})"
-                                envVarReq.envDef[index] = newEnvDef
+                                env_defs[index] = newEnvDef
                                 generated_envVar_reqs.append((etool_id, index))
+                    req.envDef = env_defs
                 case cwl.ResourceRequirement():
                     for attr in cwl.ResourceRequirement.attrs:
                         this_attr = getattr(req, attr, None)
@@ -816,9 +970,7 @@ def process_workflow_reqs_and_hints(
                             expression = get_expression(this_attr, inputs, None)
                             if expression:
                                 modified = True
-                                target = cwl.WorkflowInputParameter(
-                                    id=None, type_="long"
-                                )
+                                target = cwl.WorkflowInputParameter(id="", type_="long")
                                 etool_id = "_expression_workflow_ResourceRequirement_{}".format(
                                     attr
                                 )
@@ -843,7 +995,7 @@ def process_workflow_reqs_and_hints(
                         if expression:
                             modified = True
                             target = cwl.WorkflowInputParameter(
-                                id=None,
+                                id="",
                                 type_=cwl.InputArraySchema(
                                     ["File", "Directory"], "array", None, None
                                 ),
@@ -864,12 +1016,13 @@ def process_workflow_reqs_and_hints(
                             prop_reqs += (cwl.InitialWorkDirRequirement,)
                     else:
                         iwdr = copy.deepcopy(req)
+                        new_listing = list(iwdr.listing)
                         for index, entry in enumerate(req.listing):
                             expression = get_expression(entry, inputs, None)
                             if expression:
                                 modified = True
                                 target = cwl.WorkflowInputParameter(
-                                    id=None,
+                                    id="",
                                     type_=cwl.InputArraySchema(
                                         ["File", "Directory"], "array", None, None
                                     ),
@@ -885,7 +1038,7 @@ def process_workflow_reqs_and_hints(
                                     None,
                                     replace_etool,
                                 )
-                                iwdr.listing[index] = f"$(inputs._iwdr_listing_{index}"
+                                new_listing[index] = f"$(inputs._iwdr_listing_{index}"
                                 generated_iwdr_reqs.append((etool_id, index))
                             elif isinstance(entry, cwl.Dirent):
                                 if entry.entry:
@@ -903,16 +1056,9 @@ def process_workflow_reqs_and_hints(
                                             resources={},
                                         )
                                         modified = True
-                                        if (
-                                            isinstance(expr_result, Mapping)
-                                            and "class" in expr_result
-                                            and (
-                                                expr_result["class"]
-                                                in ("File", "Directory")
-                                            )
-                                        ):
+                                        if is_file_or_directory(expr_result):
                                             target = cwl.WorkflowInputParameter(
-                                                id=None,
+                                                id="",
                                                 type_=expr_result["class"],
                                             )
                                             replace_expr_with_etool(
@@ -923,7 +1069,7 @@ def process_workflow_reqs_and_hints(
                                                 None,
                                                 replace_etool,
                                             )
-                                            iwdr.listing[index] = (
+                                            new_listing[index] = (
                                                 "$(inputs._iwdr_listing_{}".format(
                                                     index
                                                 )
@@ -933,7 +1079,7 @@ def process_workflow_reqs_and_hints(
                                             )
                                         elif isinstance(expr_result, str):
                                             target = cwl.WorkflowInputParameter(
-                                                id=None,
+                                                id="",
                                                 type_=["File"],
                                             )
                                             if entry.entryname is None:
@@ -964,7 +1110,7 @@ def process_workflow_reqs_and_hints(
                                             None,
                                             replace_etool,
                                         )
-                                        iwdr.listing[index] = (
+                                        new_listing[index] = (
                                             f"$(inputs._iwdr_listing_{index}"
                                         )
                                         generated_iwdr_reqs.append((etool_id, index))
@@ -976,7 +1122,7 @@ def process_workflow_reqs_and_hints(
                                     if expression:
                                         modified = True
                                         target = cwl.WorkflowInputParameter(
-                                            id=None,
+                                            id="",
                                             type_="string",
                                         )
                                         etool_id = "_expression_workflow_InitialWorkDirRequirement_{}".format(
@@ -990,16 +1136,19 @@ def process_workflow_reqs_and_hints(
                                             None,
                                             replace_etool,
                                         )
-                                        iwdr.listing[index] = (
+                                        new_listing[index] = (
                                             f"$(inputs._iwdr_listing_{index}"
                                         )
                                         generated_iwdr_reqs.append((etool_id, index))
+                        iwdr.listing = new_listing
                         if generated_iwdr_reqs:
                             prop_reqs += (cwl.InitialWorkDirRequirement,)
                         else:
                             iwdr = None
+    step_inputs: list[list[cwl.WorkflowStepInput]] = [[] * len(workflow.steps)]
+    step_requirements: list[list[cwl.ProcessRequirement]] = [[] * len(workflow.steps)]
     if envVarReq and workflow.steps:
-        for step in workflow.steps:
+        for index, step in enumerate(workflow.steps):
             if step.id.split("#")[-1].startswith("_expression_"):
                 continue
             if step.requirements:
@@ -1008,17 +1157,17 @@ def process_workflow_reqs_and_hints(
                         continue
             else:
                 step.requirements = yaml.comments.CommentedSeq()
-            step.requirements.append(envVarReq)
-            for entry in generated_envVar_reqs:
-                step.in_.append(
+            step_requirements[index].append(envVarReq)
+            for entry2 in generated_envVar_reqs:
+                step_inputs[index].append(
                     cwl.WorkflowStepInput(
-                        id=f"_envDef{entry[1]}",
-                        source=f"{entry[0]}/result",
+                        id=f"_envDef{entry2[1]}",
+                        source=f"{entry2[0]}/result",
                     )
                 )
 
     if resourceReq and workflow.steps:
-        for step in workflow.steps:
+        for index, step in enumerate(workflow.steps):
             if step.id.split("#")[-1].startswith("_expression_"):
                 continue
             if step.requirements:
@@ -1027,17 +1176,17 @@ def process_workflow_reqs_and_hints(
                         continue
             else:
                 step.requirements = yaml.comments.CommentedSeq()
-            step.requirements.append(resourceReq)
-            for entry in generated_res_reqs:
-                step.in_.append(
+            step_requirements[index].append(resourceReq)
+            for entry3 in generated_res_reqs:
+                step_inputs[index].append(
                     cwl.WorkflowStepInput(
-                        id=f"_{entry[1]}",
-                        source=f"{entry[0]}/result",
+                        id=f"_{entry3[1]}",
+                        source=f"{entry3[0]}/result",
                     )
                 )
 
     if iwdr and workflow.steps:
-        for step in workflow.steps:
+        for index, step in enumerate(workflow.steps):
             if step.id.split("#")[-1].startswith("_expression_"):
                 continue
             if step.requirements:
@@ -1046,37 +1195,49 @@ def process_workflow_reqs_and_hints(
                         continue
             else:
                 step.requirements = yaml.comments.CommentedSeq()
-            step.requirements.append(iwdr)
+            step_requirements[index].append(iwdr)
             if generated_iwdr_reqs:
-                for entry in generated_iwdr_reqs:
-                    step.in_.append(
+                for entry4 in generated_iwdr_reqs:
+                    step_inputs[index].append(
                         cwl.WorkflowStepInput(
                             id=f"_iwdr_listing_{index}",
-                            source=f"{entry[0]}/result",
+                            source=f"{entry4[0]}/result",
                         )
                     )
             else:
-                step.in_.append(
+                step_inputs[index].append(
                     cwl.WorkflowStepInput(
                         id="_iwdr_listing",
                         source="_expression_workflow_InitialWorkDirRequirement/result",
                     )
                 )
+    for step, step_ins, step_reqs in zip(
+        workflow.steps, step_inputs, step_requirements
+    ):
+        if step_ins:
+            step.in_ = [*step.in_, *step_ins]
+        if step_reqs:
+            step.requirements = [
+                *cast(Sequence[cwl.ProcessRequirement], step.requirements),
+                *step_reqs,
+            ]
 
     if workflow.requirements:
-        workflow.requirements[:] = [
+        workflow.requirements = [
             x for x in workflow.requirements if not isinstance(x, prop_reqs)
         ]
     return modified
 
 
 def process_level_reqs(
-    process: cwl.CommandLineTool,
+    process: cwl_utils.parser.Process,
     step: cwl.WorkflowStep,
+    target_process: cwl_utils.parser.Process,
     parent: cwl.Workflow,
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Convert expressions inside a process into new adjacent steps."""
     # This is for reqs inside a Process (CommandLineTool, ExpressionTool)
@@ -1091,22 +1252,21 @@ def process_level_reqs(
     if not process.requirements:
         return False
     modified = False
-    target_process = step.run
-    inputs = cwl_utils.expression_refactor.empty_inputs(process, _DEFAULT_CWL_VERSION)
+    inputs = cwl_utils.expression_refactor.empty_inputs(process, context)
     generated_res_reqs: list[tuple[str, str]] = []
     generated_iwdr_reqs: list[tuple[str, int | str, Any]] = []
     generated_envVar_reqs: list[tuple[str, int | str]] = []
     if not step.id:
         return False
     step_name = step.id.split("#", 1)[-1]
-    for req_index, req in enumerate(process.requirements):
+    for req in process.requirements:
         if isinstance(req, cwl_utils.parser.EnvVarRequirement) and req.envDef:
             for env_index, envDef in enumerate(req.envDef):
                 if envDef.envValue:
                     expression = get_expression(envDef.envValue, inputs, None)
                     if expression:
                         modified = True
-                        target = cwl.WorkflowInputParameter(id=None, type_="string")
+                        target = cwl.WorkflowInputParameter(id="", type_="string")
                         etool_id = "_expression_{}_EnvVarRequirement_{}".format(
                             step_name, env_index
                         )
@@ -1119,9 +1279,7 @@ def process_level_reqs(
                             replace_etool,
                             process,
                         )
-                        target_process.requirements[req_index][
-                            env_index
-                        ].envValue = f"$(inputs._envDef{env_index})"
+                        envDef.envValue = f"$(inputs._envDef{env_index})"
                         generated_envVar_reqs.append((etool_id, env_index))
         elif isinstance(req, cwl_utils.parser.ResourceRequirement):
             for attr in cwl.ResourceRequirement.attrs:
@@ -1130,7 +1288,7 @@ def process_level_reqs(
                     expression = get_expression(this_attr, inputs, None)
                     if expression:
                         modified = True
-                        target = cwl.WorkflowInputParameter(id=None, type_="long")
+                        target = cwl.WorkflowInputParameter(id="", type_="long")
                         etool_id = "_expression_{}_ResourceRequirement_{}".format(
                             step_name, attr
                         )
@@ -1140,10 +1298,11 @@ def process_level_reqs(
                             parent,
                             target,
                             step,
+                            target_process,
                             replace_etool,
                         )
                         setattr(
-                            target_process.requirements[req_index],
+                            req,
                             attr,
                             f"$(inputs._{attr})",
                         )
@@ -1161,7 +1320,7 @@ def process_level_reqs(
                     target_type = cwl.InputArraySchema(
                         ["File", "Directory"], "array", None, None
                     )
-                    target = cwl.WorkflowInputParameter(id=None, type_=target_type)
+                    target = cwl.WorkflowInputParameter(id="", type_=target_type)
                     etool_id = "_expression_{}_InitialWorkDirRequirement".format(
                         step_name
                     )
@@ -1174,15 +1333,14 @@ def process_level_reqs(
                         replace_etool,
                         process,
                     )
-                    target_process.requirements[req_index].listing = (
-                        "$(inputs._iwdr_listing)",
-                    )
-                    step.in_.append(
+                    req.listing = ("$(inputs._iwdr_listing)",)
+                    step.in_ = [
+                        *step.in_,
                         cwl.WorkflowStepInput(
                             id="_iwdr_listing",
                             source=f"{etool_id}/result",
-                        )
-                    )
+                        ),
+                    ]
                     cwl_utils.expression_refactor.add_input_to_process(
                         target_process,
                         _DEFAULT_CWL_VERSION,
@@ -1199,7 +1357,7 @@ def process_level_reqs(
                             ["File", "Directory"], "array", None, None
                         )
                         target = cwl.WorkflowInputParameter(
-                            id=None,
+                            id="",
                             type_=target_type,
                         )
                         etool_id = "_expression_{}_InitialWorkDirRequirement_{}".format(
@@ -1214,9 +1372,9 @@ def process_level_reqs(
                             replace_etool,
                             process,
                         )
-                        target_process.requirements[req_index].listing[
-                            listing_index
-                        ] = f"$(inputs._iwdr_listing_{listing_index}"
+                        req.listing[listing_index] = (
+                            f"$(inputs._iwdr_listing_{listing_index}"
+                        )
                         generated_iwdr_reqs.append(
                             (etool_id, listing_index, target_type)
                         )
@@ -1254,7 +1412,7 @@ return result; }"""
                                     new_expression = expression
                                 d_target_type = ["File", "Directory"]
                                 target = cwl.WorkflowInputParameter(
-                                    id=None,
+                                    id="",
                                     type_=d_target_type,
                                 )
                                 etool_id = "_expression_{}_InitialWorkDirRequirement_{}".format(
@@ -1267,11 +1425,10 @@ return result; }"""
                                     parent,
                                     target,
                                     step,
+                                    step.run,
                                     replace_etool,
                                 )
-                                target_process.requirements[req_index].listing[
-                                    listing_index
-                                ].entry = "$(inputs._iwdr_listing_{})".format(
+                                entry.entry = "$(inputs._iwdr_listing_{})".format(
                                     listing_index
                                 )
                                 generated_iwdr_reqs.append(
@@ -1282,7 +1439,7 @@ return result; }"""
                             if expression:
                                 modified = True
                                 target = cwl.WorkflowInputParameter(
-                                    id=None,
+                                    id="",
                                     type_="string",
                                 )
                                 etool_id = "_expression_{}_InitialWorkDirRequirement_{}".format(
@@ -1297,32 +1454,36 @@ return result; }"""
                                     replace_etool,
                                     process,
                                 )
-                                target_process.requirements[req_index].listing[
-                                    listing_index
-                                ].entryname = "$(inputs._iwdr_listing_{})".format(
+                                entry.entryname = "$(inputs._iwdr_listing_{})".format(
                                     listing_index
                                 )
                                 generated_iwdr_reqs.append(
                                     (etool_id, listing_index, "string")
                                 )
-    for entry in generated_envVar_reqs:
-        name = f"_envDef{entry[1]}"
-        step.in_.append(cwl.WorkflowStepInput(id=name, source=f"{entry[0]}/result"))
+    step_inputs = []
+    for entry2 in generated_envVar_reqs:
+        name = f"_envDef{entry2[1]}"
+        step_inputs.append(cwl.WorkflowStepInput(id=name, source=f"{entry2[0]}/result"))
         cwl_utils.expression_refactor.add_input_to_process(
             target_process, _DEFAULT_CWL_VERSION, name, "string", process.loadingOptions
         )
-    for entry in generated_res_reqs:
-        name = f"_{entry[1]}"
-        step.in_.append(cwl.WorkflowStepInput(id=name, source=f"{entry[0]}/result"))
+    for entry3 in generated_res_reqs:
+        name = f"_{entry3[1]}"
+        step_inputs.append(cwl.WorkflowStepInput(id=name, source=f"{entry3[0]}/result"))
         cwl_utils.expression_refactor.add_input_to_process(
             target_process, _DEFAULT_CWL_VERSION, name, "long", process.loadingOptions
         )
-    for entry in generated_iwdr_reqs:
-        name = f"_iwdr_listing_{entry[1]}"
-        step.in_.append(cwl.WorkflowStepInput(id=name, source=f"{entry[0]}/result"))
+    for entry4 in generated_iwdr_reqs:
+        name = f"_iwdr_listing_{entry4[1]}"
+        step_inputs.append(cwl.WorkflowStepInput(id=name, source=f"{entry4[0]}/result"))
         cwl_utils.expression_refactor.add_input_to_process(
-            target_process, _DEFAULT_CWL_VERSION, name, entry[2], process.loadingOptions
+            target_process,
+            _DEFAULT_CWL_VERSION,
+            name,
+            entry4[2],
+            process.loadingOptions,
         )
+    step.in_ = [*step.in_, *step_inputs]
     return modified
 
 
@@ -1344,19 +1505,21 @@ def traverse_CommandLineTool(
     clt: cwl_utils.parser.CommandLineTool,
     parent: cwl.Workflow,
     step: cwl.WorkflowStep,
+    target_clt: cwl_utils.parser.CommandLineTool,
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Extract any CWL Expressions within the given CommandLineTool into sibling steps."""
     modified = False
-    # don't modify clt, modify step.run
-    target_clt = step.run
-    inputs = cwl_utils.expression_refactor.empty_inputs(clt, _DEFAULT_CWL_VERSION)
+    inputs = cwl_utils.expression_refactor.empty_inputs(clt, context)
     if not step.id:
         return False
     step_id = step.id.split("#")[-1]
+    clt_inputs, step_inputs = [], []
     if clt.arguments and not skip_command_line1:
+        arguments = list(clt.arguments)
         for index, arg in enumerate(clt.arguments):
             if isinstance(arg, str):
                 expression = get_expression(arg, inputs, None)
@@ -1365,58 +1528,71 @@ def traverse_CommandLineTool(
                     inp_id = f"_arguments_{index}"
                     etool_id = f"_expression_{step_id}{inp_id}"
                     target_type = "Any"
-                    target = cwl.WorkflowInputParameter(id=None, type_=target_type)
+                    target = cwl.WorkflowInputParameter(id="", type_=target_type)
                     replace_step_clt_expr_with_etool(
-                        expression, etool_id, parent, target, step, replace_etool
+                        expression,
+                        etool_id,
+                        parent,
+                        target,
+                        step,
+                        target_clt,
+                        replace_etool,
+                        context,
                     )
-                    target_clt.arguments[index] = (
+                    arguments[index] = (
                         cwl_utils.expression_refactor.get_command_line_binding(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             valueFrom=f"$(inputs.{inp_id})",
                         )
                     )
-                    target_clt.inputs.append(
+                    clt_inputs.append(
                         cwl_utils.expression_refactor.get_command_input_parameter(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             inp_id,
                             target_type,
                         )
                     )
-                    step.in_.append(
-                        cwl.WorkflowStepInput(
-                            f"{etool_id}/result", None, inp_id, None, None
-                        )
+                    step_inputs.append(
+                        cwl.WorkflowStepInput(id=f"{etool_id}/result", source=inp_id)
                     )
                     cwl_utils.expression_refactor.remove_JSReq(
                         target_clt, skip_command_line1
                     )
-            elif isinstance(arg, cwl.CommandLineBinding) and arg.valueFrom:
+            elif isinstance(arg, cwl_utils.parser.CommandLineBinding) and arg.valueFrom:
                 expression = get_expression(arg.valueFrom, inputs, None)
                 if expression:
                     modified = True
                     inp_id = f"_arguments_{index}"
                     etool_id = f"_expression_{step_id}{inp_id}"
                     target_type = "Any"
-                    target = cwl.WorkflowInputParameter(id=None, type_=target_type)
+                    target = cwl.WorkflowInputParameter(id="", type_=target_type)
                     replace_step_clt_expr_with_etool(
-                        expression, etool_id, parent, target, step, replace_etool
+                        expression,
+                        etool_id,
+                        parent,
+                        target,
+                        step,
+                        target_clt,
+                        replace_etool,
+                        context,
                     )
-                    target_clt.arguments[index].valueFrom = "$(inputs.{})".format(
-                        inp_id
-                    )
-                    target_clt.inputs.append(
+                    cast(
+                        cwl_utils.parser.CommandLineBinding, arguments[index]
+                    ).valueFrom = "$(inputs.{})".format(inp_id)
+                    clt_inputs.append(
                         cwl_utils.expression_refactor.get_command_input_parameter(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             inp_id,
                             target_type,
                         )
                     )
-                    step.in_.append(
-                        cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
+                    step_inputs.append(
+                        cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result"),
                     )
                     cwl_utils.expression_refactor.remove_JSReq(
                         target_clt, skip_command_line1
                     )
+        target_clt.arguments = arguments
     for streamtype in "stdout", "stderr":  # add 'stdin' for v1.1 version
         stream_value = getattr(clt, streamtype)
         if stream_value:
@@ -1426,25 +1602,34 @@ def traverse_CommandLineTool(
                 inp_id = f"_{streamtype}"
                 etool_id = f"_expression_{step_id}{inp_id}"
                 target_type = "string"
-                target = cwl.WorkflowInputParameter(id=None, type_=target_type)
+                target = cwl.WorkflowInputParameter(id="", type_=target_type)
                 replace_step_clt_expr_with_etool(
-                    expression, etool_id, parent, target, step, replace_etool
+                    expression,
+                    etool_id,
+                    parent,
+                    target,
+                    step,
+                    target_clt,
+                    replace_etool,
+                    context,
                 )
                 setattr(target_clt, streamtype, f"$(inputs.{inp_id})")
-                target_clt.inputs.append(
+                clt_inputs.append(
                     cwl_utils.expression_refactor.get_command_input_parameter(
                         target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                         inp_id,
                         target_type,
                     )
                 )
-                step.in_.append(
+                step_inputs.append(
                     cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
                 )
     for inp in clt.inputs:
         if not skip_command_line1 and inp.inputBinding and inp.inputBinding.valueFrom:
             expression = get_expression(
-                inp.inputBinding.valueFrom, inputs, example_input(inp.type_)
+                inp.inputBinding.valueFrom,
+                inputs,
+                cwl_utils.expression_refactor.example_input(inp.type_),
             )
             if expression:
                 modified = True
@@ -1452,17 +1637,27 @@ def traverse_CommandLineTool(
                 inp_id = f"_{self_id}_valueFrom"
                 etool_id = f"_expression_{step_id}{inp_id}"
                 replace_step_clt_expr_with_etool(
-                    expression, etool_id, parent, inp, step, replace_etool, self_id
+                    expression,
+                    etool_id,
+                    parent,
+                    inp,
+                    step,
+                    target_clt,
+                    replace_etool,
+                    context,
+                    self_id,
                 )
                 inp.inputBinding.valueFrom = f"$(inputs.{inp_id})"
-                target_clt.inputs.append(
+                clt_inputs.append(
                     cwl_utils.expression_refactor.get_command_input_parameter(
                         target_clt.cwlVersion or _DEFAULT_CWL_VERSION, inp_id, inp.type_
                     )
                 )
-                step.in_.append(
+                step_inputs.append(
                     cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
                 )
+    target_clt.inputs = [*target_clt.inputs, *clt_inputs]
+    step.in_ = [*step.in_, *step_inputs]
     for outp in clt.outputs:
         if outp.outputBinding:
             if outp.outputBinding.glob:
@@ -1471,20 +1666,29 @@ def traverse_CommandLineTool(
                     modified = True
                     inp_id = "_{}_glob".format(outp.id.split("#")[-1])
                     etool_id = f"_expression_{step_id}{inp_id}"
-                    glob_target_type = ["string", ArraySchema("string", "array")]
-                    target = cwl.WorkflowInputParameter(id=None, type_=glob_target_type)
+                    glob_target_type: list[str | cwl.InputArraySchema] = [
+                        "string",
+                        cwl.InputArraySchema(items="string", type_="array"),
+                    ]
+                    target = cwl.WorkflowInputParameter(id="", type_=glob_target_type)
                     replace_step_clt_expr_with_etool(
-                        expression, etool_id, parent, target, step, replace_etool
+                        expression,
+                        etool_id,
+                        parent,
+                        target,
+                        step,
+                        replace_etool,
+                        context,
                     )
                     outp.outputBinding.glob = f"$(inputs.{inp_id})"
-                    target_clt.inputs.append(
+                    clt_inputs.append(
                         cwl_utils.expression_refactor.get_command_input_parameter(
                             target_clt.cwlVersion or _DEFAULT_CWL_VERSION,
                             inp_id,
                             glob_target_type,
                         )
                     )
-                    step.in_.append(
+                    step_inputs.append(
                         cwl.WorkflowStepInput(id=inp_id, source=f"{etool_id}/result")
                     )
             if outp.outputBinding.outputEval and not skip_command_line2:
@@ -1507,27 +1711,28 @@ def traverse_CommandLineTool(
                     inp_id = f"_{outp_id}_outputEval"
                     etool_id = f"expression{inp_id}"
                     sub_wf_outputs = cltool_step_outputs_to_workflow_outputs(
-                        step, etool_id, outp_id
+                        step, target_clt, etool_id, outp_id
                     )
                     self_type = cwl.WorkflowInputParameter(
-                        id=None,
+                        id="",
                         type_=cwl.InputArraySchema("File", "array", None, None),
                     )
                     etool = generate_etool_from_expr(
                         expression, outp, False, self_type, [clt, step, parent]
                     )
                     if outp.outputBinding.loadContents:
-                        etool.inputs[0].type_.inputBinding = (
+                        etool.inputs[0].inputBinding = (
                             cwl_utils.expression_refactor.get_command_line_binding(
                                 etool.cwlVersion or _DEFAULT_CWL_VERSION,
                                 loadContents=True,
                             )
                         )
-                    etool.inputs.extend(
-                        cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
+                    etool.inputs = [
+                        *etool.inputs,
+                        *cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
                             clt, _DEFAULT_CWL_VERSION
-                        )
-                    )
+                        ),
+                    ]
                     sub_wf_inputs = (
                         cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
                             clt, _DEFAULT_CWL_VERSION
@@ -1536,19 +1741,21 @@ def traverse_CommandLineTool(
                     orig_step_inputs = copy.deepcopy(step.in_)
                     for orig_step_input in orig_step_inputs:
                         orig_step_input.id = orig_step_input.id.split("/")[-1]
-                        if isinstance(orig_step_input.source, MutableSequence):
-                            for index, source in enumerate(orig_step_input.source):
-                                orig_step_input.source[index] = source.split("#")[-1]
+                        if is_sequence(orig_step_input.source):
+                            orig_step_input.source = [
+                                source.split("#")[-1]
+                                for source in orig_step_input.source
+                            ]
                         else:
                             orig_step_input.source = orig_step_input.source.split("#")[
                                 -1
                             ]
-                    orig_step_inputs[:] = [
+                    orig_step_inputs = [
                         x for x in orig_step_inputs if not x.id.startswith("_")
                     ]
-                    for inp in orig_step_inputs:
-                        inp.source = inp.id
-                        inp.linkMerge = None
+                    for inp2 in orig_step_inputs:
+                        inp2.source = inp2.id
+                        inp2.linkMerge = None
                     final_etool: (
                         cwl_utils.parser.CommandLineTool
                         | cwl_utils.parser.ExpressionTool
@@ -1572,25 +1779,25 @@ def traverse_CommandLineTool(
                         step
                     )  # a deepcopy would be convenient, but params2.cwl gives it problems
                     new_clt_step.id = new_clt_step.id.split("#")[-1]
-                    new_clt_step.run = copy.copy(step.run)
-                    new_clt_step.run.id = None
+                    new_clt = copy.copy(target_clt)
+                    new_clt.id = ""
                     cwl_utils.expression_refactor.remove_JSReq(
-                        new_clt_step.run, skip_command_line1
+                        new_clt, skip_command_line1
                     )
                     cwl_utils.expression_refactor.process_CommandLineTool_output(
-                        new_clt_step.run, _DEFAULT_CWL_VERSION, outp_id
+                        new_clt, _DEFAULT_CWL_VERSION, outp_id
                     )
                     new_clt_step.in_ = copy.deepcopy(step.in_)
-                    for inp in new_clt_step.in_:
-                        inp.id = inp.id.split("/")[-1]
-                        inp.source = inp.id
-                        inp.linkMerge = None
-                    for index, out in enumerate(new_clt_step.out):
-                        new_clt_step.out[index] = out.split("/")[-1]
-                    for tool_inp in new_clt_step.run.inputs:
+                    for inp3 in new_clt_step.in_:
+                        inp3.id = inp3.id.split("/")[-1]
+                        inp3.source = inp3.id
+                        inp3.linkMerge = None
+                    new_clt_step.out = [out.split("/")[-1] for out in new_clt_step.out]
+                    for tool_inp in new_clt.inputs:
                         tool_inp.id = tool_inp.id.split("#")[-1]
-                    for tool_out in new_clt_step.run.outputs:
+                    for tool_out in new_clt.outputs:
                         tool_out.id = tool_out.id.split("#")[-1]
+                    new_clt_step.run = new_clt
                     sub_wf_steps = [new_clt_step, etool_step]
                     sub_workflow = cwl.Workflow(
                         inputs=sub_wf_inputs,
@@ -1617,9 +1824,10 @@ def traverse_CommandLineTool(
                             if isinstance(req, cwl.SubworkflowFeatureRequirement):
                                 has_sub_wf_req = True
                         if not has_sub_wf_req:
-                            parent.requirements.append(
-                                cwl.SubworkflowFeatureRequirement()
-                            )
+                            parent.requirements = [
+                                *parent.requirements,
+                                cwl.SubworkflowFeatureRequirement(),
+                            ]
     return modified
 
 
@@ -1648,9 +1856,10 @@ def rename_step_source(workflow: cwl.Workflow, old: str, new: str) -> None:
                         if source_id == old:
                             inp.source = new
                     else:
-                        for index, source in enumerate(inp.source):
-                            if simplify_step_id(source) == old:
-                                inp.source[index] = new
+                        inp.source = [
+                            new if simplify_step_id(source) == old else source
+                            for source in inp.source
+                        ]
 
 
 def replace_step_clt_expr_with_etool(
@@ -1659,12 +1868,14 @@ def replace_step_clt_expr_with_etool(
     workflow: cwl.Workflow,
     target: cwl.WorkflowInputParameter,
     step: cwl.WorkflowStep,
+    clt: cwl_utils.parser.CommandLineTool,
     replace_etool: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
     self_name: str | None = None,
 ) -> None:
     """Convert a step level CWL Expression to a sibling expression step."""
     etool_inputs = cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
-        step.run, _DEFAULT_CWL_VERSION
+        clt, _DEFAULT_CWL_VERSION
     )
     temp_etool = cwl_utils.expression_refactor.generate_etool_from_expr2(
         expr,
@@ -1672,7 +1883,7 @@ def replace_step_clt_expr_with_etool(
         target,
         etool_inputs,
         self_name,
-        step.run,
+        clt,
         [workflow],
     )
     etool: cwl_utils.parser.CommandLineTool | cwl_utils.parser.ExpressionTool
@@ -1688,15 +1899,21 @@ def replace_step_clt_expr_with_etool(
     wf_step_inputs = copy.deepcopy(step.in_)
     for wf_step_input in wf_step_inputs:
         wf_step_input.id = wf_step_input.id.split("/")[-1]
-    wf_step_inputs[:] = [x for x in wf_step_inputs if not x.id.startswith("_")]
-    workflow.steps.append(
+    wf_step_inputs = [x for x in wf_step_inputs if not x.id.startswith("_")]
+    if isinstance(step.run, str):
+        context[get_step_uri(step)] = (etool, True)
+        step_run = step.run
+    else:
+        step_run = cast(cwl.Process, etool)
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=wf_step_inputs,
             out=[cwl.WorkflowStepOutput("result")],
-            run=etool,
-        )
-    )
+            run=step_run,
+        ),
+    ]
 
 
 def replace_clt_hintreq_expr_with_etool(
@@ -1705,21 +1922,29 @@ def replace_clt_hintreq_expr_with_etool(
     workflow: cwl.Workflow,
     target: cwl.WorkflowInputParameter,
     step: cwl.WorkflowStep,
+    process: cwl_utils.parser.Process,
     replace_etool: bool,
     self_name: str | None = None,
 ) -> None:
     """Factor out an expression inside a CommandLineTool req or hint into a sibling step."""
     # Same as replace_step_clt_expr_with_etool or different?
-    etool_inputs = cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
-        step.run, _DEFAULT_CWL_VERSION
-    )
+    if isinstance(process, cwl_utils.parser.CommandLineTool):
+        etool_inputs = cwl_utils.expression_refactor.cltool_inputs_to_etool_inputs(
+            process, _DEFAULT_CWL_VERSION
+        )
+    elif isinstance(process, cwl_utils.parser.Operation):
+        etool_inputs = cwl_utils.expression_refactor.otool_inputs_to_etool_inputs(
+            process, _DEFAULT_CWL_VERSION
+        )
+    else:
+        etool_inputs = copy.deepcopy(process.inputs)
     temp_etool = cwl_utils.expression_refactor.generate_etool_from_expr2(
         expr,
         _DEFAULT_CWL_VERSION,
         target,
         etool_inputs,
         self_name,
-        step.run,
+        process,
         [workflow],
     )
     etool: cwl_utils.parser.CommandLineTool | cwl_utils.parser.ExpressionTool
@@ -1735,22 +1960,23 @@ def replace_clt_hintreq_expr_with_etool(
     wf_step_inputs = copy.deepcopy(step.in_)
     for wf_step_input in wf_step_inputs:
         wf_step_input.id = wf_step_input.id.split("/")[-1]
-    wf_step_inputs[:] = [x for x in wf_step_inputs if not x.id.startswith("_")]
-    workflow.steps.append(
+    wf_step_inputs = [x for x in wf_step_inputs if not x.id.startswith("_")]
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=wf_step_inputs,
             out=[cwl.WorkflowStepOutput("result")],
             run=etool,
-        )
-    )
+        ),
+    ]
 
 
 def cltool_inputs_to_etool_inputs(
     tool: cwl.CommandLineTool,
 ) -> list[cwl.WorkflowInputParameter]:
     """Copy CommandLineTool input objects into the equivalent ExpressionTool input objects."""
-    inputs = yaml.comments.CommentedSeq()
+    inputs: list[cwl.WorkflowInputParameter] = []
     if tool.inputs:
         for clt_inp in tool.inputs:
             clt_inp_id = clt_inp.id.split("#")[-1].split("/")[-1]
@@ -1764,7 +1990,7 @@ def cltool_inputs_to_etool_inputs(
                         doc=clt_inp.doc,
                         format=clt_inp.format,
                         default=clt_inp.default,
-                        type_=clt_inp.type_,
+                        type_=clt_input_schema_to_plain_input_schema(clt_inp.type_),
                         extension_fields=clt_inp.extension_fields,
                         loadingOptions=clt_inp.loadingOptions,
                     )
@@ -1772,8 +1998,37 @@ def cltool_inputs_to_etool_inputs(
     return inputs
 
 
+def otool_inputs_to_etool_inputs(
+    tool: cwl.Operation,
+) -> list[cwl.WorkflowInputParameter]:
+    """Copy CommandLineTool input objects into the equivalent ExpressionTool input objects."""
+    inputs: list[cwl.WorkflowInputParameter] = []
+    if tool.inputs:
+        for op_inp in tool.inputs:
+            clt_inp_id = op_inp.id.split("#")[-1].split("/")[-1]
+            if not clt_inp_id.startswith("_"):
+                inputs.append(
+                    cwl.WorkflowInputParameter(
+                        id=clt_inp_id,
+                        label=op_inp.label,
+                        secondaryFiles=op_inp.secondaryFiles,
+                        streamable=op_inp.streamable,
+                        doc=op_inp.doc,
+                        format=op_inp.format,
+                        default=op_inp.default,
+                        type_=op_inp.type_,
+                        extension_fields=op_inp.extension_fields,
+                        loadingOptions=op_inp.loadingOptions,
+                    )
+                )
+    return inputs
+
+
 def cltool_step_outputs_to_workflow_outputs(
-    cltool_step: cwl.WorkflowStep, etool_step_id: str, etool_out_id: str
+    cltool_step: cwl.WorkflowStep,
+    cltool: cwl_utils.parser.CommandLineTool,
+    etool_step_id: str,
+    etool_out_id: str,
 ) -> list[cwl.OutputParameter]:
     """
     Copy CommandLineTool outputs into the equivalent Workflow output parameters.
@@ -1785,8 +2040,8 @@ def cltool_step_outputs_to_workflow_outputs(
     if not cltool_step.id:
         raise WorkflowException(f"Missing step id from {cltool_step}.")
     default_step_id = cltool_step.id.split("#")[-1]
-    if cltool_step.run.outputs:
-        for clt_out in cltool_step.run.outputs:
+    if cltool.outputs:
+        for clt_out in cltool.outputs:
             clt_out_id = clt_out.id.split("#")[-1].split("/")[-1]
             if clt_out_id == etool_out_id:
                 outputSource = f"{etool_step_id}/result"
@@ -1817,18 +2072,14 @@ def generate_etool_from_expr2(
         | cwl.WorkflowInputParameter
         | cwl.OperationInputParameter
     ),
-    inputs: Sequence[
-        cwl.CommandInputParameter
-        | cwl.CommandOutputParameter
-        | cwl.WorkflowInputParameter
-    ],
+    inputs: Sequence[cwl.WorkflowInputParameter],
     expression_lib: list[str] | None,
-    hints: Sequence[Any],
+    hints: Sequence[Any | cwl.ProcessRequirement],
     requirements: Sequence[cwl.ProcessRequirement],
     self_name: str | None = None,
 ) -> cwl.ExpressionTool:
     """Generate an ExpressionTool to achieve the same result as the given expression."""
-    outputs = yaml.comments.CommentedSeq()
+    outputs: list[cwl.ExpressionToolOutputParameter] = []
     outputs.append(
         cwl.ExpressionToolOutputParameter(
             id="result",
@@ -1836,8 +2087,16 @@ def generate_etool_from_expr2(
             secondaryFiles=target.secondaryFiles,
             streamable=target.streamable,
             doc=target.doc,
-            format=target.format,
-            type_=target.type_,
+            format=(
+                "\n".join(target.format)
+                if is_sequence(target.format)
+                else target.format
+            ),
+            type_=(
+                clt_output_schema_to_plain_output_schema(
+                    cast(cwl.CommandOutputParameterType, target.type_)
+                )
+            ),
         )
     )
     expression = "${"
@@ -1857,6 +2116,7 @@ def generate_etool_from_expr2(
         expression=expression,
         requirements=[cwl.InlineJavascriptRequirement(expression_lib)]
         + [r for r in requirements],
+        hints=hints,
         cwlVersion=_DEFAULT_CWL_VERSION,
     )
 
@@ -1864,29 +2124,31 @@ def generate_etool_from_expr2(
 def traverse_step(
     step: cwl.WorkflowStep,
     parent: cwl.Workflow,
+    process: cwl_utils.parser.Process,
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> bool:
     """Process the given WorkflowStep."""
     modified = False
-    inputs = empty_inputs(step, parent)
+    inputs = cwl_utils.expression_refactor.empty_inputs(step, context, parent)
     if not step.id:
         return False
     step_id = step.id.split("#")[-1]
-    original_process = copy.deepcopy(step.run)
+    original_process = copy.deepcopy(process)
     original_step_ins = copy.deepcopy(step.in_)
     for inp in step.in_:
         if inp.valueFrom:
             if not inp.source:
                 self = None
             else:
-                if isinstance(inp.source, MutableSequence):
+                if is_sequence(inp.source):
                     self = []
                     for source in inp.source:
                         if not step.scatter:
                             self.append(
-                                example_input(
+                                cwl_utils.expression_refactor.example_input(
                                     utils.type_for_source(parent, source.split("#")[-1])
                                 )
                             )
@@ -1894,45 +2156,61 @@ def traverse_step(
                             scattered_source_type = utils.type_for_source(
                                 parent, source
                             )
-                            if isinstance(scattered_source_type, list):
+                            if is_sequence(scattered_source_type):
                                 for stype in scattered_source_type:
-                                    self.append(example_input(stype.type_))
+                                    self.append(
+                                        cwl_utils.expression_refactor.example_input(
+                                            stype.type_
+                                        )
+                                    )
                             else:
-                                self.append(example_input(scattered_source_type.type_))
+                                self.append(
+                                    cwl_utils.expression_refactor.example_input(
+                                        scattered_source_type.type_
+                                    )
+                                )
                 else:
                     if not step.scatter:
-                        self = example_input(
+                        self = cwl_utils.expression_refactor.example_input(
                             utils.type_for_source(parent, inp.source.split("#")[-1])
                         )
                     else:
                         scattered_source_type2 = utils.type_for_source(
                             parent, inp.source
                         )
-                        if isinstance(scattered_source_type2, list):
-                            self = example_input(scattered_source_type2[0].type_)
+                        if is_sequence(scattered_source_type2):
+                            self = cwl_utils.expression_refactor.example_input(
+                                scattered_source_type2[0].type_
+                            )
                         else:
-                            self = example_input(scattered_source_type2.type_)
+                            self = cwl_utils.expression_refactor.example_input(
+                                scattered_source_type2.type_
+                            )
             expression = get_expression(inp.valueFrom, inputs, self)
             if expression:
                 modified = True
                 etool_id = "_expression_{}_{}".format(step_id, inp.id.split("/")[-1])
                 target = cwl_utils.expression_refactor.get_input_for_id(
-                    inp.id, original_process
+                    inp.id, original_process, context
                 )
                 if not target:
                     raise WorkflowException("target not found")
                 input_source_id = None
                 if inp.source:
-                    if isinstance(inp.source, MutableSequence):
+                    if is_sequence(inp.source):
                         input_source_id = []
                         source_types: list[cwl.WorkflowInputParameter] = []
                         for source in inp.source:
                             source_id = source.split("#")[-1]
                             input_source_id.append(source_id)
-                            temp_type = utils.type_for_source(
-                                step.run, source_id, parent
+                            temp_type = cwl_utils.parser.utils.type_for_source(
+                                process,
+                                process.cwlVersion or _DEFAULT_CWL_VERSION,
+                                source_id,
+                                parent,
+                                loaded_steps={k: v[0] for k, v in context.items()},
                             )
-                            if isinstance(temp_type, list):
+                            if is_sequence(temp_type):
                                 for ttype in temp_type:
                                     if ttype not in source_types:
                                         source_types.append(ttype)
@@ -1943,7 +2221,7 @@ def traverse_step(
                         input_source_id = inp.source.split("#")[-1]
                 # target.id = target.id.split('#')[-1]
                 if isinstance(original_process, cwl_utils.parser.ExpressionTool):
-                    reqs: list[cwl.ProcessRequirement] = []
+                    reqs: list[cwl_utils.parser.ProcessRequirement] = []
                     if original_process.hints:
                         reqs.extend(original_process.hints)
                     if original_process.requirements:
@@ -1954,16 +2232,17 @@ def traverse_step(
                         ):
                             break
                     else:
-                        if not step.run.requirements:
-                            step.run.requirements = []
+                        if not process.requirements:
+                            process.requirements = []
                         expr_lib = cwl_utils.expression_refactor.find_expressionLib(
                             [parent]
                         )
-                        step.run.requirements.append(
+                        process.requirements = [
+                            *process.requirements,
                             cwl_utils.expression_refactor.get_inline_javascript_requirement(
-                                step.run, _DEFAULT_CWL_VERSION, expr_lib
-                            )
-                        )
+                                original_process, _DEFAULT_CWL_VERSION, expr_lib
+                            ),
+                        ]
                 replace_step_valueFrom_expr_with_etool(
                     expression,
                     etool_id,
@@ -1983,17 +2262,19 @@ def traverse_step(
         if expression:
             modified = True
             replace_step_when_expr_with_etool(
-                expression, parent, step, original_step_ins, replace_etool
+                expression, parent, step, original_step_ins, replace_etool, context
             )
 
     # TODO: skip or special process for sub workflows?
     process_modified = process_level_reqs(
         original_process,
         step,
+        process,
         parent,
         replace_etool,
         skip_command_line1,
         skip_command_line2,
+        context,
     )
     if process_modified:
         modified = True
@@ -2002,9 +2283,11 @@ def traverse_step(
             original_process,
             parent,
             step,
+            cast(cwl_utils.parser.CommandLineTool, process),
             replace_etool,
             skip_command_line1,
             skip_command_line2,
+            context,
         )
         if clt_modified:
             modified = True
@@ -2012,12 +2295,8 @@ def traverse_step(
 
 
 def workflow_step_to_WorkflowInputParameters(
-    step_ins: list[cwl.WorkflowStepInput], parent: cwl.Workflow, except_in_id: str
-) -> MutableSequence[
-    cwl_utils.parser.CommandInputParameter
-    | cwl_utils.parser.CommandOutputParameter
-    | cwl_utils.parser.WorkflowInputParameter
-]:
+    step_ins: Sequence[cwl.WorkflowStepInput], parent: cwl.Workflow, except_in_id: str
+) -> list[cwl_utils.parser.WorkflowInputParameter]:
     """Create WorkflowInputParameters to match the given WorkflowStep inputs."""
     params = []
     for inp in step_ins:
@@ -2026,7 +2305,7 @@ def workflow_step_to_WorkflowInputParameters(
         inp_id = inp.id.split("#")[-1].split("/")[-1]
         if inp.source and inp_id != except_in_id:
             param = copy.deepcopy(param_for_source_id(parent, sourcenames=inp.source))
-            if isinstance(param, MutableSequence):
+            if is_sequence(param):
                 for p in param:
                     p.id = inp_id
                     p.type_ = clean_type_ids(
@@ -2054,7 +2333,7 @@ def replace_step_valueFrom_expr_with_etool(
     step: cwl.WorkflowStep,
     step_inp: cwl.WorkflowStepInput,
     original_process: cwl_utils.parser.Process,
-    original_step_ins: list[cwl.WorkflowStepInput],
+    original_step_ins: Sequence[cwl.WorkflowStepInput],
     source: str | list[str] | None,
     replace_etool: bool,
 ) -> None:
@@ -2103,12 +2382,13 @@ def replace_step_valueFrom_expr_with_etool(
         if wf_step_input.valueFrom:
             wf_step_input.valueFrom = None
         if wf_step_input.source:
-            if isinstance(wf_step_input.source, MutableSequence):
-                for index, inp_source in enumerate(wf_step_input.source):
-                    wf_step_input.source[index] = inp_source.split("#")[-1]
+            if is_sequence(wf_step_input.source):
+                wf_step_input.source = [
+                    inp_source.split("#")[-1] for inp_source in wf_step_input.source
+                ]
             else:
                 wf_step_input.source = wf_step_input.source.split("#")[-1]
-    wf_step_inputs[:] = [
+    wf_step_inputs = [
         x
         for x in wf_step_inputs
         if x.id and not (x.id.startswith("_") or x.id.endswith(step_inp_id))
@@ -2116,15 +2396,15 @@ def replace_step_valueFrom_expr_with_etool(
     scatter = copy.deepcopy(step.scatter)
     if isinstance(scatter, str):
         scatter = [scatter]
-    if isinstance(scatter, MutableSequence):
-        for index, entry in enumerate(scatter):
-            scatter[index] = entry.split("/")[-1]
+    if is_sequence(scatter):
+        scatter = [entry.split("/")[-1] for entry in scatter]
     if scatter and step_inp_id in scatter:
         scatter = ["self"]
     # do we still need to scatter?
     else:
         scatter = None
-    workflow.steps.append(
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=name,
             in_=wf_step_inputs,
@@ -2132,16 +2412,17 @@ def replace_step_valueFrom_expr_with_etool(
             run=etool,
             scatter=scatter,
             scatterMethod=step.scatterMethod,
-        )
-    )
+        ),
+    ]
 
 
 def replace_step_when_expr_with_etool(
     expr: str,
     workflow: cwl.Workflow,
     step: cwl.WorkflowStep,
-    original_step_ins: list[cwl.WorkflowStepInput],
+    original_step_ins: Sequence[cwl.WorkflowStepInput],
     replace_etool: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> None:
     """Replace a WorkflowStep level 'when' expression with a sibling ExpressionTool step."""
     if not step.id:
@@ -2153,7 +2434,7 @@ def replace_step_when_expr_with_etool(
     temp_etool = cwl_utils.expression_refactor.generate_etool_from_expr2(
         expr,
         _DEFAULT_CWL_VERSION,
-        cwl.WorkflowInputParameter(id=None, type_="boolean"),
+        cwl.WorkflowInputParameter(id="", type_="boolean"),
         etool_inputs,
         None,
         None,
@@ -2180,31 +2461,40 @@ def replace_step_when_expr_with_etool(
             continue
         wf_step_input.id = wf_step_input.id.split("/")[-1]
         if wf_step_input.source:
-            if isinstance(wf_step_input.source, MutableSequence):
-                for index, inp_source in enumerate(wf_step_input.source):
-                    wf_step_input.source[index] = inp_source.split("#")[-1]
+            if is_sequence(wf_step_input.source):
+                wf_step_input.source = [
+                    inp_source.split("#")[-1] for inp_source in wf_step_input.source
+                ]
             else:
                 wf_step_input.source = wf_step_input.source.split("#")[-1]
-    wf_step_inputs[:] = [x for x in wf_step_inputs if x.id and not x.id.startswith("_")]
+    wf_step_inputs = [x for x in wf_step_inputs if x.id and not x.id.startswith("_")]
     scatter = copy.deepcopy(step.scatter)
     if isinstance(scatter, str):
         scatter = [scatter]
-    if isinstance(scatter, MutableSequence):
-        for index, entry in enumerate(scatter):
-            scatter[index] = entry.split("/")[-1]
+    if is_sequence(scatter):
+        scatter = [entry.split("/")[-1] for entry in scatter]
     scatter = step.scatter
-    workflow.steps.append(
+    if isinstance(step.run, str):
+        context[get_step_uri(step)] = (etool, True)
+        step_run: str | cwl.Process = step.run
+    else:
+        step_run = cast(cwl.Process, etool)
+    workflow.steps = [
+        *workflow.steps,
         cwl.WorkflowStep(
             id=etool_id,
             in_=wf_step_inputs,
             out=[cwl.WorkflowStepOutput("result")],
-            run=etool,
+            run=step_run,
             scatter=scatter,
             scatterMethod=step.scatterMethod,
-        )
-    )
+        ),
+    ]
     step.when = "$(inputs._when)"
-    step.in_.append(cwl.WorkflowStepInput(id="_when", source=f"{etool_id}/result"))
+    step.in_ = [
+        *step.in_,
+        cwl.WorkflowStepInput(id="_when", source=f"{etool_id}/result"),
+    ]
 
 
 def traverse_workflow(
@@ -2212,32 +2502,41 @@ def traverse_workflow(
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
+    context: dict[str, tuple[cwl_utils.parser.Process, bool]],
 ) -> tuple[cwl.Workflow, bool]:
     """Traverse a workflow, processing each step."""
+    processes: list[cwl_utils.parser.Process] = []
     modified = False
     for index, step in enumerate(workflow.steps):
         if isinstance(step.run, cwl.ExpressionTool) and replace_etool:
             workflow.steps[index].run = etool_to_cltool(step.run)
             modified = True
         else:
-            step_modified = cwl_utils.expression_refactor.load_step(
-                step, replace_etool, skip_command_line1, skip_command_line2
+            process, step_modified = cwl_utils.expression_refactor.load_step(
+                step, replace_etool, skip_command_line1, skip_command_line2, context
             )
+            processes.append(process)
             if step_modified:
                 modified = True
-    for step in workflow.steps:
+    for index, step in enumerate(workflow.steps):
         if not step.id.startswith("_expression"):
             step_modified = traverse_step(
-                step, workflow, replace_etool, skip_command_line1, skip_command_line2
+                step,
+                workflow,
+                processes[index],
+                replace_etool,
+                skip_command_line1,
+                skip_command_line2,
+                context,
             )
             if step_modified:
                 modified = True
-    if process_workflow_inputs_and_outputs(workflow, replace_etool):
+    if process_workflow_inputs_and_outputs(workflow, replace_etool, context):
         modified = True
-    if process_workflow_reqs_and_hints(workflow, replace_etool):
+    if process_workflow_reqs_and_hints(workflow, replace_etool, context):
         modified = True
     if workflow.requirements:
-        workflow.requirements[:] = [
+        workflow.requirements = [
             x
             for x in workflow.requirements
             if not isinstance(

--- a/src/cwl_utils/docker_extract.py
+++ b/src/cwl_utils/docker_extract.py
@@ -102,7 +102,9 @@ def extract_docker_requirements(
         yield req
 
 
-def extract_docker_reqs(process: cwl.Process) -> Iterator[cwl.DockerRequirement]:
+def extract_docker_reqs(
+    process: cwl.Process | cwl.WorkflowStep,
+) -> Iterator[cwl.DockerRequirement]:
     """For the given process, extract the DockerRequirement(s)."""
     if process.requirements:
         for req in process.requirements:

--- a/src/cwl_utils/expression_refactor.py
+++ b/src/cwl_utils/expression_refactor.py
@@ -9,6 +9,7 @@ import logging
 import shutil
 import sys
 from collections.abc import MutableMapping, MutableSequence, Sequence
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Protocol, cast, Literal, overload
 
@@ -33,7 +34,6 @@ from cwl_utils.parser import (
     OperationInputParameter,
     CommandInputParameter,
     Workflow,
-    CommandOutputParameter,
     ExpressionTool,
     InitialWorkDirRequirement,
     InlineJavascriptRequirement,
@@ -41,7 +41,13 @@ from cwl_utils.parser import (
     CommandLineTool,
     load_document_by_uri,
     CommandLineBinding,
+    CWLVersion,
+    AbstractProcess,
+    Operation,
 )
+from cwl_utils.parser.utils import type_for_source
+from cwl_utils.types import CWLFileType, CWLDirectoryType
+from cwl_utils.utils import get_step_uri
 
 _logger = logging.getLogger("cwl-expression-refactor")  # pylint: disable=invalid-name
 defaultStreamHandler = logging.StreamHandler()  # pylint: disable=invalid-name
@@ -107,7 +113,7 @@ def parse_args(args: list[str]) -> argparse.Namespace:
 
 def add_input_to_process(
     process: Process,
-    cwlVersion: Literal["v1.0", "v1.1", "v1.2"],
+    cwlVersion: CWLVersion,
     name: str,
     inptype: Any,
     loadingOptions: LoadingOptions,
@@ -132,7 +138,7 @@ def add_input_to_process(
 
 
 def cltool_inputs_to_etool_inputs(
-    tool: CommandLineTool, cwlVersion: Literal["v1.0", "v1.1", "v1.2"]
+    tool: CommandLineTool, cwlVersion: CWLVersion
 ) -> Sequence[WorkflowInputParameter]:
     match tool.cwlVersion or cwlVersion:
         case "v1.0":
@@ -155,58 +161,41 @@ def cltool_inputs_to_etool_inputs(
 
 def empty_inputs(
     process_or_step: Process | WorkflowStep,
-    cwlVersion: Literal["v1.0", "v1.1", "v1.2"],
+    context: dict[str, tuple[Process, bool]],
     parent: Workflow | None = None,
 ) -> dict[str, Any]:
-    cwlVersion = (
-        process_or_step.cwlVersion
-        if isinstance(process_or_step, Process) and process_or_step.cwlVersion
-        else cwlVersion
-    )
-    match cwlVersion:
-        case "v1.0":
-            return cwl_v1_0_expression_refactor.empty_inputs(
-                cast(
-                    cwl_v1_0.CommandLineTool
-                    | cwl_v1_0.WorkflowStep
-                    | cwl_v1_0.ExpressionTool
-                    | cwl_v1_0.Workflow,
-                    process_or_step,
-                ),
-                cast(cwl_v1_0.Workflow, parent),
-            )
-        case "v1.1":
-            return cwl_v1_1_expression_refactor.empty_inputs(
-                cast(
-                    cwl_v1_1.CommandLineTool
-                    | cwl_v1_1.WorkflowStep
-                    | cwl_v1_1.ExpressionTool
-                    | cwl_v1_1.Workflow,
-                    process_or_step,
-                ),
-                cast(cwl_v1_1.Workflow, parent),
-            )
-        case "v1.2":
-            return cwl_v1_2_expression_refactor.empty_inputs(
-                cast(
-                    cwl_v1_2.CommandLineTool
-                    | cwl_v1_2.WorkflowStep
-                    | cwl_v1_2.ExpressionTool
-                    | cwl_v1_2.Workflow
-                    | cwl_v1_2.Operation,
-                    process_or_step,
-                ),
-                cast(cwl_v1_2.Workflow, parent),
-            )
-        case _:
-            raise WorkflowException(
-                f"Sorry, {cwlVersion} is not a supported CWL version by this tool.",
-            )
+    """Produce a mock input object for the given inputs."""
+    result = {}
+    if isinstance(process_or_step, Process):
+        for param in process_or_step.inputs:
+            result[param.id.split("#")[-1]] = example_input(param.type_)
+    else:
+        for param1 in process_or_step.in_:
+            param_id = param1.id.split("/")[-1]
+            if param1.source is None and param1.valueFrom:
+                result[param_id] = example_input("string")
+            elif param1.source is None and param1.default:
+                result[param_id] = param1.default
+            elif param1.source is not None:
+                with suppress(WorkflowException):
+                    if isinstance(process_or_step.run, str):
+                        process = context[get_step_uri(process_or_step)][0]
+                    else:
+                        process = cast(Process, process_or_step.run)
+                    cwlVersion = (
+                        process.cwlVersion
+                        or (parent.cwlVersion if parent is not None else None)
+                        or "Undefined"
+                    )
+                    result[param_id] = example_input(
+                        type_for_source(process, cwlVersion, param1.source, parent)
+                    )
+    return result
 
 
 def etool_to_cltool(
     etool: ExpressionTool,
-    cwlVersion: Literal["v1.0", "v1.1", "v1.2"],
+    cwlVersion: CWLVersion,
     expressionLib: list[str] | None = None,
 ) -> CommandLineTool:
     cwlVersion = etool.cwlVersion if etool.cwlVersion is not None else cwlVersion
@@ -229,6 +218,50 @@ def etool_to_cltool(
             )
 
 
+def example_input(some_type: Any) -> Any:
+    """Produce a fake input for the given type."""
+    # TODO: accept some sort of context object with local custom type definitions
+    if some_type == "Directory":
+        return CWLDirectoryType(
+            **{
+                "class": "Directory",
+                "location": "https://www.example.com/example",
+                "basename": "example",
+                "listing": [
+                    CWLFileType(
+                        **{
+                            "class": "File",
+                            "basename": "example.txt",
+                            "size": 23,
+                            "contents": "hoopla",
+                            "nameroot": "example",
+                            "nameext": "txt",
+                        }
+                    )
+                ],
+            }
+        )
+    if some_type == "File":
+        return CWLFileType(
+            **{
+                "class": "File",
+                "location": "https://www.example.com/example.txt",
+                "basename": "example.txt",
+                "size": 23,
+                "contents": "hoopla",
+                "nameroot": "example",
+                "nameext": "txt",
+            }
+        )
+    if some_type == "int":
+        return 23
+    if some_type == "string":
+        return "hoopla!"
+    if some_type == "boolean":
+        return True
+    return None
+
+
 def find_expressionLib(
     processes: Sequence[Process | WorkflowStep],
 ) -> list[str] | None:
@@ -248,11 +281,9 @@ def find_expressionLib(
 
 def generate_etool_from_expr2(
     expr: str,
-    cwlVersion: Literal["v1.0", "v1.1", "v1.2"],
+    cwlVersion: CWLVersion,
     target: CommandInputParameter | WorkflowInputParameter | OperationInputParameter,
-    inputs: Sequence[
-        CommandInputParameter | CommandOutputParameter | WorkflowInputParameter
-    ],
+    inputs: Sequence[WorkflowInputParameter],
     self_name: str | None = None,
     process: Process | None = None,
     extra_processes: Sequence[Process | WorkflowStep] | None = None,
@@ -285,7 +316,7 @@ def generate_etool_from_expr2(
                 expr=expr,
                 target=cast(cwl_v1_0.InputParameter, target),
                 inputs=cast(
-                    Sequence[cwl_v1_0.InputParameter | cwl_v1_0.CommandOutputParameter],
+                    Sequence[cwl_v1_0.InputParameter],
                     inputs,
                 ),
                 expression_lib=find_expressionLib(procs),
@@ -301,11 +332,7 @@ def generate_etool_from_expr2(
                     target,
                 ),
                 inputs=cast(
-                    Sequence[
-                        cwl_v1_1.CommandInputParameter
-                        | cwl_v1_1.CommandOutputParameter
-                        | cwl_v1_1.WorkflowInputParameter
-                    ],
+                    Sequence[cwl_v1_1.WorkflowInputParameter],
                     inputs,
                 ),
                 expression_lib=find_expressionLib(procs),
@@ -323,11 +350,7 @@ def generate_etool_from_expr2(
                     target,
                 ),
                 inputs=cast(
-                    Sequence[
-                        cwl_v1_2.CommandInputParameter
-                        | cwl_v1_2.CommandOutputParameter
-                        | cwl_v1_2.WorkflowInputParameter
-                    ],
+                    Sequence[cwl_v1_2.WorkflowInputParameter],
                     inputs,
                 ),
                 expression_lib=find_expressionLib(procs),
@@ -360,7 +383,7 @@ def get_command_input_parameter(
 
 
 def get_command_input_parameter(
-    cwlVersion: Literal["v1.0", "v1.1", "v1.2"], id_: str, type_: Any
+    cwlVersion: CWLVersion, id_: str, type_: Any
 ) -> CommandInputParameter:
     match cwlVersion:
         case "v1.0":
@@ -400,7 +423,7 @@ def get_command_line_binding(
 
 
 def get_command_line_binding(
-    cwlVersion: Literal["v1.0", "v1.1", "v1.2"],
+    cwlVersion: CWLVersion,
     valueFrom: str | None = None,
     loadContents: bool | None = None,
 ) -> CommandLineBinding:
@@ -449,7 +472,7 @@ def get_inline_javascript_requirement(
 
 def get_inline_javascript_requirement(
     etool: ExpressionTool,
-    cwlVersion: Literal["v1.0", "v1.1", "v1.2"],
+    cwlVersion: CWLVersion,
     expression_lib: list[str] | None,
 ) -> InlineJavascriptRequirement:
     match etool.cwlVersion or cwlVersion:
@@ -472,7 +495,7 @@ def get_inline_javascript_requirement(
 
 
 def get_input_for_id(
-    name: str, tool: Process
+    name: str, tool: Process, context: dict[str, tuple[Process, bool]]
 ) -> CommandInputParameter | WorkflowInputParameter | OperationInputParameter | None:
     """Determine the CommandInputParameter for the given input name."""
     name = name.split("/")[-1]
@@ -487,7 +510,15 @@ def get_input_for_id(
         stepname, stem = name.split("/", 1)
         for step in tool.steps:
             if step.id == stepname:
-                result = get_input_for_id(stem, step.run)
+                if isinstance(step.run, str):
+                    inner_tool = context[get_step_uri(step)][0]
+                else:
+                    inner_tool = cast(Process, step.run)
+                result = get_input_for_id(
+                    stem,
+                    inner_tool,
+                    context,
+                )
                 if result:
                     return result
     return None
@@ -498,64 +529,77 @@ def load_step(
     replace_etool: bool,
     skip_command_line1: bool,
     skip_command_line2: bool,
-) -> bool:
+    context: dict[str, tuple[Process, bool]],
+) -> tuple[Process, bool]:
     """If the step's Process is not inline, load and process it."""
     modified = False
     if isinstance(step.run, str):
-        process = cast(
-            Process, load_document_by_uri(step.run, loadingOptions=step.loadingOptions)
-        )
-        # FIXME: with strong typing, it won't be possible to directly assign to step.run
-        match process.cwlVersion:
-            case "v1.0":
-                step.run, modified = cwl_v1_0_expression_refactor.traverse(
-                    cast(
-                        cwl_v1_0.CommandLineTool
-                        | cwl_v1_0.ExpressionTool
-                        | cwl_v1_0.Workflow,
+        if (uri := get_step_uri(step)) not in context:
+            process = cast(
+                AbstractProcess,
+                load_document_by_uri(path=uri, loadingOptions=step.loadingOptions),
+            )
+            if not isinstance(process, Process):
+                raise Exception(
+                    f"Unsupported process type: {process.__class__.__name__}"
+                )
+            match process.cwlVersion:
+                case "v1.0":
+                    process, modified = cwl_v1_0_expression_refactor.traverse(
                         process,
-                    ),
-                    replace_etool,
-                    True,
-                    skip_command_line1,
-                    skip_command_line2,
-                )
-            case "v1.1":
-                step.run, modified = cwl_v1_1_expression_refactor.traverse(
-                    cast(
-                        cwl_v1_1.CommandLineTool
-                        | cwl_v1_1.ExpressionTool
-                        | cwl_v1_1.Workflow,
+                        replace_etool,
+                        True,
+                        skip_command_line1,
+                        skip_command_line2,
+                        context,
+                    )
+                case "v1.1":
+                    process, modified = cwl_v1_1_expression_refactor.traverse(
                         process,
-                    ),
-                    replace_etool,
-                    True,
-                    skip_command_line1,
-                    skip_command_line2,
-                )
-            case "v1.2":
-                step.run, modified = cwl_v1_2_expression_refactor.traverse(
-                    cast(
-                        cwl_v1_2.CommandLineTool
-                        | cwl_v1_2.ExpressionTool
-                        | cwl_v1_2.Workflow
-                        | cwl_v1_2.Operation,
+                        replace_etool,
+                        True,
+                        skip_command_line1,
+                        skip_command_line2,
+                        context,
+                    )
+                case "v1.2":
+                    process, modified = cwl_v1_2_expression_refactor.traverse(
                         process,
-                    ),
-                    replace_etool,
-                    True,
-                    skip_command_line1,
-                    skip_command_line2,
-                )
-            case _:
-                raise WorkflowException(
-                    f"Sorry, {process.cwlVersion} is not a supported CWL version by this tool.",
-                )
-    return modified
+                        replace_etool,
+                        True,
+                        skip_command_line1,
+                        skip_command_line2,
+                        context,
+                    )
+                case _:
+                    raise WorkflowException(
+                        f"Sorry, {process.cwlVersion} is not a supported CWL version by this tool.",
+                    )
+            context[uri] = (process, modified)
+        return context[uri]
+    else:
+        process = step.run
+        if not isinstance(process, Process):
+            raise Exception(f"Unsupported process type: {process.__class__.__name__}")
+        return process, modified
+
+
+def otool_inputs_to_etool_inputs(
+    tool: Operation, cwlVersion: CWLVersion
+) -> Sequence[WorkflowInputParameter]:
+    match tool.cwlVersion or cwlVersion:
+        case "v1.2":
+            return cwl_v1_2_expression_refactor.otool_inputs_to_etool_inputs(
+                cast(cwl_v1_2.Operation, tool)
+            )
+        case _:
+            raise WorkflowException(
+                f"Sorry, {tool.cwlVersion or cwlVersion} is not a supported CWL version by this tool.",
+            )
 
 
 def process_CommandLineTool_output(
-    ctool: CommandLineTool, cwlVersion: Literal["v1.0", "v1.1", "v1.2"], outp_id: str
+    ctool: CommandLineTool, cwlVersion: CWLVersion, outp_id: str
 ) -> None:
     match ctool.cwlVersion or cwlVersion:
         case "v1.0":
@@ -577,14 +621,14 @@ def process_CommandLineTool_output(
 
 
 def remove_JSReq(
-    process: CommandLineTool | WorkflowStep | Workflow,
+    process: Process,
     skip_command_line1: bool,
 ) -> None:
     """Since the InlineJavascriptRequirement is longer needed, remove it."""
     if skip_command_line1 and isinstance(process, CommandLineTool):
         return
     if process.hints:
-        process.hints[:] = [
+        process.hints = [
             hint
             for hint in process.hints
             if not isinstance(hint, InlineJavascriptRequirement)
@@ -592,7 +636,7 @@ def remove_JSReq(
         if not process.hints:
             process.hints = None
     if process.requirements:
-        process.requirements[:] = [
+        process.requirements = [
             req
             for req in process.requirements
             if not isinstance(req, InlineJavascriptRequirement)
@@ -621,6 +665,7 @@ def refactor(args: argparse.Namespace) -> int:
         with open(document) as doc_handle:
             result = yaml.load(doc_handle)
         uri = Path(document).resolve().as_uri()
+        context = {}
         try:
             match result["cwlVersion"]:
                 case "v1.0":
@@ -630,6 +675,7 @@ def refactor(args: argparse.Namespace) -> int:
                         False,
                         args.skip_some1,
                         args.skip_some2,
+                        context,
                     )
                 case "v1.1":
                     result, modified = cwl_v1_1_expression_refactor.traverse(
@@ -638,6 +684,7 @@ def refactor(args: argparse.Namespace) -> int:
                         False,
                         args.skip_some1,
                         args.skip_some2,
+                        context,
                     )
                 case "v1.2":
                     result, modified = cwl_v1_2_expression_refactor.traverse(
@@ -646,6 +693,7 @@ def refactor(args: argparse.Namespace) -> int:
                         False,
                         args.skip_some1,
                         args.skip_some2,
+                        context,
                     )
                 case _:
                     _logger.error(
@@ -653,33 +701,35 @@ def refactor(args: argparse.Namespace) -> int:
                         result["cwlVersion"],
                     )
                     return -1
-            output = Path(args.dir) / Path(document).name
-            if not modified:
-                if len(args.inputs) > 1:
-                    shutil.copyfile(document, output)
-                    continue
+            if not modified and len(args.inputs) == 1:
+                return 7
+            context[document] = (result, modified)
+            for path, (process, modified) in context.items():
+                output = Path(args.dir) / Path(path).name
+                if not modified:
+                    if len(args.inputs) > 1:
+                        shutil.copyfile(path, output)
+                        continue
+                if not isinstance(process, MutableSequence):
+                    result_json = save(
+                        process,
+                        base_url=(process.loadingOptions.fileuri or ""),
+                    )
+                #   ^^ Setting the base_url and keeping the default value
+                #      for relative_uris=True means that the IDs in the generated
+                #      JSON/YAML are kept clean of the path to the input document
                 else:
-                    return 7
-            if not isinstance(result, MutableSequence):
-                result_json = save(
-                    result,
-                    base_url=(result.loadingOptions.fileuri or ""),
-                )
-            #   ^^ Setting the base_url and keeping the default value
-            #      for relative_uris=True means that the IDs in the generated
-            #      JSON/YAML are kept clean of the path to the input document
-            else:
-                result_json = [
-                    save(result_item, base_url=result_item.loadingOptions.fileuri)
-                    for result_item in result
-                ]
-            walk_tree(result_json)
-            # ^ converts multiline strings to nice multiline YAML
-            with output.open("w", encoding="utf-8") as output_filehandle:
-                output_filehandle.write(
-                    "#!/usr/bin/env cwl-runner\n"
-                )  # TODO: teach the codegen to do this?
-                yaml.dump(result_json, output_filehandle)
+                    result_json = [
+                        save(result_item, base_url=result_item.loadingOptions.fileuri)
+                        for result_item in process
+                    ]
+                walk_tree(result_json)
+                # ^ converts multiline strings to nice multiline YAML
+                with output.open("w", encoding="utf-8") as output_filehandle:
+                    output_filehandle.write(
+                        "#!/usr/bin/env cwl-runner\n"
+                    )  # TODO: teach the codegen to do this?
+                    yaml.dump(result_json, output_filehandle)
         except WorkflowException as exc:
             return_code = 1
             _logger.exception("Skipping %s due to error.", document, exc_info=exc)

--- a/src/cwl_utils/inputs_schema_gen.py
+++ b/src/cwl_utils/inputs_schema_gen.py
@@ -6,17 +6,20 @@
 """Generate JSON Schema from CWL inputs object."""
 
 import argparse
+import hashlib
 import json
 import logging
 import sys
+from collections.abc import Sequence
 from contextlib import suppress
 from copy import deepcopy
 from importlib.resources import files
 from pathlib import Path
-from typing import Any, TypeGuard
+from typing import Any, TypeGuard, TypeAlias, cast
 from urllib.parse import urlparse
 
 import requests
+from schema_salad.utils import json_dumps
 
 from cwl_utils.loghandler import _logger as _cwlutilslogger
 from cwl_utils.parser import (
@@ -33,7 +36,9 @@ from cwl_utils.parser import (
     cwl_v1_1,
     cwl_v1_2,
     load_document_by_uri,
+    SchemaDefRequirement,
 )
+from cwl_utils.types import is_sequence
 from cwl_utils.utils import (
     get_value_from_uri,
     is_local_uri,
@@ -62,7 +67,7 @@ PRIMITIVE_TYPES_MAPPING = {
 }
 
 # Some type hinting
-InputType = (
+InputType: TypeAlias = (
     InputArraySchema | InputEnumSchema | InputRecordSchema | str | File | Directory
 )
 
@@ -252,7 +257,11 @@ def generate_json_schema_property_from_input_parameter(
     """
     # Get the input name and documentation for description
     input_name = get_value_from_uri(str(input_parameter.id))
-    doc = input_parameter.doc
+    doc = (
+        "\n".join(input_parameter.doc)
+        if is_sequence(input_parameter.doc)
+        else input_parameter.doc
+    )
     required = get_is_required_from_input_parameter(input_parameter)
 
     return JSONSchemaProperty(
@@ -263,7 +272,9 @@ def generate_json_schema_property_from_input_parameter(
     )
 
 
-def generate_definition_from_schema(schema: InputRecordSchema) -> dict[str, Any]:
+def generate_definition_from_schema(
+    schema: InputRecordSchema | InputArraySchema | InputEnumSchema,
+) -> dict[str, Any]:
     """
     Given a schema, generate a JSON schema definition.
 
@@ -273,17 +284,18 @@ def generate_definition_from_schema(schema: InputRecordSchema) -> dict[str, Any]
     # Sanitise each field of the schema
     sanitised_fields = {}
 
-    if schema.fields is None:
-        return {}
+    if isinstance(schema, InputRecordSchema):
+        if schema.fields is None:
+            return {}
 
-    for field in schema.fields:
-        sanitised_fields.update(
-            {
-                get_value_from_uri(field.name): sanitise_schema_field(
-                    {"type": field.type_}
-                )
-            }
-        )
+        for field in schema.fields:
+            sanitised_fields.update(
+                {
+                    get_value_from_uri(field.name): sanitise_schema_field(
+                        {"type": field.type_}
+                    )
+                }
+            )
 
     # Generate JSON properties
     property_list = []
@@ -316,8 +328,18 @@ def generate_definition_from_schema(schema: InputRecordSchema) -> dict[str, Any]
         )
         property_list.append(prop)
 
+    if not isinstance(schema, cwl_v1_0.InputArraySchema) or hasattr(schema, "name"):
+        schema_name = to_pascal_case(get_value_from_uri(str(schema.name)))
+    else:
+        schema_name = (
+            "AnonymousInputArraySchema"
+            + hashlib.sha1(  # nosec
+                json_dumps(schema.save()).encode("utf-8")
+            ).hexdigest()
+        )
+
     return {
-        to_pascal_case(get_value_from_uri(str(schema.name))): {
+        schema_name: {
             "type": "object",
             "properties": {prop.name: prop.type_dict for prop in property_list},
             "required": [prop.name for prop in property_list if prop.required],
@@ -325,7 +347,7 @@ def generate_definition_from_schema(schema: InputRecordSchema) -> dict[str, Any]
     }
 
 
-def cwl_to_jsonschema(cwl_obj: Workflow | CommandLineTool) -> Any:
+def cwl_to_jsonschema(cwl_obj: Workflow | CommandLineTool) -> dict[str, object]:
     """
     cwl_obj: A CWL Object.
 
@@ -386,11 +408,9 @@ def cwl_to_jsonschema(cwl_obj: Workflow | CommandLineTool) -> Any:
 
         return input_record_schema
 
-    complex_schema_values: list[InputRecordSchema] = list(
-        map(
-            get_complex_schema_values,
-            complex_schema_keys,
-        )
+    complex_schema_values: map[InputRecordSchema] = map(
+        get_complex_schema_values,
+        complex_schema_keys,
     )
 
     # Load in all $imports to be referred by complex input types
@@ -403,20 +423,21 @@ def cwl_to_jsonschema(cwl_obj: Workflow | CommandLineTool) -> Any:
 
     if cwl_obj.requirements is not None:
         with suppress(StopIteration):
-            schema_def_requirement = next(
-                filter(
-                    lambda requirement_iter: requirement_iter.class_
-                    == "SchemaDefRequirement",
-                    cwl_obj.requirements,
-                )
+            schema_def_requirement = cast(
+                SchemaDefRequirement,
+                next(
+                    filter(
+                        lambda requirement_iter: requirement_iter.class_
+                        == "SchemaDefRequirement",
+                        cwl_obj.requirements,
+                    )
+                ),
             )
 
             workflow_schema_definitions_list.extend(
-                list(
-                    map(
-                        generate_definition_from_schema,
-                        schema_def_requirement.types,
-                    )
+                map(
+                    generate_definition_from_schema,
+                    schema_def_requirement.types,
                 )
             )
 
@@ -429,7 +450,7 @@ def cwl_to_jsonschema(cwl_obj: Workflow | CommandLineTool) -> Any:
     properties = list(
         map(
             generate_json_schema_property_from_input_parameter,
-            cwl_obj.inputs,
+            cast(Sequence[WorkflowInputParameter], cwl_obj.inputs),
         )
     )
 

--- a/src/cwl_utils/parser/__init__.py
+++ b/src/cwl_utils/parser/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 from abc import ABC
-from collections.abc import MutableMapping, MutableSequence
+from collections.abc import MutableMapping, MutableSequence, Sequence
 from pathlib import Path
 from typing import Any, TypeAlias, cast
 from urllib.parse import unquote_plus, urlparse
@@ -22,12 +22,20 @@ class NoType(ABC):
 
 LoadingOptions: TypeAlias = schema_salad.runtime.LoadingOptions
 """Type union for a CWL v1.x LoadingOptions object."""
+PrimitiveType: TypeAlias = schema_salad.metaschema.PrimitiveType
+"""Type union for a CWL v1.x PrimitiveType object."""
 Saveable: TypeAlias = schema_salad.runtime.Saveable
 """Type union for a CWL v1.x Saveable object."""
+InputParameterType: TypeAlias = (
+    cwl_v1_0.InputParameterType
+    | cwl_v1_1.InputParameterType
+    | cwl_v1_2.InputParameterType
+)
+"""Type union for a CWL v1.x InputParameterType object."""
 InputParameter: TypeAlias = (
     cwl_v1_0.InputParameter | cwl_v1_1.InputParameter | cwl_v1_2.InputParameter
 )
-"""Type union for a CWL v1.x InputEnumSchema object."""
+"""Type union for a CWL v1.x InputParameter object."""
 InputRecordField: TypeAlias = (
     cwl_v1_0.InputRecordField | cwl_v1_1.InputRecordField | cwl_v1_2.InputRecordField
 )
@@ -36,6 +44,12 @@ InputSchema: TypeAlias = (
     cwl_v1_0.InputSchema | cwl_v1_1.InputSchema | cwl_v1_2.InputSchema
 )
 """Type union for a CWL v1.x InputSchema object."""
+OutputParameterType: TypeAlias = (
+    cwl_v1_0.OutputParameterType
+    | cwl_v1_1.OutputParameterType
+    | cwl_v1_2.OutputParameterType
+)
+"""Type union for a CWL v1.x OutputParameterType object."""
 OutputParameter: TypeAlias = (
     cwl_v1_0.CommandOutputParameter
     | cwl_v1_0.ExpressionToolOutputParameter
@@ -100,6 +114,10 @@ WorkflowStep: TypeAlias = (
     cwl_v1_0.WorkflowStep | cwl_v1_1.WorkflowStep | cwl_v1_2.WorkflowStep
 )
 """Type union for a CWL v1.x WorkflowStep object."""
+ScatterMethod: TypeAlias = (
+    cwl_v1_0.ScatterMethod | cwl_v1_1.ScatterMethod | cwl_v1_2.ScatterMethod
+)
+"""Type union for a CWL v1.x ScatterMethod object."""
 ScatterWorkflowStep: TypeAlias = (
     cwl_v1_0.WorkflowStep | cwl_v1_1.WorkflowStep | cwl_v1_2.WorkflowStep
 )
@@ -144,18 +162,29 @@ CommandOutputBinding: TypeAlias = (
     | cwl_v1_2.CommandOutputBinding
 )
 """Type union for a CWL v1.x CommandOutputBinding object."""
+CommandInputParameterType: TypeAlias = (
+    cwl_v1_0.CommandInputParameterType
+    | cwl_v1_1.CommandInputParameterType
+    | cwl_v1_2.CommandInputParameterType
+)
+"""Type union for a CWL v1.x CommandInputParameterType object."""
 CommandInputParameter: TypeAlias = (
     cwl_v1_0.CommandInputParameter
     | cwl_v1_1.CommandInputParameter
     | cwl_v1_2.CommandInputParameter
 )
 """Type union for a CWL v1.x CommandInputParameter object."""
+CommandOutputParameterType: TypeAlias = (
+    cwl_v1_0.CommandOutputParameterType
+    | cwl_v1_1.CommandOutputParameterType
+    | cwl_v1_2.CommandOutputParameterType
+)
+"""Type union for a CWL v1.x CommandOutputParameterType object."""
 CommandOutputParameter: TypeAlias = (
     cwl_v1_0.CommandOutputParameter
     | cwl_v1_1.CommandOutputParameter
     | cwl_v1_2.CommandOutputParameter
 )
-
 """Type union for a CWL v1.x CommandOutputParameter object."""
 CommandOutputRecordField: TypeAlias = (
     cwl_v1_0.CommandOutputRecordField
@@ -193,8 +222,10 @@ DockerRequirementTypes = (
     cwl_v1_2.DockerRequirement,
 )
 """Type union for a CWL v1.x DockerRequirement object."""
-Process: TypeAlias = Workflow | CommandLineTool | ExpressionTool | cwl_v1_2.Operation
+AbstractProcess: TypeAlias = cwl_v1_0.Process | cwl_v1_1.Process | cwl_v1_2.Process
 """Type Union for a CWL v1.x Process object."""
+Process: TypeAlias = Workflow | CommandLineTool | ExpressionTool | cwl_v1_2.Operation
+"""Type Union for a CWL v1.x Process implementations."""
 ProcessRequirement: TypeAlias = (
     cwl_v1_0.ProcessRequirement
     | cwl_v1_1.ProcessRequirement
@@ -269,6 +300,10 @@ EnvVarRequirement: TypeAlias = (
     cwl_v1_0.EnvVarRequirement | cwl_v1_1.EnvVarRequirement | cwl_v1_2.EnvVarRequirement
 )
 """Type Union for a CWL v1.x EnvVarRequirement object."""
+EnvironmentDef: TypeAlias = (
+    cwl_v1_0.EnvironmentDef | cwl_v1_1.EnvironmentDef | cwl_v1_2.EnvironmentDef
+)
+"""Type Union for a CWL v1.x EnvironmentDef object."""
 InitialWorkDirRequirement: TypeAlias = (
     cwl_v1_0.InitialWorkDirRequirement
     | cwl_v1_1.InitialWorkDirRequirement
@@ -289,6 +324,26 @@ ResourceRequirement: TypeAlias = (
 """Type Union for a CWL v1.x ResourceRequirement object."""
 Loader: TypeAlias = schema_salad.runtime.Loader
 """Type union for a CWL v1.x Loader."""
+CWLVersion: TypeAlias = cwl_v1_0.CWLVersion | cwl_v1_1.CWLVersion | cwl_v1_2.CWLVersion
+"""Type union for a CWL v1.x Loader."""
+
+CWLTypeSchema: TypeAlias = (
+    ArraySchema
+    | RecordSchema
+    | PrimitiveType
+    | EnumSchema
+    | str
+    | Sequence[ArraySchema | RecordSchema | PrimitiveType | EnumSchema | str]
+)
+ParameterType: TypeAlias = (
+    InputParameterType
+    | CommandInputParameterType
+    | OutputParameterType
+    | CommandOutputParameterType
+)
+ParameterTypeOrArraySchema: TypeAlias = (
+    ParameterType | ArraySchema | Sequence[ArraySchema]
+)
 
 
 def _get_id_from_graph(yaml: MutableMapping[str, Any], id_: str | None) -> Any:
@@ -449,7 +504,7 @@ def save(
 
 def is_process(v: Any) -> bool:
     """Test to see if the object is a CWL v1.x Python Process object."""
-    return isinstance(v, cwl_v1_0.Process | cwl_v1_1.Process | cwl_v1_2.Process)
+    return isinstance(v, AbstractProcess)
 
 
 def version_split(version: str) -> MutableSequence[int]:

--- a/src/cwl_utils/parser/cwl_v1_0.py
+++ b/src/cwl_utils/parser/cwl_v1_0.py
@@ -27,12 +27,15 @@ else:
 import schema_salad.metaschema
 
 import copy
-from collections.abc import MutableSequence, Sequence, MutableMapping
+from collections.abc import Mapping, Sequence, MutableSequence, MutableMapping
 from io import StringIO
 from itertools import chain
-from typing import Any, Final, cast, Generic
+from typing import Any, Final, cast
+from typing import Literal, TypeAlias  # pylint: disable=unused-import # noqa: F401
 from urllib.parse import urldefrag, urlsplit, urlunsplit
 
+from mypy_extensions import i32, i64, trait  # pylint: disable=unused-import # noqa: F401
+from mypy_extensions import mypyc_attr
 from ruamel.yaml.comments import CommentedMap
 
 from schema_salad.exceptions import ValidationException, SchemaSaladException
@@ -42,16 +45,19 @@ from schema_salad.runtime import (
     extract_type,
     SaveableType,
     Loader,
+    FieldType,
+    EnumFieldType,
 )
 from schema_salad.sourceline import SourceLine, add_lc_filename
 from schema_salad.utils import yaml_no_ts  # requires schema-salad v8.2+
 
-_loaders: Final[dict[str, Loader | None]] = {}
+_loaders: Final[dict[str, Loader[Any] | None]] = {}
 _vocab: Final[dict[str, str]] = {}
 _rvocab: Final[dict[str, str]] = {}
 
 
-class _AnyLoader(Loader):
+@mypyc_attr(native_class=True)
+class _AnyLoader(Loader[Any]):
     def load(
         self,
         doc: Any,
@@ -65,8 +71,9 @@ class _AnyLoader(Loader):
         raise ValidationException("Expected non-null")
 
 
-class _PrimitiveLoader(Loader):
-    def __init__(self, tp: type | tuple[type[str], type[str]]) -> None:
+@mypyc_attr(native_class=True)
+class _PrimitiveLoader(Loader[FieldType]):
+    def __init__(self, tp: type[FieldType]) -> None:
         self.tp: Final = tp
 
     def load(
@@ -76,7 +83,7 @@ class _PrimitiveLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if not isinstance(doc, self.tp):
             raise ValidationException(f"Expected a {self.tp} but got {doc.__class__.__name__}")
         return doc
@@ -85,8 +92,9 @@ class _PrimitiveLoader(Loader):
         return str(self.tp)
 
 
-class _ArrayLoader(Loader):
-    def __init__(self, items: Loader) -> None:
+@mypyc_attr(native_class=True)
+class _ArrayLoader(Loader[Sequence[FieldType]]):
+    def __init__(self, items: Loader[FieldType]) -> None:
         self.items: Final = items
 
     def load(
@@ -96,9 +104,9 @@ class _ArrayLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> list[Any]:
+    ) -> list[FieldType]:
         if not isinstance(doc, MutableSequence):
-            raise ValidationException(
+            raise SourceLine(doc, None, ValidationException).makeError(
                 f"Value is a {convert_typing(extract_type(type(doc)))}, "
                 f"but valid type for this field is an array."
             )
@@ -142,10 +150,11 @@ class _ArrayLoader(Loader):
         return f"array<{self.items}>"
 
 
-class _MapLoader(Loader):
+@mypyc_attr(native_class=True)
+class _MapLoader(Loader[Mapping[str, FieldType]]):
     def __init__(
         self,
-        values: Loader,
+        values: Loader[FieldType],
         name: str | None = None,
         container: str | None = None,
         no_link_check: bool | None = None,
@@ -162,7 +171,7 @@ class _MapLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> dict[str, Any]:
+    ) -> dict[str, FieldType]:
         if not isinstance(doc, MutableMapping):
             raise ValidationException(f"Expected a map, was {type(doc)}")
         if self.container is not None or self.no_link_check is not None:
@@ -185,8 +194,9 @@ class _MapLoader(Loader):
         return self.name if self.name is not None else f"map<string, {self.values}>"
 
 
-class _EnumLoader(Loader):
-    def __init__(self, symbols: Sequence[str], name: str) -> None:
+@mypyc_attr(native_class=True)
+class _EnumLoader(Loader[EnumFieldType]):
+    def __init__(self, symbols: tuple[EnumFieldType, ...], name: str) -> None:
         self.symbols: Final = symbols
         self.name: Final = name
 
@@ -197,17 +207,18 @@ class _EnumLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> str:
+    ) -> EnumFieldType:
         if doc in self.symbols:
-            return cast(str, doc)
+            return cast(EnumFieldType, doc)
         raise ValidationException(f"Expected one of {self.symbols}")
 
     def __repr__(self) -> str:
         return self.name
 
 
-class _SecondaryDSLLoader(Loader):
-    def __init__(self, inner: Loader) -> None:
+@mypyc_attr(native_class=True)
+class _SecondaryDSLLoader(Loader[FieldType]):
+    def __init__(self, inner: Loader[FieldType]) -> None:
         self.inner: Final = inner
 
     def load(
@@ -217,7 +228,7 @@ class _SecondaryDSLLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         r: Final[list[dict[str, Any]]] = []
         match doc:
             case MutableSequence() as dlist:
@@ -279,7 +290,8 @@ class _SecondaryDSLLoader(Loader):
         return self.inner.load(r, baseuri, loadingOptions, docRoot, lc=lc)
 
 
-class _RecordLoader(Loader, Generic[SaveableType]):
+@mypyc_attr(native_class=True)
+class _RecordLoader(Loader[SaveableType]):
     def __init__(
         self,
         classtype: type[SaveableType],
@@ -299,7 +311,7 @@ class _RecordLoader(Loader, Generic[SaveableType]):
         lc: Any | None = None,
     ) -> SaveableType:
         if not isinstance(doc, MutableMapping):
-            raise ValidationException(
+            raise SourceLine(doc, None, ValidationException).makeError(
                 f"Value is a {convert_typing(extract_type(type(doc)))}, "
                 f"but valid type for this field is an object."
             )
@@ -313,7 +325,8 @@ class _RecordLoader(Loader, Generic[SaveableType]):
         return str(self.classtype.__name__)
 
 
-class _ExpressionLoader(Loader):
+@mypyc_attr(native_class=True)
+class _ExpressionLoader(Loader[str]):
     def __init__(self, items: type[str]) -> None:
         self.items: Final = items
 
@@ -326,7 +339,7 @@ class _ExpressionLoader(Loader):
         lc: Any | None = None,
     ) -> str:
         if not isinstance(doc, str):
-            raise ValidationException(
+            raise SourceLine(doc, None, ValidationException).makeError(
                 f"Value is a {convert_typing(extract_type(type(doc)))}, "
                 f"but valid type for this field is a str."
             )
@@ -334,12 +347,13 @@ class _ExpressionLoader(Loader):
             return doc
 
 
-class _UnionLoader(Loader):
-    def __init__(self, alternates: Sequence[Loader], name: str | None = None) -> None:
+@mypyc_attr(native_class=True)
+class _UnionLoader(Loader[FieldType]):
+    def __init__(self, alternates: Sequence[Loader[FieldType]], name: str | None = None) -> None:
         self.alternates = alternates
         self.name: Final = name
 
-    def add_loaders(self, loaders: Sequence[Loader]) -> None:
+    def add_loaders(self, loaders: Sequence[Loader[FieldType]]) -> None:
         self.alternates = tuple(loader for loader in chain(self.alternates, loaders))
 
     def load(
@@ -349,7 +363,7 @@ class _UnionLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         errors: Final = []
 
         if lc is None:
@@ -424,10 +438,11 @@ class _UnionLoader(Loader):
         return self.name if self.name is not None else " | ".join(str(a) for a in self.alternates)
 
 
-class _URILoader(Loader):
+@mypyc_attr(native_class=True)
+class _URILoader(Loader[FieldType]):
     def __init__(
         self,
-        inner: Loader,
+        inner: Loader[FieldType],
         scoped_id: bool,
         vocab_term: bool,
         scoped_ref: int | None,
@@ -446,7 +461,7 @@ class _URILoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if self.no_link_check is not None:
             loadingOptions = LoadingOptions(
                 copyfrom=loadingOptions, no_link_check=self.no_link_check
@@ -493,10 +508,11 @@ class _URILoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
-class _TypeDSLLoader(Loader):
+@mypyc_attr(native_class=True)
+class _TypeDSLLoader(Loader[FieldType]):
     def __init__(
         self,
-        inner: Loader,
+        inner: Loader[FieldType],
         refScope: int | None,
         salad_version: str,
     ) -> None:
@@ -567,7 +583,7 @@ class _TypeDSLLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if isinstance(doc, MutableSequence):
             r: Final[list[Any]] = []
             for d in doc:
@@ -589,8 +605,9 @@ class _TypeDSLLoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
-class _IdMapLoader(Loader):
-    def __init__(self, inner: Loader, mapSubject: str, mapPredicate: str | None) -> None:
+@mypyc_attr(native_class=True)
+class _IdMapLoader(Loader[FieldType]):
+    def __init__(self, inner: Loader[FieldType], mapSubject: str, mapPredicate: str | None) -> None:
         self.inner: Final = inner
         self.mapSubject: Final = mapSubject
         self.mapPredicate: Final = mapPredicate
@@ -602,7 +619,7 @@ class _IdMapLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if isinstance(doc, MutableMapping):
             r: Final[list[Any]] = []
             for k in doc.keys():
@@ -628,7 +645,8 @@ class _IdMapLoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
-class _ProxyLoader(Loader):
+@mypyc_attr(native_class=True)
+class _ProxyLoader(Loader[FieldType]):
     def __init__(self, name: str) -> None:
         self.name: Final = name
 
@@ -639,25 +657,25 @@ class _ProxyLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any | None:
+    ) -> FieldType:
         if (
             self.name in loadingOptions.loaders
             and (loader := loadingOptions.loaders.get(self.name)) is not None
         ):
-            return loader.load(doc, baseuri, loadingOptions, lc=lc)
+            return cast(Loader[FieldType], loader).load(doc, baseuri, loadingOptions, lc=lc)
         elif self.name in _loaders and (loader := _loaders.get(self.name)) is not None:
-            return loader.load(doc, baseuri, loadingOptions, lc=lc)
+            return cast(Loader[FieldType], loader).load(doc, baseuri, loadingOptions, lc=lc)
         else:
             raise ValidationException(f"No Loader instance available for {self.name}")
 
 
 def _document_load(
-    loader: Loader,
+    loader: Loader[FieldType],
     doc: str | MutableMapping[str, Any] | MutableSequence[Any],
     baseuri: str,
     loadingOptions: LoadingOptions,
     addl_metadata_fields: MutableSequence[str] | None = None,
-) -> tuple[Any, LoadingOptions]:
+) -> tuple[FieldType, LoadingOptions]:
     if isinstance(doc, str):
         return _document_load_by_url(
             loader,
@@ -723,11 +741,11 @@ def _document_load(
 
 
 def _document_load_by_url(
-    loader: Loader,
+    loader: Loader[FieldType],
     url: str,
     loadingOptions: LoadingOptions,
     addl_metadata_fields: MutableSequence[str] | None = None,
-) -> tuple[Any, LoadingOptions]:
+) -> tuple[FieldType, LoadingOptions]:
     if url in loadingOptions.idx:
         return loadingOptions.idx[url]
 
@@ -823,11 +841,11 @@ def _expand_url(
 
 def _load_field(
     val: Any | None,
-    fieldtype: Loader,
+    fieldtype: Loader[FieldType],
     baseuri: str,
     loadingOptions: LoadingOptions,
     lc: Any | None = None,
-) -> Any:
+) -> FieldType:
     """Load field."""
     if isinstance(val, MutableMapping):
         if "$import" in val:
@@ -854,25 +872,8 @@ def parser_info() -> str:
     return "org.w3id.cwl.v1_0"
 
 
+@mypyc_attr(native_class=True)
 class CWLArraySchema(schema_salad.metaschema.ArraySchema):
-    def __init__(
-        self,
-        items: Any,
-        type_: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.items = items
-        self.type_ = type_
-
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CWLArraySchema):
             return bool(self.items == other.items and self.type_ == other.type_)
@@ -1050,17 +1051,10 @@ class CWLArraySchema(schema_salad.metaschema.ArraySchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["items", "type"])
-
-
-class CWLRecordField(schema_salad.metaschema.RecordField):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
+        items: CWLArraySchema | CWLRecordSchema | PrimitiveType | Sequence[CWLArraySchema | CWLRecordSchema | PrimitiveType | schema_salad.metaschema.EnumSchema | str] | schema_salad.metaschema.EnumSchema | str,
+        type_: Array_name,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -1069,12 +1063,18 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.items = items
         self.type_ = type_
+
+    attrs: ClassVar[Collection[str]] = frozenset(["items", "type"])
+
+
+@mypyc_attr(native_class=True)
+class CWLRecordField(schema_salad.metaschema.RecordField):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CWLRecordField):
@@ -1149,15 +1149,62 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -1278,13 +1325,13 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -1299,7 +1346,10 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -1318,14 +1368,11 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["doc", "name", "type"])
-
-
-class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
     def __init__(
         self,
-        type_: Any,
-        fields: Any | None = None,
+        name: str,
+        type_: CWLArraySchema | CWLRecordSchema | PrimitiveType | Sequence[CWLArraySchema | CWLRecordSchema | PrimitiveType | schema_salad.metaschema.EnumSchema | str] | schema_salad.metaschema.EnumSchema | str,
+        doc: None | Sequence[str] | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -1334,12 +1381,18 @@ class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.fields = fields
+        self.doc = doc
+        self.name = name
         self.type_ = type_
 
+    attrs: ClassVar[Collection[str]] = frozenset(["doc", "name", "type"])
+
+
+@mypyc_attr(native_class=True)
+class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CWLRecordSchema):
             return bool(self.fields == other.fields and self.type_ == other.type_)
@@ -1517,9 +1570,28 @@ class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        type_: Record_name,
+        fields: None | Sequence[CWLRecordField] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.fields = fields
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(["fields", "type"])
 
 
+@mypyc_attr(native_class=True)
 class File(Saveable):
     """
     Represents a file (or group of files when ``secondaryFiles`` is provided) that will be accessible by tools using standard POSIX file system call API such as open(2) and read(2).
@@ -1547,43 +1619,6 @@ class File(Saveable):
     An ExpressionTool may forward file references from input to output by using the same value for ``location``.
 
     """
-
-    def __init__(
-        self,
-        location: Any | None = None,
-        path: Any | None = None,
-        basename: Any | None = None,
-        dirname: Any | None = None,
-        nameroot: Any | None = None,
-        nameext: Any | None = None,
-        checksum: Any | None = None,
-        size: Any | None = None,
-        secondaryFiles: Any | None = None,
-        format: Any | None = None,
-        contents: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "File"
-        self.location = location
-        self.path = path
-        self.basename = basename
-        self.dirname = dirname
-        self.nameroot = nameroot
-        self.nameext = nameext
-        self.checksum = checksum
-        self.size = size
-        self.secondaryFiles = secondaryFiles
-        self.format = format
-        self.contents = contents
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, File):
@@ -1986,7 +2021,7 @@ class File(Saveable):
             try:
                 size = _load_field(
                     _doc.get("size"),
-                    union_of_None_type_or_inttype,
+                    union_of_None_type_or_inttype_or_longtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("size")
@@ -2284,6 +2319,43 @@ class File(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        location: None | str = None,
+        path: None | str = None,
+        basename: None | str = None,
+        dirname: None | str = None,
+        nameroot: None | str = None,
+        nameext: None | str = None,
+        checksum: None | str = None,
+        size: None | i32 | i64 = None,
+        secondaryFiles: None | Sequence[Directory | File] = None,
+        format: None | str = None,
+        contents: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "File"
+        self.location = location
+        self.path = path
+        self.basename = basename
+        self.dirname = dirname
+        self.nameroot = nameroot
+        self.nameext = nameext
+        self.checksum = checksum
+        self.size = size
+        self.secondaryFiles = secondaryFiles
+        self.format = format
+        self.contents = contents
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -2302,6 +2374,7 @@ class File(Saveable):
     )
 
 
+@mypyc_attr(native_class=True)
 class Directory(Saveable):
     """
     Represents a directory to present to a command line tool.
@@ -2325,29 +2398,6 @@ class Directory(Saveable):
     Name conflicts (the same ``basename`` appearing multiple times in ``listing`` or in any entry in ``secondaryFiles`` in the listing) is a fatal error.
 
     """
-
-    def __init__(
-        self,
-        location: Any | None = None,
-        path: Any | None = None,
-        basename: Any | None = None,
-        listing: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "Directory"
-        self.location = location
-        self.path = path
-        self.basename = basename
-        self.listing = listing
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Directory):
@@ -2662,15 +2712,42 @@ class Directory(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        location: None | str = None,
+        path: None | str = None,
+        basename: None | str = None,
+        listing: None | Sequence[Directory | File] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "Directory"
+        self.location = location
+        self.path = path
+        self.basename = basename
+        self.listing = listing
+
     attrs: ClassVar[Collection[str]] = frozenset(
         ["class", "location", "path", "basename", "listing"]
     )
 
 
+@mypyc_attr(native_class=True)
+@trait
 class SchemaBase(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Parameter(SchemaBase):
     """
     Define an input or output parameter to a process.
@@ -2680,48 +2757,33 @@ class Parameter(SchemaBase):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class InputBinding(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class OutputBinding(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class InputSchema(SchemaBase):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class OutputSchema(SchemaBase):
     pass
 
 
+@mypyc_attr(native_class=True)
 class InputRecordField(CWLRecordField):
     name: str
-
-    def __init__(
-        self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        inputBinding: Any | None = None,
-        label: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.type_ = type_
-        self.inputBinding = inputBinding
-        self.label = label
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputRecordField):
@@ -2798,15 +2860,62 @@ class InputRecordField(CWLRecordField):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -2907,7 +3016,7 @@ class InputRecordField(CWLRecordField):
             try:
                 inputBinding = _load_field(
                     _doc.get("inputBinding"),
-                    union_of_None_type_or_CommandLineBindingLoader,
+                    union_of_None_type_or_InputBindingProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inputBinding")
@@ -3021,15 +3130,15 @@ class InputRecordField(CWLRecordField):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             inputBinding=inputBinding,
             label=label,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -3044,7 +3153,10 @@ class InputRecordField(CWLRecordField):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -3074,20 +3186,13 @@ class InputRecordField(CWLRecordField):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["doc", "name", "type", "inputBinding", "label"]
-    )
-
-
-class InputRecordSchema(CWLRecordSchema, InputSchema):
-    name: str
-
     def __init__(
         self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        name: Any | None = None,
+        name: str,
+        type_: CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        inputBinding: InputBinding | None = None,
+        label: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -3096,13 +3201,23 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.fields = fields
+        self.doc = doc
+        self.name = name
         self.type_ = type_
+        self.inputBinding = inputBinding
         self.label = label
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["doc", "name", "type", "inputBinding", "label"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class InputRecordSchema(CWLRecordSchema, InputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputRecordSchema):
@@ -3178,15 +3293,61 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -3354,14 +3515,14 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -3376,7 +3537,10 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -3399,19 +3563,12 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["fields", "type", "label", "name"])
-
-
-class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        inputBinding: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[InputRecordField] = None,
+        label: None | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -3420,14 +3577,20 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
-        self.inputBinding = inputBinding
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(["fields", "type", "label", "name"])
+
+
+@mypyc_attr(native_class=True)
+class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputEnumSchema):
@@ -3506,15 +3669,61 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -3663,7 +3872,7 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
             try:
                 inputBinding = _load_field(
                     _doc.get("inputBinding"),
-                    union_of_None_type_or_CommandLineBindingLoader,
+                    union_of_None_type_or_InputBindingProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inputBinding")
@@ -3738,7 +3947,7 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -3753,7 +3962,10 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -3782,18 +3994,13 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "inputBinding"]
-    )
-
-
-class InputArraySchema(CWLArraySchema, InputSchema):
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        inputBinding: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        inputBinding: InputBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -3802,14 +4009,22 @@ class InputArraySchema(CWLArraySchema, InputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.inputBinding = inputBinding
 
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "inputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class InputArraySchema(CWLArraySchema, InputSchema):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputArraySchema):
             return bool(
@@ -3985,7 +4200,7 @@ class InputArraySchema(CWLArraySchema, InputSchema):
             try:
                 inputBinding = _load_field(
                     _doc.get("inputBinding"),
-                    union_of_None_type_or_CommandLineBindingLoader,
+                    union_of_None_type_or_InputBindingProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inputBinding")
@@ -4099,20 +4314,12 @@ class InputArraySchema(CWLArraySchema, InputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["items", "type", "label", "inputBinding"]
-    )
-
-
-class OutputRecordField(CWLRecordField):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        outputBinding: Any | None = None,
+        items: CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        inputBinding: InputBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -4121,13 +4328,22 @@ class OutputRecordField(CWLRecordField):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.items = items
         self.type_ = type_
-        self.outputBinding = outputBinding
+        self.label = label
+        self.inputBinding = inputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["items", "type", "label", "inputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputRecordField(CWLRecordField):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputRecordField):
@@ -4203,15 +4419,62 @@ class OutputRecordField(CWLRecordField):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -4312,7 +4575,7 @@ class OutputRecordField(CWLRecordField):
             try:
                 outputBinding = _load_field(
                     _doc.get("outputBinding"),
-                    union_of_None_type_or_CommandOutputBindingLoader,
+                    union_of_None_type_or_OutputBindingProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outputBinding")
@@ -4379,14 +4642,14 @@ class OutputRecordField(CWLRecordField):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             outputBinding=outputBinding,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -4401,7 +4664,10 @@ class OutputRecordField(CWLRecordField):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -4427,17 +4693,12 @@ class OutputRecordField(CWLRecordField):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["doc", "name", "type", "outputBinding"]
-    )
-
-
-class OutputRecordSchema(CWLRecordSchema, OutputSchema):
     def __init__(
         self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
+        name: str,
+        type_: CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | Sequence[CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        outputBinding: None | OutputBinding = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -4446,13 +4707,21 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.fields = fields
+        self.doc = doc
+        self.name = name
         self.type_ = type_
-        self.label = label
+        self.outputBinding = outputBinding
 
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["doc", "name", "type", "outputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputRecordSchema(CWLRecordSchema, OutputSchema):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputRecordSchema):
             return bool(
@@ -4686,19 +4955,11 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["fields", "type", "label"])
-
-
-class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        outputBinding: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[OutputRecordField] = None,
+        label: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -4707,14 +4968,19 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
-        self.outputBinding = outputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(["fields", "type", "label"])
+
+
+@mypyc_attr(native_class=True)
+class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputEnumSchema):
@@ -4793,15 +5059,61 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -4950,7 +5262,7 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
             try:
                 outputBinding = _load_field(
                     _doc.get("outputBinding"),
-                    union_of_None_type_or_CommandOutputBindingLoader,
+                    union_of_None_type_or_OutputBindingProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outputBinding")
@@ -5025,7 +5337,7 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -5040,7 +5352,10 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -5069,18 +5384,13 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "outputBinding"]
-    )
-
-
-class OutputArraySchema(CWLArraySchema, OutputSchema):
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        outputBinding: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        outputBinding: None | OutputBinding = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -5089,14 +5399,22 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.outputBinding = outputBinding
 
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "outputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputArraySchema(CWLArraySchema, OutputSchema):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputArraySchema):
             return bool(
@@ -5272,7 +5590,7 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
             try:
                 outputBinding = _load_field(
                     _doc.get("outputBinding"),
-                    union_of_None_type_or_CommandOutputBindingLoader,
+                    union_of_None_type_or_OutputBindingProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outputBinding")
@@ -5386,25 +5704,12 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["items", "type", "label", "outputBinding"]
-    )
-
-
-class InputParameter(Parameter):
-    id: str
-
     def __init__(
         self,
-        id: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        inputBinding: Any | None = None,
-        default: Any | None = None,
-        type_: Any | None = None,
+        items: CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | Sequence[CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        outputBinding: None | OutputBinding = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -5413,18 +5718,22 @@ class InputParameter(Parameter):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.inputBinding = inputBinding
-        self.default = default
+        self.items = items
         self.type_ = type_
+        self.label = label
+        self.outputBinding = outputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["items", "type", "label", "outputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class InputParameter(Parameter):
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputParameter):
@@ -5517,15 +5826,62 @@ class InputParameter(Parameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -5766,7 +6122,7 @@ class InputParameter(Parameter):
             try:
                 inputBinding = _load_field(
                     _doc.get("inputBinding"),
-                    union_of_None_type_or_CommandLineBindingLoader,
+                    union_of_None_type_or_InputBindingProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("inputBinding")
@@ -5860,7 +6216,7 @@ class InputParameter(Parameter):
             try:
                 type_ = _load_field(
                     _doc.get("type"),
-                    typedsl_union_of_None_type_or_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2,
+                    typedsl_union_of_None_type_or_InputParameterTypeLoader_2,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("type")
@@ -5927,11 +6283,11 @@ class InputParameter(Parameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             inputBinding=inputBinding,
             default=default,
@@ -5939,7 +6295,7 @@ class InputParameter(Parameter):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -5954,7 +6310,10 @@ class InputParameter(Parameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -6005,6 +6364,38 @@ class InputParameter(Parameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        label: None | str = None,
+        secondaryFiles: None | Sequence[str] | str = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | Sequence[str] | str = None,
+        inputBinding: InputBinding | None = None,
+        default: CWLObjectType | None = None,
+        type_: InputParameterType | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.inputBinding = inputBinding
+        self.default = default
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -6020,36 +6411,9 @@ class InputParameter(Parameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class OutputParameter(Parameter):
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        outputBinding: Any | None = None,
-        format: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.outputBinding = outputBinding
-        self.format = format
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputParameter):
@@ -6138,15 +6502,62 @@ class OutputParameter(Parameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -6340,7 +6751,7 @@ class OutputParameter(Parameter):
             try:
                 outputBinding = _load_field(
                     _doc.get("outputBinding"),
-                    union_of_None_type_or_CommandOutputBindingLoader,
+                    union_of_None_type_or_OutputBindingProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outputBinding")
@@ -6454,17 +6865,17 @@ class OutputParameter(Parameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             outputBinding=outputBinding,
             format=format,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -6479,7 +6890,10 @@ class OutputParameter(Parameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -6522,6 +6936,34 @@ class OutputParameter(Parameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        label: None | str = None,
+        secondaryFiles: None | Sequence[str] | str = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        outputBinding: None | OutputBinding = None,
+        format: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.outputBinding = outputBinding
+        self.format = format
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -6535,6 +6977,8 @@ class OutputParameter(Parameter):
     )
 
 
+@mypyc_attr(native_class=True)
+@trait
 class ProcessRequirement(Saveable):
     """
     A process requirement declares a prerequisite that may or must be fulfilled before executing a process.  See ```Process.hints`` <#process>`__ and ```Process.requirements`` <#process>`__.
@@ -6546,6 +6990,8 @@ class ProcessRequirement(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Process(Saveable):
     """
     The base executable type in CWL is the ``Process`` object defined by the document.  Note that the ``Process`` object is abstract and cannot be directly executed.
@@ -6555,28 +7001,12 @@ class Process(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
 class InlineJavascriptRequirement(ProcessRequirement):
     """
     Indicates that the workflow platform must support inline Javascript expressions. If this requirement is not present, the workflow platform must not perform expression interpolatation.
 
     """
-
-    def __init__(
-        self,
-        expressionLib: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "InlineJavascriptRequirement"
-        self.expressionLib = expressionLib
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InlineJavascriptRequirement):
@@ -6735,18 +7165,9 @@ class InlineJavascriptRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "expressionLib"])
-
-
-class SchemaDefRequirement(ProcessRequirement):
-    """
-    This field consists of an array of type definitions which must be used when interpreting the ``inputs`` and ``outputs`` fields.  When a ``type`` field contain a IRI, the implementation must check if the type is defined in ``schemaDefs`` and use that definition.  If the type is not found in ``schemaDefs``, it is an error.  The entries in ``schemaDefs`` must be processed in the order listed such that later schema definitions may refer to earlier schema definitions.
-
-    """
-
     def __init__(
         self,
-        types: Any,
+        expressionLib: None | Sequence[str] = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -6755,11 +7176,21 @@ class SchemaDefRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "SchemaDefRequirement"
-        self.types = types
+        self.class_: Final[str] = "InlineJavascriptRequirement"
+        self.expressionLib = expressionLib
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "expressionLib"])
+
+
+@mypyc_attr(native_class=True)
+class SchemaDefRequirement(ProcessRequirement):
+    """
+    This field consists of an array of type definitions which must be used when interpreting the ``inputs`` and ``outputs`` fields.  When a ``type`` field contain a IRI, the implementation must check if the type is defined in ``schemaDefs`` and use that definition.  If the type is not found in ``schemaDefs``, it is an error.  The entries in ``schemaDefs`` must be processed in the order listed such that later schema definitions may refer to earlier schema definitions.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SchemaDefRequirement):
@@ -6806,7 +7237,7 @@ class SchemaDefRequirement(ProcessRequirement):
 
             types = _load_field(
                 _doc.get("types"),
-                array_of_InputSchema,
+                array_of_InputSchemaProxyLoader,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("types")
@@ -6913,19 +7344,9 @@ class SchemaDefRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "types"])
-
-
-class EnvironmentDef(Saveable):
-    """
-    Define an environment variable that will be set in the runtime environment by the workflow platform when executing the command line tool.  May be the result of executing an expression, such as getting a parameter from input.
-
-    """
-
     def __init__(
         self,
-        envName: Any,
-        envValue: Any,
+        types: Sequence[InputSchema],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -6934,11 +7355,21 @@ class EnvironmentDef(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.envName = envName
-        self.envValue = envValue
+        self.class_: Final[str] = "SchemaDefRequirement"
+        self.types = types
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "types"])
+
+
+@mypyc_attr(native_class=True)
+class EnvironmentDef(Saveable):
+    """
+    Define an environment variable that will be set in the runtime environment by the workflow platform when executing the command line tool.  May be the result of executing an expression, such as getting a parameter from input.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, EnvironmentDef):
@@ -7120,9 +7551,28 @@ class EnvironmentDef(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        envName: str,
+        envValue: str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.envName = envName
+        self.envValue = envValue
+
     attrs: ClassVar[Collection[str]] = frozenset(["envName", "envValue"])
 
 
+@mypyc_attr(native_class=True)
 class CommandLineBinding(InputBinding):
     """
     When listed under ``inputBinding`` in the input schema, the term "value" refers to the the corresponding value in the input object.  For binding objects listed in ``CommandLineTool.arguments``, the term "value" refers to the effective value after evaluating ``valueFrom``.
@@ -7146,34 +7596,6 @@ class CommandLineBinding(InputBinding):
     - **null**: Add nothing.
 
     """
-
-    def __init__(
-        self,
-        loadContents: Any | None = None,
-        position: Any | None = None,
-        prefix: Any | None = None,
-        separate: Any | None = None,
-        itemSeparator: Any | None = None,
-        valueFrom: Any | None = None,
-        shellQuote: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.loadContents = loadContents
-        self.position = position
-        self.prefix = prefix
-        self.separate = separate
-        self.itemSeparator = itemSeparator
-        self.valueFrom = valueFrom
-        self.shellQuote = shellQuote
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandLineBinding):
@@ -7641,6 +8063,34 @@ class CommandLineBinding(InputBinding):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        loadContents: None | bool = None,
+        position: None | i32 = None,
+        prefix: None | str = None,
+        separate: None | bool = None,
+        itemSeparator: None | str = None,
+        valueFrom: None | str = None,
+        shellQuote: None | bool = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.loadContents = loadContents
+        self.position = position
+        self.prefix = prefix
+        self.separate = separate
+        self.itemSeparator = itemSeparator
+        self.valueFrom = valueFrom
+        self.shellQuote = shellQuote
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "loadContents",
@@ -7654,6 +8104,7 @@ class CommandLineBinding(InputBinding):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandOutputBinding(OutputBinding):
     """
     Describes how to generate an output parameter based on the files produced by a CommandLineTool.
@@ -7666,26 +8117,6 @@ class CommandOutputBinding(OutputBinding):
     - secondaryFiles
 
     """
-
-    def __init__(
-        self,
-        glob: Any | None = None,
-        loadContents: Any | None = None,
-        outputEval: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.glob = glob
-        self.loadContents = loadContents
-        self.outputEval = outputEval
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputBinding):
@@ -7925,19 +8356,11 @@ class CommandOutputBinding(OutputBinding):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["glob", "loadContents", "outputEval"])
-
-
-class CommandInputRecordField(InputRecordField):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        inputBinding: Any | None = None,
-        label: Any | None = None,
+        glob: None | Sequence[str] | str = None,
+        loadContents: None | bool = None,
+        outputEval: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -7946,14 +8369,19 @@ class CommandInputRecordField(InputRecordField):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.type_ = type_
-        self.inputBinding = inputBinding
-        self.label = label
+        self.glob = glob
+        self.loadContents = loadContents
+        self.outputEval = outputEval
+
+    attrs: ClassVar[Collection[str]] = frozenset(["glob", "loadContents", "outputEval"])
+
+
+@mypyc_attr(native_class=True)
+class CommandInputRecordField(InputRecordField):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputRecordField):
@@ -8030,15 +8458,62 @@ class CommandInputRecordField(InputRecordField):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -8253,15 +8728,15 @@ class CommandInputRecordField(InputRecordField):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             inputBinding=inputBinding,
             label=label,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -8276,7 +8751,10 @@ class CommandInputRecordField(InputRecordField):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -8306,20 +8784,13 @@ class CommandInputRecordField(InputRecordField):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["doc", "name", "type", "inputBinding", "label"]
-    )
-
-
-class CommandInputRecordSchema(InputRecordSchema):
-    name: str
-
     def __init__(
         self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        name: Any | None = None,
+        name: str,
+        type_: CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | Sequence[CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        inputBinding: CommandLineBinding | None = None,
+        label: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -8328,13 +8799,23 @@ class CommandInputRecordSchema(InputRecordSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.fields = fields
+        self.doc = doc
+        self.name = name
         self.type_ = type_
+        self.inputBinding = inputBinding
         self.label = label
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["doc", "name", "type", "inputBinding", "label"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandInputRecordSchema(InputRecordSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputRecordSchema):
@@ -8410,15 +8891,61 @@ class CommandInputRecordSchema(InputRecordSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -8586,14 +9113,14 @@ class CommandInputRecordSchema(InputRecordSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -8608,7 +9135,10 @@ class CommandInputRecordSchema(InputRecordSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -8631,19 +9161,12 @@ class CommandInputRecordSchema(InputRecordSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["fields", "type", "label", "name"])
-
-
-class CommandInputEnumSchema(InputEnumSchema):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        inputBinding: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[CommandInputRecordField] = None,
+        label: None | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -8652,14 +9175,20 @@ class CommandInputEnumSchema(InputEnumSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
-        self.inputBinding = inputBinding
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(["fields", "type", "label", "name"])
+
+
+@mypyc_attr(native_class=True)
+class CommandInputEnumSchema(InputEnumSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputEnumSchema):
@@ -8738,15 +9267,61 @@ class CommandInputEnumSchema(InputEnumSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -8970,7 +9545,7 @@ class CommandInputEnumSchema(InputEnumSchema):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -8985,7 +9560,10 @@ class CommandInputEnumSchema(InputEnumSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -9014,18 +9592,13 @@ class CommandInputEnumSchema(InputEnumSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "inputBinding"]
-    )
-
-
-class CommandInputArraySchema(InputArraySchema):
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        inputBinding: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        inputBinding: CommandLineBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -9034,14 +9607,22 @@ class CommandInputArraySchema(InputArraySchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.inputBinding = inputBinding
 
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "inputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandInputArraySchema(InputArraySchema):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputArraySchema):
             return bool(
@@ -9331,20 +9912,12 @@ class CommandInputArraySchema(InputArraySchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["items", "type", "label", "inputBinding"]
-    )
-
-
-class CommandOutputRecordField(OutputRecordField):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        outputBinding: Any | None = None,
+        items: CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | Sequence[CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        inputBinding: CommandLineBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -9353,13 +9926,22 @@ class CommandOutputRecordField(OutputRecordField):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.items = items
         self.type_ = type_
-        self.outputBinding = outputBinding
+        self.label = label
+        self.inputBinding = inputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["items", "type", "label", "inputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandOutputRecordField(OutputRecordField):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputRecordField):
@@ -9435,15 +10017,62 @@ class CommandOutputRecordField(OutputRecordField):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -9611,14 +10240,14 @@ class CommandOutputRecordField(OutputRecordField):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             outputBinding=outputBinding,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -9633,7 +10262,10 @@ class CommandOutputRecordField(OutputRecordField):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -9659,20 +10291,12 @@ class CommandOutputRecordField(OutputRecordField):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["doc", "name", "type", "outputBinding"]
-    )
-
-
-class CommandOutputRecordSchema(OutputRecordSchema):
-    name: str
-
     def __init__(
         self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        name: Any | None = None,
+        name: str,
+        type_: CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | Sequence[CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        outputBinding: CommandOutputBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -9681,13 +10305,22 @@ class CommandOutputRecordSchema(OutputRecordSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.fields = fields
+        self.doc = doc
+        self.name = name
         self.type_ = type_
-        self.label = label
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.outputBinding = outputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["doc", "name", "type", "outputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandOutputRecordSchema(OutputRecordSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputRecordSchema):
@@ -9763,15 +10396,61 @@ class CommandOutputRecordSchema(OutputRecordSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -9939,14 +10618,14 @@ class CommandOutputRecordSchema(OutputRecordSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -9961,7 +10640,10 @@ class CommandOutputRecordSchema(OutputRecordSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -9984,19 +10666,12 @@ class CommandOutputRecordSchema(OutputRecordSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["fields", "type", "label", "name"])
-
-
-class CommandOutputEnumSchema(OutputEnumSchema):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        outputBinding: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[CommandOutputRecordField] = None,
+        label: None | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -10005,14 +10680,20 @@ class CommandOutputEnumSchema(OutputEnumSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
-        self.outputBinding = outputBinding
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(["fields", "type", "label", "name"])
+
+
+@mypyc_attr(native_class=True)
+class CommandOutputEnumSchema(OutputEnumSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputEnumSchema):
@@ -10091,15 +10772,61 @@ class CommandOutputEnumSchema(OutputEnumSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -10323,7 +11050,7 @@ class CommandOutputEnumSchema(OutputEnumSchema):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -10338,7 +11065,10 @@ class CommandOutputEnumSchema(OutputEnumSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -10367,18 +11097,13 @@ class CommandOutputEnumSchema(OutputEnumSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "outputBinding"]
-    )
-
-
-class CommandOutputArraySchema(OutputArraySchema):
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        outputBinding: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        outputBinding: CommandOutputBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -10387,14 +11112,22 @@ class CommandOutputArraySchema(OutputArraySchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.outputBinding = outputBinding
 
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "outputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandOutputArraySchema(OutputArraySchema):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputArraySchema):
             return bool(
@@ -10684,30 +11417,12 @@ class CommandOutputArraySchema(OutputArraySchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["items", "type", "label", "outputBinding"]
-    )
-
-
-class CommandInputParameter(InputParameter):
-    """
-    An input parameter for a CommandLineTool.
-
-    """
-
-    id: str
-
     def __init__(
         self,
-        id: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        inputBinding: Any | None = None,
-        default: Any | None = None,
-        type_: Any | None = None,
+        items: CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | Sequence[CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        outputBinding: CommandOutputBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -10716,18 +11431,27 @@ class CommandInputParameter(InputParameter):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.inputBinding = inputBinding
-        self.default = default
+        self.items = items
         self.type_ = type_
+        self.label = label
+        self.outputBinding = outputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["items", "type", "label", "outputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandInputParameter(InputParameter):
+    """
+    An input parameter for a CommandLineTool.
+
+    """
+
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputParameter):
@@ -10820,15 +11544,62 @@ class CommandInputParameter(InputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -11163,7 +11934,7 @@ class CommandInputParameter(InputParameter):
             try:
                 type_ = _load_field(
                     _doc.get("type"),
-                    typedsl_union_of_None_type_or_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2,
+                    typedsl_union_of_None_type_or_CommandInputParameterTypeLoader_2,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("type")
@@ -11230,11 +12001,11 @@ class CommandInputParameter(InputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             inputBinding=inputBinding,
             default=default,
@@ -11242,7 +12013,7 @@ class CommandInputParameter(InputParameter):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -11257,7 +12028,10 @@ class CommandInputParameter(InputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -11308,6 +12082,38 @@ class CommandInputParameter(InputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        label: None | str = None,
+        secondaryFiles: None | Sequence[str] | str = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | Sequence[str] | str = None,
+        inputBinding: CommandLineBinding | None = None,
+        default: CWLObjectType | None = None,
+        type_: CommandInputParameterType | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.inputBinding = inputBinding
+        self.default = default
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -11323,6 +12129,7 @@ class CommandInputParameter(InputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandOutputParameter(OutputParameter):
     """
     An output parameter for a CommandLineTool.
@@ -11330,36 +12137,6 @@ class CommandOutputParameter(OutputParameter):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        outputBinding: Any | None = None,
-        format: Any | None = None,
-        type_: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.outputBinding = outputBinding
-        self.format = format
-        self.type_ = type_
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputParameter):
@@ -11450,15 +12227,62 @@ class CommandOutputParameter(OutputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -11746,7 +12570,7 @@ class CommandOutputParameter(OutputParameter):
             try:
                 type_ = _load_field(
                     _doc.get("type"),
-                    typedsl_union_of_None_type_or_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2,
+                    typedsl_union_of_None_type_or_CommandOutputParameterTypeLoader_2,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("type")
@@ -11813,18 +12637,18 @@ class CommandOutputParameter(OutputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             outputBinding=outputBinding,
             format=format,
             type_=type_,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -11839,7 +12663,10 @@ class CommandOutputParameter(OutputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -11886,6 +12713,36 @@ class CommandOutputParameter(OutputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        label: None | str = None,
+        secondaryFiles: None | Sequence[str] | str = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        outputBinding: CommandOutputBinding | None = None,
+        format: None | str = None,
+        type_: CommandOutputParameterType | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.outputBinding = outputBinding
+        self.format = format
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -11900,6 +12757,7 @@ class CommandOutputParameter(OutputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandLineTool(Process):
     """
     This defines the schema of the CWL Command Line Tool Description document.
@@ -11907,53 +12765,6 @@ class CommandLineTool(Process):
     """
 
     id: str
-
-    def __init__(
-        self,
-        inputs: Any,
-        outputs: Any,
-        id: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        cwlVersion: Any | None = None,
-        baseCommand: Any | None = None,
-        arguments: Any | None = None,
-        stdin: Any | None = None,
-        stderr: Any | None = None,
-        stdout: Any | None = None,
-        successCodes: Any | None = None,
-        temporaryFailCodes: Any | None = None,
-        permanentFailCodes: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.label = label
-        self.doc = doc
-        self.cwlVersion = cwlVersion
-        self.class_: Final[str] = "CommandLineTool"
-        self.baseCommand = baseCommand
-        self.arguments = arguments
-        self.stdin = stdin
-        self.stderr = stderr
-        self.stdout = stdout
-        self.successCodes = successCodes
-        self.temporaryFailCodes = temporaryFailCodes
-        self.permanentFailCodes = permanentFailCodes
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandLineTool):
@@ -12062,15 +12873,61 @@ class CommandLineTool(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -12189,7 +13046,7 @@ class CommandLineTool(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -12236,7 +13093,7 @@ class CommandLineTool(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -12839,7 +13696,7 @@ class CommandLineTool(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -12854,7 +13711,10 @@ class CommandLineTool(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -12949,6 +13809,53 @@ class CommandLineTool(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[CommandInputParameter],
+        outputs: Sequence[CommandOutputParameter],
+        id: None | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        label: None | str = None,
+        doc: None | str = None,
+        cwlVersion: CWLVersion | None = None,
+        baseCommand: None | Sequence[str] | str = None,
+        arguments: None | Sequence[CommandLineBinding | str] = None,
+        stdin: None | str = None,
+        stderr: None | str = None,
+        stdout: None | str = None,
+        successCodes: None | Sequence[i32] = None,
+        temporaryFailCodes: None | Sequence[i32] = None,
+        permanentFailCodes: None | Sequence[i32] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.label = label
+        self.doc = doc
+        self.cwlVersion = cwlVersion
+        self.class_: Final[str] = "CommandLineTool"
+        self.baseCommand = baseCommand
+        self.arguments = arguments
+        self.stdin = stdin
+        self.stderr = stderr
+        self.stdout = stdout
+        self.successCodes = successCodes
+        self.temporaryFailCodes = temporaryFailCodes
+        self.permanentFailCodes = permanentFailCodes
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -12972,6 +13879,7 @@ class CommandLineTool(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class DockerRequirement(ProcessRequirement):
     """
     Indicates that a workflow component should be run in a `Docker <http://docker.com>`__ container, and specifies how to fetch or build the image.
@@ -12992,33 +13900,6 @@ class DockerRequirement(ProcessRequirement):
     If `EnvVarRequirement <#EnvVarRequirement>`__ is specified alongside a DockerRequirement, the environment variables must be provided to Docker using ``--env`` or ``--env-file`` and interact with the container's preexisting environment as defined by Docker.
 
     """
-
-    def __init__(
-        self,
-        dockerPull: Any | None = None,
-        dockerLoad: Any | None = None,
-        dockerFile: Any | None = None,
-        dockerImport: Any | None = None,
-        dockerImageId: Any | None = None,
-        dockerOutputDirectory: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "DockerRequirement"
-        self.dockerPull = dockerPull
-        self.dockerLoad = dockerLoad
-        self.dockerFile = dockerFile
-        self.dockerImport = dockerImport
-        self.dockerImageId = dockerImageId
-        self.dockerOutputDirectory = dockerOutputDirectory
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, DockerRequirement):
@@ -13467,6 +14348,33 @@ class DockerRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        dockerPull: None | str = None,
+        dockerLoad: None | str = None,
+        dockerFile: None | str = None,
+        dockerImport: None | str = None,
+        dockerImageId: None | str = None,
+        dockerOutputDirectory: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "DockerRequirement"
+        self.dockerPull = dockerPull
+        self.dockerLoad = dockerLoad
+        self.dockerFile = dockerFile
+        self.dockerImport = dockerImport
+        self.dockerImageId = dockerImageId
+        self.dockerOutputDirectory = dockerOutputDirectory
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -13480,28 +14388,12 @@ class DockerRequirement(ProcessRequirement):
     )
 
 
+@mypyc_attr(native_class=True)
 class SoftwareRequirement(ProcessRequirement):
     """
     A list of software packages that should be configured in the environment of the defined process.
 
     """
-
-    def __init__(
-        self,
-        packages: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "SoftwareRequirement"
-        self.packages = packages
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SoftwareRequirement):
@@ -13655,15 +14547,9 @@ class SoftwareRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "packages"])
-
-
-class SoftwarePackage(Saveable):
     def __init__(
         self,
-        package: Any,
-        version: Any | None = None,
-        specs: Any | None = None,
+        packages: Sequence[SoftwarePackage],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -13672,13 +14558,17 @@ class SoftwarePackage(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.package = package
-        self.version = version
-        self.specs = specs
+        self.class_: Final[str] = "SoftwareRequirement"
+        self.packages = packages
 
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "packages"])
+
+
+@mypyc_attr(native_class=True)
+class SoftwarePackage(Saveable):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SoftwarePackage):
             return bool(
@@ -13911,20 +14801,11 @@ class SoftwarePackage(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["package", "version", "specs"])
-
-
-class Dirent(Saveable):
-    """
-    Define a file or subdirectory that must be placed in the designated output directory prior to executing the command line tool.  May be the result of executing an expression, such as building a configuration file from a template.
-
-    """
-
     def __init__(
         self,
-        entry: Any,
-        entryname: Any | None = None,
-        writable: Any | None = None,
+        package: str,
+        version: None | Sequence[str] = None,
+        specs: None | Sequence[str] = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -13933,12 +14814,22 @@ class Dirent(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.entryname = entryname
-        self.entry = entry
-        self.writable = writable
+        self.package = package
+        self.version = version
+        self.specs = specs
+
+    attrs: ClassVar[Collection[str]] = frozenset(["package", "version", "specs"])
+
+
+@mypyc_attr(native_class=True)
+class Dirent(Saveable):
+    """
+    Define a file or subdirectory that must be placed in the designated output directory prior to executing the command line tool.  May be the result of executing an expression, such as building a configuration file from a template.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Dirent):
@@ -14176,18 +15067,11 @@ class Dirent(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["entryname", "entry", "writable"])
-
-
-class InitialWorkDirRequirement(ProcessRequirement):
-    """
-    Define a list of files and subdirectories that must be created by the workflow platform in the designated output directory prior to executing the command line tool.
-
-    """
-
     def __init__(
         self,
-        listing: Any,
+        entry: str,
+        entryname: None | str = None,
+        writable: None | bool = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -14196,11 +15080,22 @@ class InitialWorkDirRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "InitialWorkDirRequirement"
-        self.listing = listing
+        self.entryname = entryname
+        self.entry = entry
+        self.writable = writable
+
+    attrs: ClassVar[Collection[str]] = frozenset(["entryname", "entry", "writable"])
+
+
+@mypyc_attr(native_class=True)
+class InitialWorkDirRequirement(ProcessRequirement):
+    """
+    Define a list of files and subdirectories that must be created by the workflow platform in the designated output directory prior to executing the command line tool.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InitialWorkDirRequirement):
@@ -14354,18 +15249,9 @@ class InitialWorkDirRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "listing"])
-
-
-class EnvVarRequirement(ProcessRequirement):
-    """
-    Define a list of environment variables which will be set in the execution environment of the tool.  See ``EnvironmentDef`` for details.
-
-    """
-
     def __init__(
         self,
-        envDef: Any,
+        listing: Sequence[Directory | Dirent | File | str] | str,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -14374,11 +15260,21 @@ class EnvVarRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "EnvVarRequirement"
-        self.envDef = envDef
+        self.class_: Final[str] = "InitialWorkDirRequirement"
+        self.listing = listing
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "listing"])
+
+
+@mypyc_attr(native_class=True)
+class EnvVarRequirement(ProcessRequirement):
+    """
+    Define a list of environment variables which will be set in the execution environment of the tool.  See ``EnvironmentDef`` for details.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, EnvVarRequirement):
@@ -14532,17 +15428,9 @@ class EnvVarRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "envDef"])
-
-
-class ShellCommandRequirement(ProcessRequirement):
-    """
-    Modify the behavior of CommandLineTool to generate a single string containing a shell command line.  Each item in the argument list must be joined into a string separated by single spaces and quoted to prevent interpretation by the shell, unless ``CommandLineBinding`` for that argument contains ``shellQuote: false``.  If ``shellQuote: false`` is specified, the argument is joined into the command string without quoting, which allows the use of shell metacharacters such as ``|`` for pipes.
-
-    """
-
     def __init__(
         self,
+        envDef: Sequence[EnvironmentDef],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -14551,10 +15439,21 @@ class ShellCommandRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ShellCommandRequirement"
+        self.class_: Final[str] = "EnvVarRequirement"
+        self.envDef = envDef
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "envDef"])
+
+
+@mypyc_attr(native_class=True)
+class ShellCommandRequirement(ProcessRequirement):
+    """
+    Modify the behavior of CommandLineTool to generate a single string containing a shell command line.  Each item in the argument list must be joined into a string separated by single spaces and quoted to prevent interpretation by the shell, unless ``CommandLineBinding`` for that argument contains ``shellQuote: false``.  If ``shellQuote: false`` is specified, the argument is joined into the command string without quoting, which allows the use of shell metacharacters such as ``|`` for pipes.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ShellCommandRequirement):
@@ -14653,9 +15552,25 @@ class ShellCommandRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "ShellCommandRequirement"
+
     attrs: ClassVar[Collection[str]] = frozenset(["class"])
 
 
+@mypyc_attr(native_class=True)
 class ResourceRequirement(ProcessRequirement):
     """
     Specify basic hardware resource requirements.
@@ -14673,37 +15588,6 @@ class ResourceRequirement(ProcessRequirement):
     If neither "min" nor "max" is specified for a resource, an implementation may provide a default.
 
     """
-
-    def __init__(
-        self,
-        coresMin: Any | None = None,
-        coresMax: Any | None = None,
-        ramMin: Any | None = None,
-        ramMax: Any | None = None,
-        tmpdirMin: Any | None = None,
-        tmpdirMax: Any | None = None,
-        outdirMin: Any | None = None,
-        outdirMax: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ResourceRequirement"
-        self.coresMin = coresMin
-        self.coresMax = coresMax
-        self.ramMin = ramMin
-        self.ramMax = ramMax
-        self.tmpdirMin = tmpdirMin
-        self.tmpdirMax = tmpdirMax
-        self.outdirMin = outdirMin
-        self.outdirMax = outdirMax
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ResourceRequirement):
@@ -14771,7 +15655,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 coresMin = _load_field(
                     _doc.get("coresMin"),
-                    union_of_None_type_or_inttype_or_strtype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_strtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("coresMin")
@@ -14865,7 +15749,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 ramMin = _load_field(
                     _doc.get("ramMin"),
-                    union_of_None_type_or_inttype_or_strtype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_strtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("ramMin")
@@ -14912,7 +15796,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 ramMax = _load_field(
                     _doc.get("ramMax"),
-                    union_of_None_type_or_inttype_or_strtype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_strtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("ramMax")
@@ -14959,7 +15843,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 tmpdirMin = _load_field(
                     _doc.get("tmpdirMin"),
-                    union_of_None_type_or_inttype_or_strtype_or_ExpressionLoader,
+                    union_of_None_type_or_longtype_or_strtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("tmpdirMin")
@@ -15006,7 +15890,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 tmpdirMax = _load_field(
                     _doc.get("tmpdirMax"),
-                    union_of_None_type_or_inttype_or_strtype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_strtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("tmpdirMax")
@@ -15053,7 +15937,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 outdirMin = _load_field(
                     _doc.get("outdirMin"),
-                    union_of_None_type_or_inttype_or_strtype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_strtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outdirMin")
@@ -15100,7 +15984,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 outdirMax = _load_field(
                     _doc.get("outdirMax"),
-                    union_of_None_type_or_inttype_or_strtype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_strtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outdirMax")
@@ -15254,6 +16138,37 @@ class ResourceRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        coresMin: None | i32 | i64 | str = None,
+        coresMax: None | i32 | str = None,
+        ramMin: None | i32 | i64 | str = None,
+        ramMax: None | i32 | i64 | str = None,
+        tmpdirMin: None | i64 | str = None,
+        tmpdirMax: None | i32 | i64 | str = None,
+        outdirMin: None | i32 | i64 | str = None,
+        outdirMax: None | i32 | i64 | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "ResourceRequirement"
+        self.coresMin = coresMin
+        self.coresMax = coresMax
+        self.ramMin = ramMin
+        self.ramMax = ramMax
+        self.tmpdirMin = tmpdirMin
+        self.tmpdirMax = tmpdirMax
+        self.outdirMin = outdirMin
+        self.outdirMax = outdirMax
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -15269,38 +16184,9 @@ class ResourceRequirement(ProcessRequirement):
     )
 
 
+@mypyc_attr(native_class=True)
 class ExpressionToolOutputParameter(OutputParameter):
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        outputBinding: Any | None = None,
-        format: Any | None = None,
-        type_: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.outputBinding = outputBinding
-        self.format = format
-        self.type_ = type_
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ExpressionToolOutputParameter):
@@ -15391,15 +16277,62 @@ class ExpressionToolOutputParameter(OutputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -15593,7 +16526,7 @@ class ExpressionToolOutputParameter(OutputParameter):
             try:
                 outputBinding = _load_field(
                     _doc.get("outputBinding"),
-                    union_of_None_type_or_CommandOutputBindingLoader,
+                    union_of_None_type_or_OutputBindingProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outputBinding")
@@ -15687,7 +16620,7 @@ class ExpressionToolOutputParameter(OutputParameter):
             try:
                 type_ = _load_field(
                     _doc.get("type"),
-                    typedsl_union_of_None_type_or_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2,
+                    typedsl_union_of_None_type_or_OutputParameterTypeLoader_2,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("type")
@@ -15754,18 +16687,18 @@ class ExpressionToolOutputParameter(OutputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             outputBinding=outputBinding,
             format=format,
             type_=type_,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -15780,7 +16713,10 @@ class ExpressionToolOutputParameter(OutputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -15827,6 +16763,36 @@ class ExpressionToolOutputParameter(OutputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        label: None | str = None,
+        secondaryFiles: None | Sequence[str] | str = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        outputBinding: None | OutputBinding = None,
+        format: None | str = None,
+        type_: None | OutputParameterType = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.outputBinding = outputBinding
+        self.format = format
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -15841,6 +16807,7 @@ class ExpressionToolOutputParameter(OutputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class ExpressionTool(Process):
     """
     Execute an expression as a Workflow step.
@@ -15848,39 +16815,6 @@ class ExpressionTool(Process):
     """
 
     id: str
-
-    def __init__(
-        self,
-        inputs: Any,
-        outputs: Any,
-        expression: Any,
-        id: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        cwlVersion: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.label = label
-        self.doc = doc
-        self.cwlVersion = cwlVersion
-        self.class_: Final[str] = "ExpressionTool"
-        self.expression = expression
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ExpressionTool):
@@ -15975,15 +16909,61 @@ class ExpressionTool(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -16102,7 +17082,7 @@ class ExpressionTool(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -16149,7 +17129,7 @@ class ExpressionTool(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -16417,7 +17397,7 @@ class ExpressionTool(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -16432,7 +17412,10 @@ class ExpressionTool(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -16490,6 +17473,39 @@ class ExpressionTool(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[InputParameter],
+        outputs: Sequence[ExpressionToolOutputParameter],
+        expression: str,
+        id: None | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        label: None | str = None,
+        doc: None | str = None,
+        cwlVersion: CWLVersion | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.label = label
+        self.doc = doc
+        self.cwlVersion = cwlVersion
+        self.class_: Final[str] = "ExpressionTool"
+        self.expression = expression
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -16506,6 +17522,7 @@ class ExpressionTool(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class WorkflowOutputParameter(OutputParameter):
     """
     Describe an output parameter of a workflow.  The parameter must be connected to one or more parameters defined in the workflow that will provide the value of the output parameter.
@@ -16513,40 +17530,6 @@ class WorkflowOutputParameter(OutputParameter):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        outputBinding: Any | None = None,
-        format: Any | None = None,
-        outputSource: Any | None = None,
-        linkMerge: Any | None = None,
-        type_: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.outputBinding = outputBinding
-        self.format = format
-        self.outputSource = outputSource
-        self.linkMerge = linkMerge
-        self.type_ = type_
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowOutputParameter):
@@ -16641,15 +17624,62 @@ class WorkflowOutputParameter(OutputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -16843,7 +17873,7 @@ class WorkflowOutputParameter(OutputParameter):
             try:
                 outputBinding = _load_field(
                     _doc.get("outputBinding"),
-                    union_of_None_type_or_CommandOutputBindingLoader,
+                    union_of_None_type_or_OutputBindingProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outputBinding")
@@ -17031,7 +18061,7 @@ class WorkflowOutputParameter(OutputParameter):
             try:
                 type_ = _load_field(
                     _doc.get("type"),
-                    typedsl_union_of_None_type_or_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2,
+                    typedsl_union_of_None_type_or_OutputParameterTypeLoader_2,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("type")
@@ -17098,11 +18128,11 @@ class WorkflowOutputParameter(OutputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             outputBinding=outputBinding,
             format=format,
             outputSource=outputSource,
@@ -17111,7 +18141,7 @@ class WorkflowOutputParameter(OutputParameter):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -17126,7 +18156,10 @@ class WorkflowOutputParameter(OutputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -17180,6 +18213,40 @@ class WorkflowOutputParameter(OutputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        label: None | str = None,
+        secondaryFiles: None | Sequence[str] | str = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        outputBinding: None | OutputBinding = None,
+        format: None | str = None,
+        outputSource: None | Sequence[str] | str = None,
+        linkMerge: LinkMergeMethod | None = None,
+        type_: None | OutputParameterType = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.outputBinding = outputBinding
+        self.format = format
+        self.outputSource = outputSource
+        self.linkMerge = linkMerge
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -17196,10 +18263,13 @@ class WorkflowOutputParameter(OutputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Sink(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
 class WorkflowStepInput(Sink):
     """
     The input of a workflow step connects an upstream parameter (from the workflow inputs, or the outputs of other workflows steps) with the input parameters of the underlying step.
@@ -17228,30 +18298,6 @@ class WorkflowStepInput(Sink):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        source: Any | None = None,
-        linkMerge: Any | None = None,
-        default: Any | None = None,
-        valueFrom: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.source = source
-        self.linkMerge = linkMerge
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.default = default
-        self.valueFrom = valueFrom
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowStepInput):
@@ -17330,15 +18376,62 @@ class WorkflowStepInput(Sink):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         source = None
         if "source" in _doc:
             try:
@@ -17552,15 +18645,15 @@ class WorkflowStepInput(Sink):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             source=source,
             linkMerge=linkMerge,
-            id=id,
             default=default,
             valueFrom=valueFrom,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -17575,7 +18668,10 @@ class WorkflowStepInput(Sink):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.source is not None:
             u = save_relative_uri(self.source, self.id, False, 2, relative_uris)
@@ -17601,22 +18697,13 @@ class WorkflowStepInput(Sink):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["source", "linkMerge", "id", "default", "valueFrom"]
-    )
-
-
-class WorkflowStepOutput(Saveable):
-    """
-    Associate an output parameter of the underlying process with a workflow parameter.  The workflow parameter (given in the ``id`` field) be may be used as a ``source`` to connect with input parameters of other workflow steps, or with an output parameter of the process.
-
-    """
-
-    id: str
-
     def __init__(
         self,
-        id: Any,
+        id: str,
+        source: None | Sequence[str] | str = None,
+        linkMerge: LinkMergeMethod | None = None,
+        default: CWLObjectType | None = None,
+        valueFrom: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -17625,10 +18712,28 @@ class WorkflowStepOutput(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.source = source
+        self.linkMerge = linkMerge
+        self.id = id
+        self.default = default
+        self.valueFrom = valueFrom
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["source", "linkMerge", "id", "default", "valueFrom"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class WorkflowStepOutput(Saveable):
+    """
+    Associate an output parameter of the underlying process with a workflow parameter.  The workflow parameter (given in the ``id`` field) be may be used as a ``source`` to connect with input parameters of other workflow steps, or with an output parameter of the process.
+
+    """
+
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowStepOutput):
@@ -17699,15 +18804,62 @@ class WorkflowStepOutput(Saveable):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         extension_fields: MutableMapping[str, Any] = {}
         for k in _doc.keys():
             if k not in cls.attrs:
@@ -17735,7 +18887,7 @@ class WorkflowStepOutput(Saveable):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -17750,7 +18902,10 @@ class WorkflowStepOutput(Saveable):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
 
         # top refers to the directory level
@@ -17761,9 +18916,26 @@ class WorkflowStepOutput(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id
+
     attrs: ClassVar[Collection[str]] = frozenset(["id"])
 
 
+@mypyc_attr(native_class=True)
 class WorkflowStep(Saveable):
     """
     A workflow step is an executable element of a workflow.  It specifies the underlying process implementation (such as ``CommandLineTool`` or another ``Workflow``) in the ``run`` field and connects the input and output parameters of the underlying process to workflow parameters.
@@ -17799,40 +18971,6 @@ class WorkflowStep(Saveable):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        in_: Any,
-        out: Any,
-        run: Any,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        scatter: Any | None = None,
-        scatterMethod: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.in_ = in_
-        self.out = out
-        self.requirements = requirements
-        self.hints = hints
-        self.label = label
-        self.doc = doc
-        self.run = run
-        self.scatter = scatter
-        self.scatterMethod = scatterMethod
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowStep):
@@ -17927,15 +19065,62 @@ class WorkflowStep(Saveable):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("in") is None:
                 raise ValidationException("missing required field `in`", None, [])
@@ -18037,7 +19222,7 @@ class WorkflowStep(Saveable):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -18226,7 +19411,7 @@ class WorkflowStep(Saveable):
 
             run = _load_field(
                 _doc.get("run"),
-                uri_union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader_False_False_None_None,
+                uri_union_of_strtype_or_ProcessProxyLoader_False_False_None_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("run")
@@ -18400,7 +19585,7 @@ class WorkflowStep(Saveable):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -18415,7 +19600,10 @@ class WorkflowStep(Saveable):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.in_ is not None:
             r["in"] = save(
@@ -18463,6 +19651,40 @@ class WorkflowStep(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        in_: Sequence[WorkflowStepInput],
+        out: Sequence[WorkflowStepOutput | str],
+        run: Process | str,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any] = None,
+        label: None | str = None,
+        doc: None | str = None,
+        scatter: None | Sequence[str] | str = None,
+        scatterMethod: None | ScatterMethod = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id
+        self.in_ = in_
+        self.out = out
+        self.requirements = requirements
+        self.hints = hints
+        self.label = label
+        self.doc = doc
+        self.run = run
+        self.scatter = scatter
+        self.scatterMethod = scatterMethod
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -18479,6 +19701,7 @@ class WorkflowStep(Saveable):
     )
 
 
+@mypyc_attr(native_class=True)
 class Workflow(Process):
     """
     A workflow describes a set of **steps** and the **dependencies** between those steps.  When a step produces output that will be consumed by a second step, the first step is a dependency of the second step.
@@ -18508,39 +19731,6 @@ class Workflow(Process):
     """
 
     id: str
-
-    def __init__(
-        self,
-        inputs: Any,
-        outputs: Any,
-        steps: Any,
-        id: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        cwlVersion: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.label = label
-        self.doc = doc
-        self.cwlVersion = cwlVersion
-        self.class_: Final[str] = "Workflow"
-        self.steps = steps
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Workflow):
@@ -18635,15 +19825,61 @@ class Workflow(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -18762,7 +19998,7 @@ class Workflow(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -18809,7 +20045,7 @@ class Workflow(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -19077,7 +20313,7 @@ class Workflow(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -19092,7 +20328,10 @@ class Workflow(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -19147,6 +20386,39 @@ class Workflow(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[InputParameter],
+        outputs: Sequence[WorkflowOutputParameter],
+        steps: Sequence[WorkflowStep],
+        id: None | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        label: None | str = None,
+        doc: None | str = None,
+        cwlVersion: CWLVersion | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.label = label
+        self.doc = doc
+        self.cwlVersion = cwlVersion
+        self.class_: Final[str] = "Workflow"
+        self.steps = steps
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -19163,26 +20435,12 @@ class Workflow(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class SubworkflowFeatureRequirement(ProcessRequirement):
     """
     Indicates that the workflow platform must support nested workflows in the ``run`` field of `WorkflowStep <#WorkflowStep>`__.
 
     """
-
-    def __init__(
-        self,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "SubworkflowFeatureRequirement"
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SubworkflowFeatureRequirement):
@@ -19281,15 +20539,6 @@ class SubworkflowFeatureRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class ScatterFeatureRequirement(ProcessRequirement):
-    """
-    Indicates that the workflow platform must support the ``scatter`` and ``scatterMethod`` fields of `WorkflowStep <#WorkflowStep>`__.
-
-    """
-
     def __init__(
         self,
         extension_fields: MutableMapping[str, Any] | None = None,
@@ -19300,10 +20549,20 @@ class ScatterFeatureRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ScatterFeatureRequirement"
+        self.class_: Final[str] = "SubworkflowFeatureRequirement"
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class ScatterFeatureRequirement(ProcessRequirement):
+    """
+    Indicates that the workflow platform must support the ``scatter`` and ``scatterMethod`` fields of `WorkflowStep <#WorkflowStep>`__.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ScatterFeatureRequirement):
@@ -19402,15 +20661,6 @@ class ScatterFeatureRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class MultipleInputFeatureRequirement(ProcessRequirement):
-    """
-    Indicates that the workflow platform must support multiple inbound data links listed in the ``source`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
-
-    """
-
     def __init__(
         self,
         extension_fields: MutableMapping[str, Any] | None = None,
@@ -19421,10 +20671,20 @@ class MultipleInputFeatureRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "MultipleInputFeatureRequirement"
+        self.class_: Final[str] = "ScatterFeatureRequirement"
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class MultipleInputFeatureRequirement(ProcessRequirement):
+    """
+    Indicates that the workflow platform must support multiple inbound data links listed in the ``source`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, MultipleInputFeatureRequirement):
@@ -19523,15 +20783,6 @@ class MultipleInputFeatureRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class StepInputExpressionRequirement(ProcessRequirement):
-    """
-    Indicate that the workflow platform must support the ``valueFrom`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
-
-    """
-
     def __init__(
         self,
         extension_fields: MutableMapping[str, Any] | None = None,
@@ -19542,10 +20793,20 @@ class StepInputExpressionRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "StepInputExpressionRequirement"
+        self.class_: Final[str] = "MultipleInputFeatureRequirement"
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class StepInputExpressionRequirement(ProcessRequirement):
+    """
+    Indicate that the workflow platform must support the ``valueFrom`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, StepInputExpressionRequirement):
@@ -19644,13 +20905,8 @@ class StepInputExpressionRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class LoadListingRequirement(ProcessRequirement):
     def __init__(
         self,
-        loadListing: Any,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -19659,12 +20915,16 @@ class LoadListingRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "LoadListingRequirement"
-        self.loadListing = loadListing
+        self.class_: Final[str] = "StepInputExpressionRequirement"
 
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class LoadListingRequirement(ProcessRequirement):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, LoadListingRequirement):
             return bool(
@@ -19822,13 +21082,9 @@ class LoadListingRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "loadListing"])
-
-
-class InplaceUpdateRequirement(ProcessRequirement):
     def __init__(
         self,
-        inplaceUpdate: Any,
+        loadListing: LoadListingEnum,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -19837,12 +21093,17 @@ class InplaceUpdateRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "InplaceUpdateRequirement"
-        self.inplaceUpdate = inplaceUpdate
+        self.class_: Final[str] = "LoadListingRequirement"
+        self.loadListing = loadListing
 
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "loadListing"])
+
+
+@mypyc_attr(native_class=True)
+class InplaceUpdateRequirement(ProcessRequirement):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InplaceUpdateRequirement):
             return bool(
@@ -20001,13 +21262,9 @@ class InplaceUpdateRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "inplaceUpdate"])
-
-
-class Secrets(ProcessRequirement):
     def __init__(
         self,
-        secrets: Any,
+        inplaceUpdate: bool,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -20016,12 +21273,17 @@ class Secrets(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "Secrets"
-        self.secrets = secrets
+        self.class_: Final[str] = "InplaceUpdateRequirement"
+        self.inplaceUpdate = inplaceUpdate
 
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "inplaceUpdate"])
+
+
+@mypyc_attr(native_class=True)
+class Secrets(ProcessRequirement):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Secrets):
             return bool(self.class_ == other.class_ and self.secrets == other.secrets)
@@ -20173,18 +21435,9 @@ class Secrets(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "secrets"])
-
-
-class TimeLimit(ProcessRequirement):
-    """
-    Set an upper limit on the execution time of a CommandLineTool or ExpressionTool.  A tool execution which exceeds the time limit may be preemptively terminated and considered failed.  May also be used by batch systems to make scheduling decisions.
-
-    """
-
     def __init__(
         self,
-        timelimit: Any,
+        secrets: Sequence[str],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -20193,11 +21446,21 @@ class TimeLimit(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "TimeLimit"
-        self.timelimit = timelimit
+        self.class_: Final[str] = "Secrets"
+        self.secrets = secrets
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "secrets"])
+
+
+@mypyc_attr(native_class=True)
+class TimeLimit(ProcessRequirement):
+    """
+    Set an upper limit on the execution time of a CommandLineTool or ExpressionTool.  A tool execution which exceeds the time limit may be preemptively terminated and considered failed.  May also be used by batch systems to make scheduling decisions.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, TimeLimit):
@@ -20246,7 +21509,7 @@ class TimeLimit(ProcessRequirement):
 
             timelimit = _load_field(
                 _doc.get("timelimit"),
-                union_of_inttype_or_strtype,
+                union_of_longtype_or_strtype,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("timelimit")
@@ -20356,20 +21619,9 @@ class TimeLimit(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "timelimit"])
-
-
-class WorkReuse(ProcessRequirement):
-    """
-    For implementations that support reusing output from past work (on the assumption that same code and same input produce same results), control whether to enable or disable the reuse behavior for a particular tool or step (to accommodate situations where that assumption is incorrect).  A reused step is not executed but instead returns the same output as the original execution.
-
-    If ``enableReuse`` is not specified, correct tools should assume it is enabled by default.
-
-    """
-
     def __init__(
         self,
-        enableReuse: Any,
+        timelimit: i64 | str,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -20378,11 +21630,23 @@ class WorkReuse(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "WorkReuse"
-        self.enableReuse = enableReuse
+        self.class_: Final[str] = "TimeLimit"
+        self.timelimit = timelimit
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "timelimit"])
+
+
+@mypyc_attr(native_class=True)
+class WorkReuse(ProcessRequirement):
+    """
+    For implementations that support reusing output from past work (on the assumption that same code and same input produce same results), control whether to enable or disable the reuse behavior for a particular tool or step (to accommodate situations where that assumption is incorrect).  A reused step is not executed but instead returns the same output as the original execution.
+
+    If ``enableReuse`` is not specified, correct tools should assume it is enabled by default.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkReuse):
@@ -20541,9 +21805,27 @@ class WorkReuse(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        enableReuse: bool | str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "WorkReuse"
+        self.enableReuse = enableReuse
+
     attrs: ClassVar[Collection[str]] = frozenset(["class", "enableReuse"])
 
 
+@mypyc_attr(native_class=True)
 class NetworkAccess(ProcessRequirement):
     """
     Indicate whether a process requires outgoing IPv4/IPv6 network access.  Choice of IPv4 or IPv6 is implementation and site specific, correct tools must support both.
@@ -20555,23 +21837,6 @@ class NetworkAccess(ProcessRequirement):
     Enabling network access does not imply a publicly routable IP address or the ability to accept inbound connections.
 
     """
-
-    def __init__(
-        self,
-        networkAccess: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "NetworkAccess"
-        self.networkAccess = networkAccess
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, NetworkAccess):
@@ -20731,23 +21996,9 @@ class NetworkAccess(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "networkAccess"])
-
-
-class ProcessGenerator(Process):
-    id: str
-
     def __init__(
         self,
-        inputs: Any,
-        outputs: Any,
-        run: Any,
-        id: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        cwlVersion: Any | None = None,
+        networkAccess: bool | str,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -20756,19 +22007,18 @@ class ProcessGenerator(Process):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.label = label
-        self.doc = doc
-        self.cwlVersion = cwlVersion
-        self.class_: Final[str] = "ProcessGenerator"
-        self.run = run
+        self.class_: Final[str] = "NetworkAccess"
+        self.networkAccess = networkAccess
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "networkAccess"])
+
+
+@mypyc_attr(native_class=True)
+class ProcessGenerator(Process):
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ProcessGenerator):
@@ -20863,15 +22113,61 @@ class ProcessGenerator(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -20990,7 +22286,7 @@ class ProcessGenerator(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -21037,7 +22333,7 @@ class ProcessGenerator(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -21226,7 +22522,7 @@ class ProcessGenerator(Process):
 
             run = _load_field(
                 _doc.get("run"),
-                uri_union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader_False_False_None_None,
+                uri_union_of_strtype_or_ProcessProxyLoader_False_False_None_None,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("run")
@@ -21305,7 +22601,7 @@ class ProcessGenerator(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -21320,7 +22616,10 @@ class ProcessGenerator(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -21374,6 +22673,39 @@ class ProcessGenerator(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[InputParameter],
+        outputs: Sequence[ExpressionToolOutputParameter],
+        run: Process | str,
+        id: None | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        label: None | str = None,
+        doc: None | str = None,
+        cwlVersion: CWLVersion | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.label = label
+        self.doc = doc
+        self.cwlVersion = cwlVersion
+        self.class_: Final[str] = "ProcessGenerator"
+        self.run = run
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -21390,28 +22722,12 @@ class ProcessGenerator(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class MPIRequirement(ProcessRequirement):
     """
     Indicates that a process requires an MPI runtime.
 
     """
-
-    def __init__(
-        self,
-        processes: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "MPIRequirement"
-        self.processes = processes
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, MPIRequirement):
@@ -21570,21 +22886,9 @@ class MPIRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "processes"])
-
-
-class CUDARequirement(ProcessRequirement):
-    """
-    Require support for NVIDA CUDA (GPU hardware acceleration).
-
-    """
-
     def __init__(
         self,
-        cudaComputeCapability: Any,
-        cudaVersionMin: Any,
-        cudaDeviceCountMax: Any | None = None,
-        cudaDeviceCountMin: Any | None = None,
+        processes: i32 | str,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -21593,14 +22897,21 @@ class CUDARequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "CUDARequirement"
-        self.cudaComputeCapability = cudaComputeCapability
-        self.cudaDeviceCountMax = cudaDeviceCountMax
-        self.cudaDeviceCountMin = cudaDeviceCountMin
-        self.cudaVersionMin = cudaVersionMin
+        self.class_: Final[str] = "MPIRequirement"
+        self.processes = processes
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "processes"])
+
+
+@mypyc_attr(native_class=True)
+class CUDARequirement(ProcessRequirement):
+    """
+    Require support for NVIDA CUDA (GPU hardware acceleration).
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CUDARequirement):
@@ -21937,6 +23248,29 @@ class CUDARequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        cudaComputeCapability: Sequence[str] | str,
+        cudaVersionMin: str,
+        cudaDeviceCountMax: None | i32 | str = None,
+        cudaDeviceCountMin: None | i32 | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "CUDARequirement"
+        self.cudaComputeCapability = cudaComputeCapability
+        self.cudaDeviceCountMax = cudaDeviceCountMax
+        self.cudaDeviceCountMin = cudaDeviceCountMin
+        self.cudaVersionMin = cudaVersionMin
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -21948,24 +23282,8 @@ class CUDARequirement(ProcessRequirement):
     )
 
 
+@mypyc_attr(native_class=True)
 class ShmSize(ProcessRequirement):
-    def __init__(
-        self,
-        shmSize: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ShmSize"
-        self.shmSize = shmSize
-
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ShmSize):
             return bool(self.class_ == other.class_ and self.shmSize == other.shmSize)
@@ -22118,6 +23436,23 @@ class ShmSize(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        shmSize: str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "ShmSize"
+        self.shmSize = shmSize
+
     attrs: ClassVar[Collection[str]] = frozenset(["class", "shmSize"])
 
 
@@ -22135,6 +23470,7 @@ _vocab.update({
     "CommandInputArraySchema": "https://w3id.org/cwl/cwl#CommandInputArraySchema",
     "CommandInputEnumSchema": "https://w3id.org/cwl/cwl#CommandInputEnumSchema",
     "CommandInputParameter": "https://w3id.org/cwl/cwl#CommandInputParameter",
+    "CommandInputParameterType": "https://w3id.org/cwl/cwl#CommandInputParameterType",
     "CommandInputRecordField": "https://w3id.org/cwl/cwl#CommandInputRecordField",
     "CommandInputRecordSchema": "https://w3id.org/cwl/cwl#CommandInputRecordSchema",
     "CommandLineBinding": "https://w3id.org/cwl/cwl#CommandLineBinding",
@@ -22143,6 +23479,7 @@ _vocab.update({
     "CommandOutputBinding": "https://w3id.org/cwl/cwl#CommandOutputBinding",
     "CommandOutputEnumSchema": "https://w3id.org/cwl/cwl#CommandOutputEnumSchema",
     "CommandOutputParameter": "https://w3id.org/cwl/cwl#CommandOutputParameter",
+    "CommandOutputParameterType": "https://w3id.org/cwl/cwl#CommandOutputParameterType",
     "CommandOutputRecordField": "https://w3id.org/cwl/cwl#CommandOutputRecordField",
     "CommandOutputRecordSchema": "https://w3id.org/cwl/cwl#CommandOutputRecordSchema",
     "Directory": "https://w3id.org/cwl/cwl#Directory",
@@ -22164,6 +23501,7 @@ _vocab.update({
     "InputBinding": "https://w3id.org/cwl/cwl#InputBinding",
     "InputEnumSchema": "https://w3id.org/cwl/cwl#InputEnumSchema",
     "InputParameter": "https://w3id.org/cwl/cwl#InputParameter",
+    "InputParameterType": "https://w3id.org/cwl/cwl#InputParameterType",
     "InputRecordField": "https://w3id.org/cwl/cwl#InputRecordField",
     "InputRecordSchema": "https://w3id.org/cwl/cwl#InputRecordSchema",
     "InputSchema": "https://w3id.org/cwl/cwl#InputSchema",
@@ -22177,6 +23515,7 @@ _vocab.update({
     "OutputBinding": "https://w3id.org/cwl/cwl#OutputBinding",
     "OutputEnumSchema": "https://w3id.org/cwl/cwl#OutputEnumSchema",
     "OutputParameter": "https://w3id.org/cwl/cwl#OutputParameter",
+    "OutputParameterType": "https://w3id.org/cwl/cwl#OutputParameterType",
     "OutputRecordField": "https://w3id.org/cwl/cwl#OutputRecordField",
     "OutputRecordSchema": "https://w3id.org/cwl/cwl#OutputRecordSchema",
     "OutputSchema": "https://w3id.org/cwl/cwl#OutputSchema",
@@ -22246,6 +23585,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#CommandInputArraySchema": "CommandInputArraySchema",
     "https://w3id.org/cwl/cwl#CommandInputEnumSchema": "CommandInputEnumSchema",
     "https://w3id.org/cwl/cwl#CommandInputParameter": "CommandInputParameter",
+    "https://w3id.org/cwl/cwl#CommandInputParameterType": "CommandInputParameterType",
     "https://w3id.org/cwl/cwl#CommandInputRecordField": "CommandInputRecordField",
     "https://w3id.org/cwl/cwl#CommandInputRecordSchema": "CommandInputRecordSchema",
     "https://w3id.org/cwl/cwl#CommandLineBinding": "CommandLineBinding",
@@ -22254,6 +23594,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#CommandOutputBinding": "CommandOutputBinding",
     "https://w3id.org/cwl/cwl#CommandOutputEnumSchema": "CommandOutputEnumSchema",
     "https://w3id.org/cwl/cwl#CommandOutputParameter": "CommandOutputParameter",
+    "https://w3id.org/cwl/cwl#CommandOutputParameterType": "CommandOutputParameterType",
     "https://w3id.org/cwl/cwl#CommandOutputRecordField": "CommandOutputRecordField",
     "https://w3id.org/cwl/cwl#CommandOutputRecordSchema": "CommandOutputRecordSchema",
     "https://w3id.org/cwl/cwl#Directory": "Directory",
@@ -22275,6 +23616,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#InputBinding": "InputBinding",
     "https://w3id.org/cwl/cwl#InputEnumSchema": "InputEnumSchema",
     "https://w3id.org/cwl/cwl#InputParameter": "InputParameter",
+    "https://w3id.org/cwl/cwl#InputParameterType": "InputParameterType",
     "https://w3id.org/cwl/cwl#InputRecordField": "InputRecordField",
     "https://w3id.org/cwl/cwl#InputRecordSchema": "InputRecordSchema",
     "https://w3id.org/cwl/cwl#InputSchema": "InputSchema",
@@ -22288,6 +23630,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#OutputBinding": "OutputBinding",
     "https://w3id.org/cwl/cwl#OutputEnumSchema": "OutputEnumSchema",
     "https://w3id.org/cwl/cwl#OutputParameter": "OutputParameter",
+    "https://w3id.org/cwl/cwl#OutputParameterType": "OutputParameterType",
     "https://w3id.org/cwl/cwl#OutputRecordField": "OutputRecordField",
     "https://w3id.org/cwl/cwl#OutputRecordSchema": "OutputRecordSchema",
     "https://w3id.org/cwl/cwl#OutputSchema": "OutputSchema",
@@ -22344,14 +23687,20 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#v1.0": "v1.0",
 })
 
-strtype: Final = _PrimitiveLoader(str)
-inttype: Final = _PrimitiveLoader(int)
-floattype: Final = _PrimitiveLoader(float)
-booltype: Final = _PrimitiveLoader(bool)
-None_type: Final = _PrimitiveLoader(type(None))
-Any_type: Final = _AnyLoader()
-DocumentedProxyLoader: Final = _ProxyLoader("DocumentedLoader")
-PrimitiveTypeLoader: Final = _EnumLoader(
+strtype: Final[Loader[str]] = _PrimitiveLoader(str)
+inttype: Final[Loader[i32]] = _PrimitiveLoader(i32)
+longtype: Final[Loader[i64]] = _PrimitiveLoader(i64)
+floattype: Final[Loader[float]] = _PrimitiveLoader(float)
+booltype: Final[Loader[bool]] = _PrimitiveLoader(bool)
+None_type: Final[Loader[None]] = _PrimitiveLoader(type(None))
+Any_type: Final[Loader[Any]] = _AnyLoader()
+DocumentedProxyLoader: Final[Loader[schema_salad.metaschema.Documented]] = _ProxyLoader(
+    "DocumentedLoader"
+)
+PrimitiveType: TypeAlias = Literal[
+    "null", "boolean", "int", "long", "float", "double", "string"
+]
+PrimitiveTypeLoader: Final[Loader[PrimitiveType]] = _EnumLoader[PrimitiveType](
     (
         "null",
         "boolean",
@@ -22382,25 +23731,33 @@ double: double precision (64-bit) IEEE 754 floating-point number
 
 string: Unicode character sequence
 """
-AnyLoader: Final = _EnumLoader(("Any",), "Any")
+Any_: TypeAlias = Literal["Any"]
+Any_Loader: Final[Loader[Any_]] = _EnumLoader[Any_](("Any",), "Any_")
 """
 The **Any** type validates for any non-null value.
 """
-RecordFieldLoader: Final = _RecordLoader(
+RecordFieldLoader: Final[Loader[schema_salad.metaschema.RecordField]] = _RecordLoader(
     schema_salad.metaschema.RecordField, None, None
 )
-RecordSchemaLoader: Final = _RecordLoader(
+RecordSchemaLoader: Final[Loader[schema_salad.metaschema.RecordSchema]] = _RecordLoader(
     schema_salad.metaschema.RecordSchema, None, None
 )
-EnumSchemaLoader: Final = _RecordLoader(schema_salad.metaschema.EnumSchema, None, None)
-ArraySchemaLoader: Final = _RecordLoader(
+EnumSchemaLoader: Final[Loader[schema_salad.metaschema.EnumSchema]] = _RecordLoader(
+    schema_salad.metaschema.EnumSchema, None, None
+)
+ArraySchemaLoader: Final[Loader[schema_salad.metaschema.ArraySchema]] = _RecordLoader(
     schema_salad.metaschema.ArraySchema, None, None
 )
-MapSchemaLoader: Final = _RecordLoader(schema_salad.metaschema.MapSchema, None, None)
-UnionSchemaLoader: Final = _RecordLoader(
+MapSchemaLoader: Final[Loader[schema_salad.metaschema.MapSchema]] = _RecordLoader(
+    schema_salad.metaschema.MapSchema, None, None
+)
+UnionSchemaLoader: Final[Loader[schema_salad.metaschema.UnionSchema]] = _RecordLoader(
     schema_salad.metaschema.UnionSchema, None, None
 )
-CWLTypeLoader: Final = _EnumLoader(
+CWLType: TypeAlias = Literal[
+    "null", "boolean", "int", "long", "float", "double", "string", "File", "Directory"
+]
+CWLTypeLoader: Final[Loader[CWLType]] = _EnumLoader[CWLType](
     (
         "null",
         "boolean",
@@ -22421,80 +23778,248 @@ File: A File object
 
 Directory: A Directory object
 """
-CWLArraySchemaLoader: Final = _RecordLoader(CWLArraySchema, None, None)
-CWLRecordFieldLoader: Final = _RecordLoader(CWLRecordField, None, None)
-CWLRecordSchemaLoader: Final = _RecordLoader(CWLRecordSchema, None, None)
-FileLoader: Final = _RecordLoader(File, None, None)
-DirectoryLoader: Final = _RecordLoader(Directory, None, None)
-CWLObjectTypeLoader: Final = _UnionLoader((), "CWLObjectTypeLoader")
-union_of_None_type_or_CWLObjectTypeLoader: Final = _UnionLoader(
-    (
-        None_type,
-        CWLObjectTypeLoader,
+CWLArraySchemaLoader: Final[Loader[CWLArraySchema]] = _RecordLoader(
+    CWLArraySchema, None, None
+)
+CWLRecordFieldLoader: Final[Loader[CWLRecordField]] = _RecordLoader(
+    CWLRecordField, None, None
+)
+CWLRecordSchemaLoader: Final[Loader[CWLRecordSchema]] = _RecordLoader(
+    CWLRecordSchema, None, None
+)
+FileLoader: Final[Loader[File]] = _RecordLoader(File, None, None)
+DirectoryLoader: Final[Loader[Directory]] = _RecordLoader(Directory, None, None)
+CWLObjectTypeLoader: Final[Loader[CWLObjectType]] = _UnionLoader(
+    (), "CWLObjectTypeLoader"
+)
+union_of_None_type_or_CWLObjectTypeLoader: Final[Loader[CWLObjectType | None]] = (
+    _UnionLoader(
+        (
+            None_type,
+            CWLObjectTypeLoader,
+        )
     )
 )
-array_of_union_of_None_type_or_CWLObjectTypeLoader: Final = _ArrayLoader(
-    union_of_None_type_or_CWLObjectTypeLoader
+array_of_union_of_None_type_or_CWLObjectTypeLoader: Final[
+    Loader[Sequence[CWLObjectType | None]]
+] = _ArrayLoader(union_of_None_type_or_CWLObjectTypeLoader)
+map_of_union_of_None_type_or_CWLObjectTypeLoader: Final[
+    Loader[Mapping[str, CWLObjectType | None]]
+] = _MapLoader(union_of_None_type_or_CWLObjectTypeLoader, "CWLInputFile", "@list", True)
+CWLObjectType: TypeAlias = (
+    "Directory | File | Mapping[str, CWLObjectType | None] | Sequence[CWLObjectType | None] | bool | float | i32 | str"
 )
-map_of_union_of_None_type_or_CWLObjectTypeLoader: Final = _MapLoader(
-    union_of_None_type_or_CWLObjectTypeLoader, "CWLInputFile", "@list", True
+CWLInputFileLoader: Final[Loader[Mapping[str, CWLObjectType | None]]] = (
+    map_of_union_of_None_type_or_CWLObjectTypeLoader
 )
-CWLInputFileLoader: Final = map_of_union_of_None_type_or_CWLObjectTypeLoader
-CWLVersionLoader: Final = _EnumLoader(("v1.0",), "CWLVersion")
+CWLVersion: TypeAlias = Literal["v1.0"]
+CWLVersionLoader: Final[Loader[CWLVersion]] = _EnumLoader[CWLVersion](
+    ("v1.0",), "CWLVersion"
+)
 """
 Current version symbol for CWL documents.
 """
-SchemaBaseProxyLoader: Final = _ProxyLoader("SchemaBaseLoader")
-ParameterProxyLoader: Final = _ProxyLoader("ParameterLoader")
-ExpressionLoader: Final = _ExpressionLoader(str)
-InputBindingProxyLoader: Final = _ProxyLoader("InputBindingLoader")
-OutputBindingProxyLoader: Final = _ProxyLoader("OutputBindingLoader")
-InputSchemaProxyLoader: Final = _ProxyLoader("InputSchemaLoader")
-OutputSchemaProxyLoader: Final = _ProxyLoader("OutputSchemaLoader")
-InputRecordFieldLoader: Final = _RecordLoader(InputRecordField, None, None)
-InputRecordSchemaLoader: Final = _RecordLoader(InputRecordSchema, None, None)
-InputEnumSchemaLoader: Final = _RecordLoader(InputEnumSchema, None, None)
-InputArraySchemaLoader: Final = _RecordLoader(InputArraySchema, None, None)
-OutputRecordFieldLoader: Final = _RecordLoader(OutputRecordField, None, None)
-OutputRecordSchemaLoader: Final = _RecordLoader(OutputRecordSchema, None, None)
-OutputEnumSchemaLoader: Final = _RecordLoader(OutputEnumSchema, None, None)
-OutputArraySchemaLoader: Final = _RecordLoader(OutputArraySchema, None, None)
-InputParameterLoader: Final = _RecordLoader(InputParameter, None, None)
-OutputParameterLoader: Final = _RecordLoader(OutputParameter, None, None)
-ProcessRequirementProxyLoader: Final = _ProxyLoader("ProcessRequirementLoader")
-ProcessProxyLoader: Final = _ProxyLoader("ProcessLoader")
-InlineJavascriptRequirementLoader: Final = _RecordLoader(
-    InlineJavascriptRequirement, None, None
+SchemaBaseProxyLoader: Final[Loader[SchemaBase]] = _ProxyLoader("SchemaBaseLoader")
+ParameterProxyLoader: Final[Loader[Parameter]] = _ProxyLoader("ParameterLoader")
+Expression: TypeAlias = Literal["ExpressionPlaceholder"]
+ExpressionLoader: Final[Loader[str]] = _ExpressionLoader(str)
+InputBindingProxyLoader: Final[Loader[InputBinding]] = _ProxyLoader(
+    "InputBindingLoader"
 )
-SchemaDefRequirementLoader: Final = _RecordLoader(SchemaDefRequirement, None, None)
-EnvironmentDefLoader: Final = _RecordLoader(EnvironmentDef, None, None)
-CommandLineBindingLoader: Final = _RecordLoader(CommandLineBinding, None, None)
-CommandOutputBindingLoader: Final = _RecordLoader(CommandOutputBinding, None, None)
-CommandInputRecordFieldLoader: Final = _RecordLoader(
+OutputBindingProxyLoader: Final[Loader[OutputBinding]] = _ProxyLoader(
+    "OutputBindingLoader"
+)
+InputSchemaProxyLoader: Final[Loader[InputSchema]] = _ProxyLoader("InputSchemaLoader")
+OutputSchemaProxyLoader: Final[Loader[OutputSchema]] = _ProxyLoader(
+    "OutputSchemaLoader"
+)
+InputRecordFieldLoader: Final[Loader[InputRecordField]] = _RecordLoader(
+    InputRecordField, None, None
+)
+InputRecordSchemaLoader: Final[Loader[InputRecordSchema]] = _RecordLoader(
+    InputRecordSchema, None, None
+)
+InputEnumSchemaLoader: Final[Loader[InputEnumSchema]] = _RecordLoader(
+    InputEnumSchema, None, None
+)
+InputArraySchemaLoader: Final[Loader[InputArraySchema]] = _RecordLoader(
+    InputArraySchema, None, None
+)
+InputParameterTypeLoader: Final[Loader[InputParameterType]] = _UnionLoader(
+    (), "InputParameterTypeLoader"
+)
+union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: Final[
+    Loader[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        InputRecordSchemaLoader,
+        InputEnumSchemaLoader,
+        InputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype
+)
+InputParameterType: TypeAlias = (
+    CWLType
+    | InputArraySchema
+    | InputEnumSchema
+    | InputRecordSchema
+    | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+    | str
+)
+OutputRecordFieldLoader: Final[Loader[OutputRecordField]] = _RecordLoader(
+    OutputRecordField, None, None
+)
+OutputRecordSchemaLoader: Final[Loader[OutputRecordSchema]] = _RecordLoader(
+    OutputRecordSchema, None, None
+)
+OutputEnumSchemaLoader: Final[Loader[OutputEnumSchema]] = _RecordLoader(
+    OutputEnumSchema, None, None
+)
+OutputArraySchemaLoader: Final[Loader[OutputArraySchema]] = _RecordLoader(
+    OutputArraySchema, None, None
+)
+OutputParameterTypeLoader: Final[Loader[OutputParameterType]] = _UnionLoader(
+    (), "OutputParameterTypeLoader"
+)
+union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: Final[
+    Loader[CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        OutputRecordSchemaLoader,
+        OutputEnumSchemaLoader,
+        OutputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype
+)
+OutputParameterType: TypeAlias = (
+    CWLType
+    | OutputArraySchema
+    | OutputEnumSchema
+    | OutputRecordSchema
+    | Sequence[
+        CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+    ]
+    | str
+)
+InputParameterLoader: Final[Loader[InputParameter]] = _RecordLoader(
+    InputParameter, None, None
+)
+OutputParameterLoader: Final[Loader[OutputParameter]] = _RecordLoader(
+    OutputParameter, None, None
+)
+ProcessRequirementProxyLoader: Final[Loader[ProcessRequirement]] = _ProxyLoader(
+    "ProcessRequirementLoader"
+)
+ProcessProxyLoader: Final[Loader[Process]] = _ProxyLoader("ProcessLoader")
+InlineJavascriptRequirementLoader: Final[Loader[InlineJavascriptRequirement]] = (
+    _RecordLoader(InlineJavascriptRequirement, None, None)
+)
+SchemaDefRequirementLoader: Final[Loader[SchemaDefRequirement]] = _RecordLoader(
+    SchemaDefRequirement, None, None
+)
+EnvironmentDefLoader: Final[Loader[EnvironmentDef]] = _RecordLoader(
+    EnvironmentDef, None, None
+)
+CommandLineBindingLoader: Final[Loader[CommandLineBinding]] = _RecordLoader(
+    CommandLineBinding, None, None
+)
+CommandOutputBindingLoader: Final[Loader[CommandOutputBinding]] = _RecordLoader(
+    CommandOutputBinding, None, None
+)
+CommandInputRecordFieldLoader: Final[Loader[CommandInputRecordField]] = _RecordLoader(
     CommandInputRecordField, None, None
 )
-CommandInputRecordSchemaLoader: Final = _RecordLoader(
+CommandInputRecordSchemaLoader: Final[Loader[CommandInputRecordSchema]] = _RecordLoader(
     CommandInputRecordSchema, None, None
 )
-CommandInputEnumSchemaLoader: Final = _RecordLoader(CommandInputEnumSchema, None, None)
-CommandInputArraySchemaLoader: Final = _RecordLoader(
+CommandInputEnumSchemaLoader: Final[Loader[CommandInputEnumSchema]] = _RecordLoader(
+    CommandInputEnumSchema, None, None
+)
+CommandInputArraySchemaLoader: Final[Loader[CommandInputArraySchema]] = _RecordLoader(
     CommandInputArraySchema, None, None
 )
-CommandOutputRecordFieldLoader: Final = _RecordLoader(
+CommandOutputRecordFieldLoader: Final[Loader[CommandOutputRecordField]] = _RecordLoader(
     CommandOutputRecordField, None, None
 )
-CommandOutputRecordSchemaLoader: Final = _RecordLoader(
-    CommandOutputRecordSchema, None, None
+CommandOutputRecordSchemaLoader: Final[Loader[CommandOutputRecordSchema]] = (
+    _RecordLoader(CommandOutputRecordSchema, None, None)
 )
-CommandOutputEnumSchemaLoader: Final = _RecordLoader(
+CommandOutputEnumSchemaLoader: Final[Loader[CommandOutputEnumSchema]] = _RecordLoader(
     CommandOutputEnumSchema, None, None
 )
-CommandOutputArraySchemaLoader: Final = _RecordLoader(
+CommandOutputArraySchemaLoader: Final[Loader[CommandOutputArraySchema]] = _RecordLoader(
     CommandOutputArraySchema, None, None
 )
-CommandInputParameterLoader: Final = _RecordLoader(CommandInputParameter, None, None)
-CommandOutputParameterLoader: Final = _RecordLoader(CommandOutputParameter, None, None)
-stdoutLoader: Final = _EnumLoader(("stdout",), "stdout")
+CommandInputParameterTypeLoader: Final[Loader[CommandInputParameterType]] = (
+    _UnionLoader((), "CommandInputParameterTypeLoader")
+)
+union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | str
+    ]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        CommandInputRecordSchemaLoader,
+        CommandInputEnumSchemaLoader,
+        CommandInputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype
+)
+CommandInputParameterType: TypeAlias = (
+    CWLType
+    | CommandInputArraySchema
+    | CommandInputEnumSchema
+    | CommandInputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | str
+    ]
+    | str
+)
+CommandInputParameterLoader: Final[Loader[CommandInputParameter]] = _RecordLoader(
+    CommandInputParameter, None, None
+)
+stdout: TypeAlias = Literal["stdout"]
+stdoutLoader: Final[Loader[stdout]] = _EnumLoader[stdout](("stdout",), "stdout")
 """
 Only valid as a ``type`` for a ``CommandLineTool`` output with no ``outputBinding`` set.
 
@@ -22545,7 +24070,8 @@ is equivalent to
 
    stdout: random_stdout_filenameABCDEFG
 """
-stderrLoader: Final = _EnumLoader(("stderr",), "stderr")
+stderr: TypeAlias = Literal["stderr"]
+stderrLoader: Final[Loader[stderr]] = _EnumLoader[stderr](("stderr",), "stderr")
 """
 Only valid as a ``type`` for a ``CommandLineTool`` output with no ``outputBinding`` set.
 
@@ -22596,24 +24122,91 @@ is equivalent to
 
    stderr: random_stderr_filenameABCDEFG
 """
-CommandLineToolLoader: Final = _RecordLoader(CommandLineTool, None, None)
-DockerRequirementLoader: Final = _RecordLoader(DockerRequirement, None, None)
-SoftwareRequirementLoader: Final = _RecordLoader(SoftwareRequirement, None, None)
-SoftwarePackageLoader: Final = _RecordLoader(SoftwarePackage, None, None)
-DirentLoader: Final = _RecordLoader(Dirent, None, None)
-InitialWorkDirRequirementLoader: Final = _RecordLoader(
-    InitialWorkDirRequirement, None, None
+CommandOutputParameterTypeLoader: Final[Loader[CommandOutputParameterType]] = (
+    _UnionLoader((), "CommandOutputParameterTypeLoader")
 )
-EnvVarRequirementLoader: Final = _RecordLoader(EnvVarRequirement, None, None)
-ShellCommandRequirementLoader: Final = _RecordLoader(
+union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | str
+    ]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        CommandOutputRecordSchemaLoader,
+        CommandOutputEnumSchemaLoader,
+        CommandOutputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype
+)
+CommandOutputParameterType: TypeAlias = (
+    CWLType
+    | CommandOutputArraySchema
+    | CommandOutputEnumSchema
+    | CommandOutputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | str
+    ]
+    | stderr
+    | stdout
+    | str
+)
+CommandOutputParameterLoader: Final[Loader[CommandOutputParameter]] = _RecordLoader(
+    CommandOutputParameter, None, None
+)
+CommandLineToolLoader: Final[Loader[CommandLineTool]] = _RecordLoader(
+    CommandLineTool, None, None
+)
+DockerRequirementLoader: Final[Loader[DockerRequirement]] = _RecordLoader(
+    DockerRequirement, None, None
+)
+SoftwareRequirementLoader: Final[Loader[SoftwareRequirement]] = _RecordLoader(
+    SoftwareRequirement, None, None
+)
+SoftwarePackageLoader: Final[Loader[SoftwarePackage]] = _RecordLoader(
+    SoftwarePackage, None, None
+)
+DirentLoader: Final[Loader[Dirent]] = _RecordLoader(Dirent, None, None)
+InitialWorkDirRequirementLoader: Final[Loader[InitialWorkDirRequirement]] = (
+    _RecordLoader(InitialWorkDirRequirement, None, None)
+)
+EnvVarRequirementLoader: Final[Loader[EnvVarRequirement]] = _RecordLoader(
+    EnvVarRequirement, None, None
+)
+ShellCommandRequirementLoader: Final[Loader[ShellCommandRequirement]] = _RecordLoader(
     ShellCommandRequirement, None, None
 )
-ResourceRequirementLoader: Final = _RecordLoader(ResourceRequirement, None, None)
-ExpressionToolOutputParameterLoader: Final = _RecordLoader(
-    ExpressionToolOutputParameter, None, None
+ResourceRequirementLoader: Final[Loader[ResourceRequirement]] = _RecordLoader(
+    ResourceRequirement, None, None
 )
-ExpressionToolLoader: Final = _RecordLoader(ExpressionTool, None, None)
-LinkMergeMethodLoader: Final = _EnumLoader(
+ExpressionToolOutputParameterLoader: Final[Loader[ExpressionToolOutputParameter]] = (
+    _RecordLoader(ExpressionToolOutputParameter, None, None)
+)
+ExpressionToolLoader: Final[Loader[ExpressionTool]] = _RecordLoader(
+    ExpressionTool, None, None
+)
+LinkMergeMethod: TypeAlias = Literal["merge_nested", "merge_flattened"]
+LinkMergeMethodLoader: Final[Loader[LinkMergeMethod]] = _EnumLoader[LinkMergeMethod](
     (
         "merge_nested",
         "merge_flattened",
@@ -22623,13 +24216,20 @@ LinkMergeMethodLoader: Final = _EnumLoader(
 """
 The input link merge method, described in `WorkflowStepInput <#WorkflowStepInput>`__.
 """
-WorkflowOutputParameterLoader: Final = _RecordLoader(
+WorkflowOutputParameterLoader: Final[Loader[WorkflowOutputParameter]] = _RecordLoader(
     WorkflowOutputParameter, None, None
 )
-SinkProxyLoader: Final = _ProxyLoader("SinkLoader")
-WorkflowStepInputLoader: Final = _RecordLoader(WorkflowStepInput, None, None)
-WorkflowStepOutputLoader: Final = _RecordLoader(WorkflowStepOutput, None, None)
-ScatterMethodLoader: Final = _EnumLoader(
+SinkProxyLoader: Final[Loader[Sink]] = _ProxyLoader("SinkLoader")
+WorkflowStepInputLoader: Final[Loader[WorkflowStepInput]] = _RecordLoader(
+    WorkflowStepInput, None, None
+)
+WorkflowStepOutputLoader: Final[Loader[WorkflowStepOutput]] = _RecordLoader(
+    WorkflowStepOutput, None, None
+)
+ScatterMethod: TypeAlias = Literal[
+    "dotproduct", "nested_crossproduct", "flat_crossproduct"
+]
+ScatterMethodLoader: Final[Loader[ScatterMethod]] = _EnumLoader[ScatterMethod](
     (
         "dotproduct",
         "nested_crossproduct",
@@ -22640,44 +24240,68 @@ ScatterMethodLoader: Final = _EnumLoader(
 """
 The scatter method, as described in `workflow step scatter <#WorkflowStep>`__.
 """
-WorkflowStepLoader: Final = _RecordLoader(WorkflowStep, None, None)
-WorkflowLoader: Final = _RecordLoader(Workflow, None, None)
-SubworkflowFeatureRequirementLoader: Final = _RecordLoader(
-    SubworkflowFeatureRequirement, None, None
+WorkflowStepLoader: Final[Loader[WorkflowStep]] = _RecordLoader(
+    WorkflowStep, None, None
 )
-ScatterFeatureRequirementLoader: Final = _RecordLoader(
-    ScatterFeatureRequirement, None, None
+WorkflowLoader: Final[Loader[Workflow]] = _RecordLoader(Workflow, None, None)
+SubworkflowFeatureRequirementLoader: Final[Loader[SubworkflowFeatureRequirement]] = (
+    _RecordLoader(SubworkflowFeatureRequirement, None, None)
 )
-MultipleInputFeatureRequirementLoader: Final = _RecordLoader(
-    MultipleInputFeatureRequirement, None, None
+ScatterFeatureRequirementLoader: Final[Loader[ScatterFeatureRequirement]] = (
+    _RecordLoader(ScatterFeatureRequirement, None, None)
 )
-StepInputExpressionRequirementLoader: Final = _RecordLoader(
-    StepInputExpressionRequirement, None, None
+MultipleInputFeatureRequirementLoader: Final[
+    Loader[MultipleInputFeatureRequirement]
+] = _RecordLoader(MultipleInputFeatureRequirement, None, None)
+StepInputExpressionRequirementLoader: Final[Loader[StepInputExpressionRequirement]] = (
+    _RecordLoader(StepInputExpressionRequirement, None, None)
 )
-LoadListingRequirementLoader: Final = _RecordLoader(LoadListingRequirement, None, None)
-InplaceUpdateRequirementLoader: Final = _RecordLoader(
+LoadListingRequirementLoader: Final[Loader[LoadListingRequirement]] = _RecordLoader(
+    LoadListingRequirement, None, None
+)
+InplaceUpdateRequirementLoader: Final[Loader[InplaceUpdateRequirement]] = _RecordLoader(
     InplaceUpdateRequirement, None, None
 )
-SecretsLoader: Final = _RecordLoader(Secrets, None, None)
-TimeLimitLoader: Final = _RecordLoader(TimeLimit, None, None)
-WorkReuseLoader: Final = _RecordLoader(WorkReuse, None, None)
-NetworkAccessLoader: Final = _RecordLoader(NetworkAccess, None, None)
-ProcessGeneratorLoader: Final = _RecordLoader(ProcessGenerator, None, None)
-MPIRequirementLoader: Final = _RecordLoader(MPIRequirement, None, None)
-CUDARequirementLoader: Final = _RecordLoader(CUDARequirement, None, None)
-ShmSizeLoader: Final = _RecordLoader(ShmSize, None, None)
-array_of_strtype: Final = _ArrayLoader(strtype)
-union_of_None_type_or_strtype_or_array_of_strtype: Final = _UnionLoader(
+SecretsLoader: Final[Loader[Secrets]] = _RecordLoader(Secrets, None, None)
+TimeLimitLoader: Final[Loader[TimeLimit]] = _RecordLoader(TimeLimit, None, None)
+WorkReuseLoader: Final[Loader[WorkReuse]] = _RecordLoader(WorkReuse, None, None)
+NetworkAccessLoader: Final[Loader[NetworkAccess]] = _RecordLoader(
+    NetworkAccess, None, None
+)
+ProcessGeneratorLoader: Final[Loader[ProcessGenerator]] = _RecordLoader(
+    ProcessGenerator, None, None
+)
+MPIRequirementLoader: Final[Loader[MPIRequirement]] = _RecordLoader(
+    MPIRequirement, None, None
+)
+CUDARequirementLoader: Final[Loader[CUDARequirement]] = _RecordLoader(
+    CUDARequirement, None, None
+)
+ShmSizeLoader: Final[Loader[ShmSize]] = _RecordLoader(ShmSize, None, None)
+array_of_strtype: Final[Loader[Sequence[str]]] = _ArrayLoader(strtype)
+union_of_None_type_or_strtype_or_array_of_strtype: Final[
+    Loader[None | Sequence[str] | str]
+] = _UnionLoader(
     (
         None_type,
         strtype,
         array_of_strtype,
     )
 )
-uri_strtype_True_False_None_None: Final = _URILoader(strtype, True, False, None, None)
-union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+uri_strtype_True_False_None_None: Final[Loader[str]] = _URILoader(
+    strtype, True, False, None, None
+)
+union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: Final[
+    Loader[
+        PrimitiveType
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         RecordSchemaLoader,
@@ -22688,14 +24312,41 @@ union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArrayS
         strtype,
     )
 )
-array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
     union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype
 )
-union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: Final[
+    Loader[
+        PrimitiveType
+        | Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         RecordSchemaLoader,
@@ -22707,57 +24358,141 @@ union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArrayS
         array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2: Final[
+    Loader[
+        PrimitiveType
+        | Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _TypeDSLLoader[
+    PrimitiveType
+    | Sequence[
+        PrimitiveType
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+    | schema_salad.metaschema.ArraySchema
+    | schema_salad.metaschema.EnumSchema
+    | schema_salad.metaschema.MapSchema
+    | schema_salad.metaschema.RecordSchema
+    | schema_salad.metaschema.UnionSchema
+    | str
+](
     union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_RecordFieldLoader: Final = _ArrayLoader(RecordFieldLoader)
-union_of_None_type_or_array_of_RecordFieldLoader: Final = _UnionLoader(
+array_of_RecordFieldLoader: Final[
+    Loader[Sequence[schema_salad.metaschema.RecordField]]
+] = _ArrayLoader(RecordFieldLoader)
+union_of_None_type_or_array_of_RecordFieldLoader: Final[
+    Loader[None | Sequence[schema_salad.metaschema.RecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_RecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader: Final = _IdMapLoader(
-    union_of_None_type_or_array_of_RecordFieldLoader, "name", "type"
+idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader: Final[
+    Loader[None | Sequence[schema_salad.metaschema.RecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_RecordFieldLoader, "name", "type")
+Record_name: TypeAlias = Literal["record"]
+Record_nameLoader: Final[Loader[Record_name]] = _EnumLoader[Record_name](
+    ("record",), "Record_name"
 )
-Record_nameLoader: Final = _EnumLoader(("record",), "Record_name")
-typedsl_Record_nameLoader_2: Final = _TypeDSLLoader(Record_nameLoader, 2, "v1.1")
-union_of_None_type_or_strtype: Final = _UnionLoader(
+typedsl_Record_nameLoader_2: Final[Loader[Record_name]] = _TypeDSLLoader[Record_name](
+    Record_nameLoader, 2, "v1.1"
+)
+union_of_None_type_or_strtype: Final[Loader[None | str]] = _UnionLoader(
     (
         None_type,
         strtype,
     )
 )
-uri_union_of_None_type_or_strtype_True_False_None_None: Final = _URILoader(
-    union_of_None_type_or_strtype, True, False, None, None
+uri_union_of_None_type_or_strtype_True_False_None_None: Final[Loader[None | str]] = (
+    _URILoader(union_of_None_type_or_strtype, True, False, None, None)
 )
-uri_array_of_strtype_True_False_None_None: Final = _URILoader(
+uri_array_of_strtype_True_False_None_None: Final[Loader[Sequence[str]]] = _URILoader(
     array_of_strtype, True, False, None, None
 )
-Enum_nameLoader: Final = _EnumLoader(("enum",), "Enum_name")
-typedsl_Enum_nameLoader_2: Final = _TypeDSLLoader(Enum_nameLoader, 2, "v1.1")
-uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+Enum_name: TypeAlias = Literal["enum"]
+Enum_nameLoader: Final[Loader[Enum_name]] = _EnumLoader[Enum_name](
+    ("enum",), "Enum_name"
+)
+typedsl_Enum_nameLoader_2: Final[Loader[Enum_name]] = _TypeDSLLoader[Enum_name](
+    Enum_nameLoader, 2, "v1.1"
+)
+uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        PrimitiveType
+        | Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _URILoader(
     union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-Array_nameLoader: Final = _EnumLoader(("array",), "Array_name")
-typedsl_Array_nameLoader_2: Final = _TypeDSLLoader(Array_nameLoader, 2, "v1.1")
-Map_nameLoader: Final = _EnumLoader(("map",), "Map_name")
-typedsl_Map_nameLoader_2: Final = _TypeDSLLoader(Map_nameLoader, 2, "v1.1")
-Union_nameLoader: Final = _EnumLoader(("union",), "Union_name")
-typedsl_Union_nameLoader_2: Final = _TypeDSLLoader(Union_nameLoader, 2, "v1.1")
-union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+Array_name: TypeAlias = Literal["array"]
+Array_nameLoader: Final[Loader[Array_name]] = _EnumLoader[Array_name](
+    ("array",), "Array_name"
+)
+typedsl_Array_nameLoader_2: Final[Loader[Array_name]] = _TypeDSLLoader[Array_name](
+    Array_nameLoader, 2, "v1.1"
+)
+Map_name: TypeAlias = Literal["map"]
+Map_nameLoader: Final[Loader[Map_name]] = _EnumLoader[Map_name](("map",), "Map_name")
+typedsl_Map_nameLoader_2: Final[Loader[Map_name]] = _TypeDSLLoader[Map_name](
+    Map_nameLoader, 2, "v1.1"
+)
+Union_name: TypeAlias = Literal["union"]
+Union_nameLoader: Final[Loader[Union_name]] = _EnumLoader[Union_name](
+    ("union",), "Union_name"
+)
+typedsl_Union_nameLoader_2: Final[Loader[Union_name]] = _TypeDSLLoader[Union_name](
+    Union_nameLoader, 2, "v1.1"
+)
+union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         CWLRecordSchemaLoader,
@@ -22766,14 +24501,35 @@ union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWL
         strtype,
     )
 )
-array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
     union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype
 )
-union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         CWLRecordSchemaLoader,
@@ -22783,81 +24539,133 @@ union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWL
         array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype,
     )
 )
-uri_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+uri_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _URILoader(
     union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-typedsl_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLArraySchema
+    | CWLRecordSchema
+    | PrimitiveType
+    | Sequence[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+    | schema_salad.metaschema.EnumSchema
+    | str
+](
     union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_CWLRecordFieldLoader: Final = _ArrayLoader(CWLRecordFieldLoader)
-union_of_None_type_or_array_of_CWLRecordFieldLoader: Final = _UnionLoader(
+array_of_CWLRecordFieldLoader: Final[Loader[Sequence[CWLRecordField]]] = _ArrayLoader(
+    CWLRecordFieldLoader
+)
+union_of_None_type_or_array_of_CWLRecordFieldLoader: Final[
+    Loader[None | Sequence[CWLRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_CWLRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_CWLRecordFieldLoader: Final = _IdMapLoader(
-    union_of_None_type_or_array_of_CWLRecordFieldLoader, "name", "type"
+idmap_fields_union_of_None_type_or_array_of_CWLRecordFieldLoader: Final[
+    Loader[None | Sequence[CWLRecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_CWLRecordFieldLoader, "name", "type")
+File_class: TypeAlias = Literal["File"]
+File_classLoader: Final[Loader[File_class]] = _EnumLoader[File_class](
+    ("File",), "File_class"
 )
-File_classLoader: Final = _EnumLoader(("File",), "File_class")
-uri_File_classLoader_False_True_None_None: Final = _URILoader(
+uri_File_classLoader_False_True_None_None: Final[Loader[File_class]] = _URILoader(
     File_classLoader, False, True, None, None
 )
-uri_union_of_None_type_or_strtype_False_False_None_None: Final = _URILoader(
-    union_of_None_type_or_strtype, False, False, None, None
+uri_union_of_None_type_or_strtype_False_False_None_None: Final[Loader[None | str]] = (
+    _URILoader(union_of_None_type_or_strtype, False, False, None, None)
 )
-union_of_None_type_or_inttype: Final = _UnionLoader(
-    (
-        None_type,
-        inttype,
+union_of_None_type_or_inttype_or_longtype: Final[Loader[None | i32 | i64]] = (
+    _UnionLoader(
+        (
+            None_type,
+            inttype,
+            longtype,
+        )
     )
 )
-union_of_FileLoader_or_DirectoryLoader: Final = _UnionLoader(
+union_of_FileLoader_or_DirectoryLoader: Final[Loader[Directory | File]] = _UnionLoader(
     (
         FileLoader,
         DirectoryLoader,
     )
 )
-array_of_union_of_FileLoader_or_DirectoryLoader: Final = _ArrayLoader(
-    union_of_FileLoader_or_DirectoryLoader
-)
-union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final = (
-    _UnionLoader(
-        (
-            None_type,
-            array_of_union_of_FileLoader_or_DirectoryLoader,
-        )
+array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[Sequence[Directory | File]]
+] = _ArrayLoader(union_of_FileLoader_or_DirectoryLoader)
+union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[None | Sequence[Directory | File]]
+] = _UnionLoader(
+    (
+        None_type,
+        array_of_union_of_FileLoader_or_DirectoryLoader,
     )
 )
-uri_union_of_None_type_or_strtype_True_False_None_True: Final = _URILoader(
-    union_of_None_type_or_strtype, True, False, None, True
+uri_union_of_None_type_or_strtype_True_False_None_True: Final[Loader[None | str]] = (
+    _URILoader(union_of_None_type_or_strtype, True, False, None, True)
 )
-Directory_classLoader: Final = _EnumLoader(("Directory",), "Directory_class")
-uri_Directory_classLoader_False_True_None_None: Final = _URILoader(
-    Directory_classLoader, False, True, None, None
+Directory_class: TypeAlias = Literal["Directory"]
+Directory_classLoader: Final[Loader[Directory_class]] = _EnumLoader[Directory_class](
+    ("Directory",), "Directory_class"
 )
-union_of_strtype_or_ExpressionLoader: Final = _UnionLoader(
+uri_Directory_classLoader_False_True_None_None: Final[Loader[Directory_class]] = (
+    _URILoader(Directory_classLoader, False, True, None, None)
+)
+union_of_strtype_or_ExpressionLoader: Final[Loader[str]] = _UnionLoader(
     (
         strtype,
         ExpressionLoader,
     )
 )
-array_of_union_of_strtype_or_ExpressionLoader: Final = _ArrayLoader(
-    union_of_strtype_or_ExpressionLoader
+array_of_union_of_strtype_or_ExpressionLoader: Final[Loader[Sequence[str]]] = (
+    _ArrayLoader(union_of_strtype_or_ExpressionLoader)
 )
-union_of_None_type_or_strtype_or_ExpressionLoader_or_array_of_union_of_strtype_or_ExpressionLoader: (
-    Final
-) = _UnionLoader(
+union_of_None_type_or_strtype_or_ExpressionLoader_or_array_of_union_of_strtype_or_ExpressionLoader: Final[
+    Loader[None | Sequence[str] | str]
+] = _UnionLoader(
     (
         None_type,
         strtype,
@@ -22865,31 +24673,24 @@ union_of_None_type_or_strtype_or_ExpressionLoader_or_array_of_union_of_strtype_o
         array_of_union_of_strtype_or_ExpressionLoader,
     )
 )
-union_of_None_type_or_booltype: Final = _UnionLoader(
+union_of_None_type_or_booltype: Final[Loader[None | bool]] = _UnionLoader(
     (
         None_type,
         booltype,
     )
 )
-union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        InputRecordSchemaLoader,
-        InputEnumSchemaLoader,
-        InputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | InputArraySchema
+        | InputEnumSchema
+        | InputRecordSchema
+        | Sequence[
+            CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         InputRecordSchemaLoader,
@@ -22899,57 +24700,81 @@ union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_In
         array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | InputArraySchema
+        | InputEnumSchema
+        | InputRecordSchema
+        | Sequence[
+            CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | InputArraySchema
+    | InputEnumSchema
+    | InputRecordSchema
+    | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+    | str
+](
     union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-union_of_None_type_or_CommandLineBindingLoader: Final = _UnionLoader(
-    (
-        None_type,
-        CommandLineBindingLoader,
+union_of_None_type_or_InputBindingProxyLoader: Final[Loader[InputBinding | None]] = (
+    _UnionLoader(
+        (
+            None_type,
+            InputBindingProxyLoader,
+        )
     )
 )
-array_of_InputRecordFieldLoader: Final = _ArrayLoader(InputRecordFieldLoader)
-union_of_None_type_or_array_of_InputRecordFieldLoader: Final = _UnionLoader(
+array_of_InputRecordFieldLoader: Final[Loader[Sequence[InputRecordField]]] = (
+    _ArrayLoader(InputRecordFieldLoader)
+)
+union_of_None_type_or_array_of_InputRecordFieldLoader: Final[
+    Loader[None | Sequence[InputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_InputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_InputRecordFieldLoader: Final = (
-    _IdMapLoader(union_of_None_type_or_array_of_InputRecordFieldLoader, "name", "type")
-)
-uri_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+idmap_fields_union_of_None_type_or_array_of_InputRecordFieldLoader: Final[
+    Loader[None | Sequence[InputRecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_InputRecordFieldLoader, "name", "type")
+uri_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | InputArraySchema
+        | InputEnumSchema
+        | InputRecordSchema
+        | Sequence[
+            CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        OutputRecordSchemaLoader,
-        OutputEnumSchemaLoader,
-        OutputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | OutputArraySchema
+        | OutputEnumSchema
+        | OutputRecordSchema
+        | Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         OutputRecordSchemaLoader,
@@ -22959,248 +24784,299 @@ union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_
         array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | OutputArraySchema
+        | OutputEnumSchema
+        | OutputRecordSchema
+        | Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | OutputArraySchema
+    | OutputEnumSchema
+    | OutputRecordSchema
+    | Sequence[
+        CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+    ]
+    | str
+](
     union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-union_of_None_type_or_CommandOutputBindingLoader: Final = _UnionLoader(
-    (
-        None_type,
-        CommandOutputBindingLoader,
+union_of_None_type_or_OutputBindingProxyLoader: Final[Loader[None | OutputBinding]] = (
+    _UnionLoader(
+        (
+            None_type,
+            OutputBindingProxyLoader,
+        )
     )
 )
-array_of_OutputRecordFieldLoader: Final = _ArrayLoader(OutputRecordFieldLoader)
-union_of_None_type_or_array_of_OutputRecordFieldLoader: Final = _UnionLoader(
+array_of_OutputRecordFieldLoader: Final[Loader[Sequence[OutputRecordField]]] = (
+    _ArrayLoader(OutputRecordFieldLoader)
+)
+union_of_None_type_or_array_of_OutputRecordFieldLoader: Final[
+    Loader[None | Sequence[OutputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_OutputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_OutputRecordFieldLoader: Final = (
-    _IdMapLoader(union_of_None_type_or_array_of_OutputRecordFieldLoader, "name", "type")
-)
-uri_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+idmap_fields_union_of_None_type_or_array_of_OutputRecordFieldLoader: Final[
+    Loader[None | Sequence[OutputRecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_OutputRecordFieldLoader, "name", "type")
+uri_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | OutputArraySchema
+        | OutputEnumSchema
+        | OutputRecordSchema
+        | Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader: Final = (
-    _UnionLoader(
-        (
-            None_type,
-            strtype,
-            array_of_strtype,
-            ExpressionLoader,
-        )
+union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader: Final[
+    Loader[None | Sequence[str] | str]
+] = _UnionLoader(
+    (
+        None_type,
+        strtype,
+        array_of_strtype,
+        ExpressionLoader,
     )
 )
-uri_union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader_True_False_None_True: (
-    Final
-) = _URILoader(
+uri_union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader_True_False_None_True: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(
     union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader,
     True,
     False,
     None,
     True,
 )
-union_of_None_type_or_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_None_type_or_InputParameterTypeLoader: Final[
+    Loader[InputParameterType | None]
+] = _UnionLoader(
     (
         None_type,
-        CWLTypeLoader,
-        InputRecordSchemaLoader,
-        InputEnumSchemaLoader,
-        InputArraySchemaLoader,
-        strtype,
-        array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
+        InputParameterTypeLoader,
     )
 )
-typedsl_union_of_None_type_or_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
-    union_of_None_type_or_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
-    2,
-    "v1.1",
+typedsl_union_of_None_type_or_InputParameterTypeLoader_2: Final[
+    Loader[InputParameterType | None]
+] = _TypeDSLLoader[InputParameterType | None](
+    union_of_None_type_or_InputParameterTypeLoader, 2, "v1.1"
 )
-union_of_None_type_or_strtype_or_ExpressionLoader: Final = _UnionLoader(
-    (
-        None_type,
-        strtype,
-        ExpressionLoader,
-    )
-)
-uri_union_of_None_type_or_strtype_or_ExpressionLoader_True_False_None_True: Final = (
-    _URILoader(
-        union_of_None_type_or_strtype_or_ExpressionLoader, True, False, None, True
-    )
-)
-array_of_InputParameterLoader: Final = _ArrayLoader(InputParameterLoader)
-idmap_inputs_array_of_InputParameterLoader: Final = _IdMapLoader(
-    array_of_InputParameterLoader, "id", "type"
-)
-array_of_OutputParameterLoader: Final = _ArrayLoader(OutputParameterLoader)
-idmap_outputs_array_of_OutputParameterLoader: Final = _IdMapLoader(
-    array_of_OutputParameterLoader, "id", "type"
-)
-union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader: (
-    Final
-) = _UnionLoader(
-    (
-        InlineJavascriptRequirementLoader,
-        SchemaDefRequirementLoader,
-        DockerRequirementLoader,
-        SoftwareRequirementLoader,
-        InitialWorkDirRequirementLoader,
-        EnvVarRequirementLoader,
-        ShellCommandRequirementLoader,
-        ResourceRequirementLoader,
-        SubworkflowFeatureRequirementLoader,
-        ScatterFeatureRequirementLoader,
-        MultipleInputFeatureRequirementLoader,
-        StepInputExpressionRequirementLoader,
-        LoadListingRequirementLoader,
-        InplaceUpdateRequirementLoader,
-        SecretsLoader,
-        TimeLimitLoader,
-        WorkReuseLoader,
-        NetworkAccessLoader,
-        MPIRequirementLoader,
-        CUDARequirementLoader,
-        ShmSizeLoader,
-    )
-)
-array_of_ProcessRequirement: Final = _ArrayLoader(ProcessRequirementProxyLoader)
-union_of_None_type_or_array_of_ProcessRequirement: Final = _UnionLoader(
-    (
-        None_type,
-        array_of_ProcessRequirement,
-    )
-)
-idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement: Final = (
-    _IdMapLoader(union_of_None_type_or_array_of_ProcessRequirement, "class", "None")
-)
-union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
-) = _UnionLoader(
-    (
-        InlineJavascriptRequirementLoader,
-        SchemaDefRequirementLoader,
-        DockerRequirementLoader,
-        SoftwareRequirementLoader,
-        InitialWorkDirRequirementLoader,
-        EnvVarRequirementLoader,
-        ShellCommandRequirementLoader,
-        ResourceRequirementLoader,
-        SubworkflowFeatureRequirementLoader,
-        ScatterFeatureRequirementLoader,
-        MultipleInputFeatureRequirementLoader,
-        StepInputExpressionRequirementLoader,
-        LoadListingRequirementLoader,
-        InplaceUpdateRequirementLoader,
-        SecretsLoader,
-        TimeLimitLoader,
-        WorkReuseLoader,
-        NetworkAccessLoader,
-        MPIRequirementLoader,
-        CUDARequirementLoader,
-        ShmSizeLoader,
-        Any_type,
-    )
-)
-array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
-) = _ArrayLoader(
-    union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type
-)
-union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
-) = _UnionLoader(
-    (
-        None_type,
-        array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
-    )
-)
-idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
-) = _IdMapLoader(
-    union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
-    "class",
-    "None",
-)
-union_of_None_type_or_CWLVersionLoader: Final = _UnionLoader(
-    (
-        None_type,
-        CWLVersionLoader,
-    )
-)
-uri_union_of_None_type_or_CWLVersionLoader_False_True_None_None: Final = _URILoader(
-    union_of_None_type_or_CWLVersionLoader, False, True, None, None
-)
-InlineJavascriptRequirement_classLoader: Final = _EnumLoader(
-    ("InlineJavascriptRequirement",), "InlineJavascriptRequirement_class"
-)
-uri_InlineJavascriptRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    InlineJavascriptRequirement_classLoader, False, True, None, None
-)
-union_of_None_type_or_array_of_strtype: Final = _UnionLoader(
-    (
-        None_type,
-        array_of_strtype,
-    )
-)
-SchemaDefRequirement_classLoader: Final = _EnumLoader(
-    ("SchemaDefRequirement",), "SchemaDefRequirement_class"
-)
-uri_SchemaDefRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    SchemaDefRequirement_classLoader, False, True, None, None
-)
-union_of_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader: (
-    Final
-) = _UnionLoader(
-    (
-        InputRecordSchemaLoader,
-        InputEnumSchemaLoader,
-        InputArraySchemaLoader,
-    )
-)
-array_of_InputSchema: Final = _ArrayLoader(InputSchemaProxyLoader)
-union_of_None_type_or_strtype_or_ExpressionLoader_or_array_of_strtype: Final = (
+union_of_None_type_or_strtype_or_ExpressionLoader: Final[Loader[None | str]] = (
     _UnionLoader(
         (
             None_type,
             strtype,
             ExpressionLoader,
+        )
+    )
+)
+uri_union_of_None_type_or_strtype_or_ExpressionLoader_True_False_None_True: Final[
+    Loader[None | str]
+] = _URILoader(
+    union_of_None_type_or_strtype_or_ExpressionLoader, True, False, None, True
+)
+array_of_InputParameterLoader: Final[Loader[Sequence[InputParameter]]] = _ArrayLoader(
+    InputParameterLoader
+)
+idmap_inputs_array_of_InputParameterLoader: Final[Loader[Sequence[InputParameter]]] = (
+    _IdMapLoader(array_of_InputParameterLoader, "id", "type")
+)
+array_of_OutputParameterLoader: Final[Loader[Sequence[OutputParameter]]] = _ArrayLoader(
+    OutputParameterLoader
+)
+idmap_outputs_array_of_OutputParameterLoader: Final[
+    Loader[Sequence[OutputParameter]]
+] = _IdMapLoader(array_of_OutputParameterLoader, "id", "type")
+union_of_StepInputExpressionRequirementLoader_or_SchemaDefRequirementLoader_or_WorkReuseLoader_or_ShmSizeLoader_or_TimeLimitLoader_or_ScatterFeatureRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_CUDARequirementLoader_or_EnvVarRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_InlineJavascriptRequirementLoader_or_SoftwareRequirementLoader_or_InplaceUpdateRequirementLoader_or_InitialWorkDirRequirementLoader_or_NetworkAccessLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_MPIRequirementLoader_or_ResourceRequirementLoader_or_SecretsLoader_or_ShellCommandRequirementLoader: Final[
+    Loader[
+        CUDARequirement
+        | DockerRequirement
+        | EnvVarRequirement
+        | InitialWorkDirRequirement
+        | InlineJavascriptRequirement
+        | InplaceUpdateRequirement
+        | LoadListingRequirement
+        | MPIRequirement
+        | MultipleInputFeatureRequirement
+        | NetworkAccess
+        | ResourceRequirement
+        | ScatterFeatureRequirement
+        | SchemaDefRequirement
+        | Secrets
+        | ShellCommandRequirement
+        | ShmSize
+        | SoftwareRequirement
+        | StepInputExpressionRequirement
+        | SubworkflowFeatureRequirement
+        | TimeLimit
+        | WorkReuse
+    ]
+] = _UnionLoader(
+    (
+        StepInputExpressionRequirementLoader,
+        SchemaDefRequirementLoader,
+        WorkReuseLoader,
+        ShmSizeLoader,
+        TimeLimitLoader,
+        ScatterFeatureRequirementLoader,
+        SubworkflowFeatureRequirementLoader,
+        CUDARequirementLoader,
+        EnvVarRequirementLoader,
+        MultipleInputFeatureRequirementLoader,
+        InlineJavascriptRequirementLoader,
+        SoftwareRequirementLoader,
+        InplaceUpdateRequirementLoader,
+        InitialWorkDirRequirementLoader,
+        NetworkAccessLoader,
+        LoadListingRequirementLoader,
+        DockerRequirementLoader,
+        MPIRequirementLoader,
+        ResourceRequirementLoader,
+        SecretsLoader,
+        ShellCommandRequirementLoader,
+    )
+)
+array_of_ProcessRequirementProxyLoader: Final[Loader[Sequence[ProcessRequirement]]] = (
+    _ArrayLoader(ProcessRequirementProxyLoader)
+)
+union_of_None_type_or_array_of_ProcessRequirementProxyLoader: Final[
+    Loader[None | Sequence[ProcessRequirement]]
+] = _UnionLoader(
+    (
+        None_type,
+        array_of_ProcessRequirementProxyLoader,
+    )
+)
+idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader: Final[
+    Loader[None | Sequence[ProcessRequirement]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_ProcessRequirementProxyLoader, "class", "None"
+)
+union_of_ProcessRequirementProxyLoader_or_Any_type: Final[
+    Loader[Any | ProcessRequirement]
+] = _UnionLoader(
+    (
+        ProcessRequirementProxyLoader,
+        Any_type,
+    )
+)
+array_of_union_of_ProcessRequirementProxyLoader_or_Any_type: Final[
+    Loader[Sequence[Any | ProcessRequirement]]
+] = _ArrayLoader(union_of_ProcessRequirementProxyLoader_or_Any_type)
+union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type: (
+    Final[Loader[None | Sequence[Any | ProcessRequirement]]]
+) = _UnionLoader(
+    (
+        None_type,
+        array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
+    )
+)
+idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type: Final[
+    Loader[None | Sequence[Any | ProcessRequirement]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
+    "class",
+    "None",
+)
+union_of_None_type_or_CWLVersionLoader: Final[Loader[CWLVersion | None]] = _UnionLoader(
+    (
+        None_type,
+        CWLVersionLoader,
+    )
+)
+uri_union_of_None_type_or_CWLVersionLoader_False_True_None_None: Final[
+    Loader[CWLVersion | None]
+] = _URILoader(union_of_None_type_or_CWLVersionLoader, False, True, None, None)
+InlineJavascriptRequirement_class: TypeAlias = Literal["InlineJavascriptRequirement"]
+InlineJavascriptRequirement_classLoader: Final[
+    Loader[InlineJavascriptRequirement_class]
+] = _EnumLoader[InlineJavascriptRequirement_class](
+    ("InlineJavascriptRequirement",), "InlineJavascriptRequirement_class"
+)
+uri_InlineJavascriptRequirement_classLoader_False_True_None_None: Final[
+    Loader[InlineJavascriptRequirement_class]
+] = _URILoader(InlineJavascriptRequirement_classLoader, False, True, None, None)
+union_of_None_type_or_array_of_strtype: Final[Loader[None | Sequence[str]]] = (
+    _UnionLoader(
+        (
+            None_type,
             array_of_strtype,
         )
     )
 )
-union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        CommandInputRecordSchemaLoader,
-        CommandInputEnumSchemaLoader,
-        CommandInputArraySchemaLoader,
-        strtype,
+SchemaDefRequirement_class: TypeAlias = Literal["SchemaDefRequirement"]
+SchemaDefRequirement_classLoader: Final[Loader[SchemaDefRequirement_class]] = (
+    _EnumLoader[SchemaDefRequirement_class](
+        ("SchemaDefRequirement",), "SchemaDefRequirement_class"
     )
 )
-array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
+uri_SchemaDefRequirement_classLoader_False_True_None_None: Final[
+    Loader[SchemaDefRequirement_class]
+] = _URILoader(SchemaDefRequirement_classLoader, False, True, None, None)
+union_of_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_InputRecordSchemaLoader: (
+    Final[Loader[InputArraySchema | InputEnumSchema | InputRecordSchema]]
 ) = _UnionLoader(
+    (
+        InputEnumSchemaLoader,
+        InputArraySchemaLoader,
+        InputRecordSchemaLoader,
+    )
+)
+array_of_InputSchemaProxyLoader: Final[Loader[Sequence[InputSchema]]] = _ArrayLoader(
+    InputSchemaProxyLoader
+)
+union_of_None_type_or_inttype: Final[Loader[None | i32]] = _UnionLoader(
+    (
+        None_type,
+        inttype,
+    )
+)
+union_of_None_type_or_strtype_or_ExpressionLoader_or_array_of_strtype: Final[
+    Loader[None | Sequence[str] | str]
+] = _UnionLoader(
+    (
+        None_type,
+        strtype,
+        ExpressionLoader,
+        array_of_strtype,
+    )
+)
+union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         CommandInputRecordSchemaLoader,
@@ -23210,55 +25086,101 @@ union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSche
         array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | CommandInputArraySchema
+    | CommandInputEnumSchema
+    | CommandInputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | str
+    ]
+    | str
+](
     union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_CommandInputRecordFieldLoader: Final = _ArrayLoader(
-    CommandInputRecordFieldLoader
+union_of_None_type_or_CommandLineBindingLoader: Final[
+    Loader[CommandLineBinding | None]
+] = _UnionLoader(
+    (
+        None_type,
+        CommandLineBindingLoader,
+    )
 )
-union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final = _UnionLoader(
+array_of_CommandInputRecordFieldLoader: Final[
+    Loader[Sequence[CommandInputRecordField]]
+] = _ArrayLoader(CommandInputRecordFieldLoader)
+union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandInputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_CommandInputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final = (
-    _IdMapLoader(
-        union_of_None_type_or_array_of_CommandInputRecordFieldLoader, "name", "type"
-    )
+idmap_fields_union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandInputRecordField]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_CommandInputRecordFieldLoader, "name", "type"
 )
-uri_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+uri_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        CommandOutputRecordSchemaLoader,
-        CommandOutputEnumSchemaLoader,
-        CommandOutputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         CommandOutputRecordSchemaLoader,
@@ -23268,146 +25190,193 @@ union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSc
         array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | CommandOutputArraySchema
+    | CommandOutputEnumSchema
+    | CommandOutputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | str
+    ]
+    | str
+](
     union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_CommandOutputRecordFieldLoader: Final = _ArrayLoader(
-    CommandOutputRecordFieldLoader
+union_of_None_type_or_CommandOutputBindingLoader: Final[
+    Loader[CommandOutputBinding | None]
+] = _UnionLoader(
+    (
+        None_type,
+        CommandOutputBindingLoader,
+    )
 )
-union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final = _UnionLoader(
+array_of_CommandOutputRecordFieldLoader: Final[
+    Loader[Sequence[CommandOutputRecordField]]
+] = _ArrayLoader(CommandOutputRecordFieldLoader)
+union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandOutputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_CommandOutputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final = (
-    _IdMapLoader(
-        union_of_None_type_or_array_of_CommandOutputRecordFieldLoader, "name", "type"
-    )
+idmap_fields_union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandOutputRecordField]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_CommandOutputRecordFieldLoader, "name", "type"
 )
-uri_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+uri_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_None_type_or_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_None_type_or_CommandInputParameterTypeLoader: Final[
+    Loader[CommandInputParameterType | None]
+] = _UnionLoader(
     (
         None_type,
-        CWLTypeLoader,
-        CommandInputRecordSchemaLoader,
-        CommandInputEnumSchemaLoader,
-        CommandInputArraySchemaLoader,
-        strtype,
-        array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
+        CommandInputParameterTypeLoader,
     )
 )
-typedsl_union_of_None_type_or_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
-    union_of_None_type_or_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
-    2,
-    "v1.1",
+typedsl_union_of_None_type_or_CommandInputParameterTypeLoader_2: Final[
+    Loader[CommandInputParameterType | None]
+] = _TypeDSLLoader[CommandInputParameterType | None](
+    union_of_None_type_or_CommandInputParameterTypeLoader, 2, "v1.1"
 )
-union_of_None_type_or_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_None_type_or_CommandOutputParameterTypeLoader: Final[
+    Loader[CommandOutputParameterType | None]
+] = _UnionLoader(
     (
         None_type,
-        CWLTypeLoader,
-        stdoutLoader,
-        stderrLoader,
-        CommandOutputRecordSchemaLoader,
-        CommandOutputEnumSchemaLoader,
-        CommandOutputArraySchemaLoader,
-        strtype,
-        array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
+        CommandOutputParameterTypeLoader,
     )
 )
-typedsl_union_of_None_type_or_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
-    union_of_None_type_or_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
-    2,
-    "v1.1",
+typedsl_union_of_None_type_or_CommandOutputParameterTypeLoader_2: Final[
+    Loader[CommandOutputParameterType | None]
+] = _TypeDSLLoader[CommandOutputParameterType | None](
+    union_of_None_type_or_CommandOutputParameterTypeLoader, 2, "v1.1"
 )
-CommandLineTool_classLoader: Final = _EnumLoader(
-    ("CommandLineTool",), "CommandLineTool_class"
+CommandLineTool_class: TypeAlias = Literal["CommandLineTool"]
+CommandLineTool_classLoader: Final[Loader[CommandLineTool_class]] = _EnumLoader[
+    CommandLineTool_class
+](("CommandLineTool",), "CommandLineTool_class")
+uri_CommandLineTool_classLoader_False_True_None_None: Final[
+    Loader[CommandLineTool_class]
+] = _URILoader(CommandLineTool_classLoader, False, True, None, None)
+array_of_CommandInputParameterLoader: Final[Loader[Sequence[CommandInputParameter]]] = (
+    _ArrayLoader(CommandInputParameterLoader)
 )
-uri_CommandLineTool_classLoader_False_True_None_None: Final = _URILoader(
-    CommandLineTool_classLoader, False, True, None, None
-)
-array_of_CommandInputParameterLoader: Final = _ArrayLoader(CommandInputParameterLoader)
-idmap_inputs_array_of_CommandInputParameterLoader: Final = _IdMapLoader(
-    array_of_CommandInputParameterLoader, "id", "type"
-)
-array_of_CommandOutputParameterLoader: Final = _ArrayLoader(
-    CommandOutputParameterLoader
-)
-idmap_outputs_array_of_CommandOutputParameterLoader: Final = _IdMapLoader(
-    array_of_CommandOutputParameterLoader, "id", "type"
-)
-union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final = _UnionLoader(
+idmap_inputs_array_of_CommandInputParameterLoader: Final[
+    Loader[Sequence[CommandInputParameter]]
+] = _IdMapLoader(array_of_CommandInputParameterLoader, "id", "type")
+array_of_CommandOutputParameterLoader: Final[
+    Loader[Sequence[CommandOutputParameter]]
+] = _ArrayLoader(CommandOutputParameterLoader)
+idmap_outputs_array_of_CommandOutputParameterLoader: Final[
+    Loader[Sequence[CommandOutputParameter]]
+] = _IdMapLoader(array_of_CommandOutputParameterLoader, "id", "type")
+union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final[
+    Loader[CommandLineBinding | str]
+] = _UnionLoader(
     (
         strtype,
         ExpressionLoader,
         CommandLineBindingLoader,
     )
 )
-array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final = (
-    _ArrayLoader(union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader)
-)
-union_of_None_type_or_array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: (
-    Final
-) = _UnionLoader(
+array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final[
+    Loader[Sequence[CommandLineBinding | str]]
+] = _ArrayLoader(union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader)
+union_of_None_type_or_array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final[
+    Loader[None | Sequence[CommandLineBinding | str]]
+] = _UnionLoader(
     (
         None_type,
         array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader,
     )
 )
-array_of_inttype: Final = _ArrayLoader(inttype)
-union_of_None_type_or_array_of_inttype: Final = _UnionLoader(
-    (
-        None_type,
-        array_of_inttype,
+array_of_inttype: Final[Loader[Sequence[i32]]] = _ArrayLoader(inttype)
+union_of_None_type_or_array_of_inttype: Final[Loader[None | Sequence[i32]]] = (
+    _UnionLoader(
+        (
+            None_type,
+            array_of_inttype,
+        )
     )
 )
-DockerRequirement_classLoader: Final = _EnumLoader(
-    ("DockerRequirement",), "DockerRequirement_class"
+DockerRequirement_class: TypeAlias = Literal["DockerRequirement"]
+DockerRequirement_classLoader: Final[Loader[DockerRequirement_class]] = _EnumLoader[
+    DockerRequirement_class
+](("DockerRequirement",), "DockerRequirement_class")
+uri_DockerRequirement_classLoader_False_True_None_None: Final[
+    Loader[DockerRequirement_class]
+] = _URILoader(DockerRequirement_classLoader, False, True, None, None)
+SoftwareRequirement_class: TypeAlias = Literal["SoftwareRequirement"]
+SoftwareRequirement_classLoader: Final[Loader[SoftwareRequirement_class]] = _EnumLoader[
+    SoftwareRequirement_class
+](("SoftwareRequirement",), "SoftwareRequirement_class")
+uri_SoftwareRequirement_classLoader_False_True_None_None: Final[
+    Loader[SoftwareRequirement_class]
+] = _URILoader(SoftwareRequirement_classLoader, False, True, None, None)
+array_of_SoftwarePackageLoader: Final[Loader[Sequence[SoftwarePackage]]] = _ArrayLoader(
+    SoftwarePackageLoader
 )
-uri_DockerRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    DockerRequirement_classLoader, False, True, None, None
-)
-SoftwareRequirement_classLoader: Final = _EnumLoader(
-    ("SoftwareRequirement",), "SoftwareRequirement_class"
-)
-uri_SoftwareRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    SoftwareRequirement_classLoader, False, True, None, None
-)
-array_of_SoftwarePackageLoader: Final = _ArrayLoader(SoftwarePackageLoader)
-idmap_packages_array_of_SoftwarePackageLoader: Final = _IdMapLoader(
-    array_of_SoftwarePackageLoader, "package", "specs"
-)
-uri_union_of_None_type_or_array_of_strtype_False_False_None_True: Final = _URILoader(
-    union_of_None_type_or_array_of_strtype, False, False, None, True
-)
-InitialWorkDirRequirement_classLoader: Final = _EnumLoader(
+idmap_packages_array_of_SoftwarePackageLoader: Final[
+    Loader[Sequence[SoftwarePackage]]
+] = _IdMapLoader(array_of_SoftwarePackageLoader, "package", "specs")
+uri_union_of_None_type_or_array_of_strtype_False_False_None_True: Final[
+    Loader[None | Sequence[str]]
+] = _URILoader(union_of_None_type_or_array_of_strtype, False, False, None, True)
+InitialWorkDirRequirement_class: TypeAlias = Literal["InitialWorkDirRequirement"]
+InitialWorkDirRequirement_classLoader: Final[
+    Loader[InitialWorkDirRequirement_class]
+] = _EnumLoader[InitialWorkDirRequirement_class](
     ("InitialWorkDirRequirement",), "InitialWorkDirRequirement_class"
 )
-uri_InitialWorkDirRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    InitialWorkDirRequirement_classLoader, False, True, None, None
-)
+uri_InitialWorkDirRequirement_classLoader_False_True_None_None: Final[
+    Loader[InitialWorkDirRequirement_class]
+] = _URILoader(InitialWorkDirRequirement_classLoader, False, True, None, None)
 union_of_FileLoader_or_DirectoryLoader_or_DirentLoader_or_strtype_or_ExpressionLoader: (
-    Final
+    Final[Loader[Directory | Dirent | File | str]]
 ) = _UnionLoader(
     (
         FileLoader,
@@ -23417,43 +25386,63 @@ union_of_FileLoader_or_DirectoryLoader_or_DirentLoader_or_strtype_or_ExpressionL
         ExpressionLoader,
     )
 )
-array_of_union_of_FileLoader_or_DirectoryLoader_or_DirentLoader_or_strtype_or_ExpressionLoader: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_FileLoader_or_DirectoryLoader_or_DirentLoader_or_strtype_or_ExpressionLoader: Final[
+    Loader[Sequence[Directory | Dirent | File | str]]
+] = _ArrayLoader(
     union_of_FileLoader_or_DirectoryLoader_or_DirentLoader_or_strtype_or_ExpressionLoader
 )
-union_of_array_of_union_of_FileLoader_or_DirectoryLoader_or_DirentLoader_or_strtype_or_ExpressionLoader_or_strtype_or_ExpressionLoader: (
-    Final
-) = _UnionLoader(
+union_of_array_of_union_of_FileLoader_or_DirectoryLoader_or_DirentLoader_or_strtype_or_ExpressionLoader_or_strtype_or_ExpressionLoader: Final[
+    Loader[Sequence[Directory | Dirent | File | str] | str]
+] = _UnionLoader(
     (
         array_of_union_of_FileLoader_or_DirectoryLoader_or_DirentLoader_or_strtype_or_ExpressionLoader,
         strtype,
         ExpressionLoader,
     )
 )
-EnvVarRequirement_classLoader: Final = _EnumLoader(
-    ("EnvVarRequirement",), "EnvVarRequirement_class"
+EnvVarRequirement_class: TypeAlias = Literal["EnvVarRequirement"]
+EnvVarRequirement_classLoader: Final[Loader[EnvVarRequirement_class]] = _EnumLoader[
+    EnvVarRequirement_class
+](("EnvVarRequirement",), "EnvVarRequirement_class")
+uri_EnvVarRequirement_classLoader_False_True_None_None: Final[
+    Loader[EnvVarRequirement_class]
+] = _URILoader(EnvVarRequirement_classLoader, False, True, None, None)
+array_of_EnvironmentDefLoader: Final[Loader[Sequence[EnvironmentDef]]] = _ArrayLoader(
+    EnvironmentDefLoader
 )
-uri_EnvVarRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    EnvVarRequirement_classLoader, False, True, None, None
+idmap_envDef_array_of_EnvironmentDefLoader: Final[Loader[Sequence[EnvironmentDef]]] = (
+    _IdMapLoader(array_of_EnvironmentDefLoader, "envName", "envValue")
 )
-array_of_EnvironmentDefLoader: Final = _ArrayLoader(EnvironmentDefLoader)
-idmap_envDef_array_of_EnvironmentDefLoader: Final = _IdMapLoader(
-    array_of_EnvironmentDefLoader, "envName", "envValue"
+ShellCommandRequirement_class: TypeAlias = Literal["ShellCommandRequirement"]
+ShellCommandRequirement_classLoader: Final[Loader[ShellCommandRequirement_class]] = (
+    _EnumLoader[ShellCommandRequirement_class](
+        ("ShellCommandRequirement",), "ShellCommandRequirement_class"
+    )
 )
-ShellCommandRequirement_classLoader: Final = _EnumLoader(
-    ("ShellCommandRequirement",), "ShellCommandRequirement_class"
+uri_ShellCommandRequirement_classLoader_False_True_None_None: Final[
+    Loader[ShellCommandRequirement_class]
+] = _URILoader(ShellCommandRequirement_classLoader, False, True, None, None)
+ResourceRequirement_class: TypeAlias = Literal["ResourceRequirement"]
+ResourceRequirement_classLoader: Final[Loader[ResourceRequirement_class]] = _EnumLoader[
+    ResourceRequirement_class
+](("ResourceRequirement",), "ResourceRequirement_class")
+uri_ResourceRequirement_classLoader_False_True_None_None: Final[
+    Loader[ResourceRequirement_class]
+] = _URILoader(ResourceRequirement_classLoader, False, True, None, None)
+union_of_None_type_or_inttype_or_longtype_or_strtype_or_ExpressionLoader: Final[
+    Loader[None | i32 | i64 | str]
+] = _UnionLoader(
+    (
+        None_type,
+        inttype,
+        longtype,
+        strtype,
+        ExpressionLoader,
+    )
 )
-uri_ShellCommandRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    ShellCommandRequirement_classLoader, False, True, None, None
-)
-ResourceRequirement_classLoader: Final = _EnumLoader(
-    ("ResourceRequirement",), "ResourceRequirement_class"
-)
-uri_ResourceRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    ResourceRequirement_classLoader, False, True, None, None
-)
-union_of_None_type_or_inttype_or_strtype_or_ExpressionLoader: Final = _UnionLoader(
+union_of_None_type_or_inttype_or_strtype_or_ExpressionLoader: Final[
+    Loader[None | i32 | str]
+] = _UnionLoader(
     (
         None_type,
         inttype,
@@ -23461,160 +25450,199 @@ union_of_None_type_or_inttype_or_strtype_or_ExpressionLoader: Final = _UnionLoad
         ExpressionLoader,
     )
 )
-union_of_None_type_or_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_None_type_or_longtype_or_strtype_or_ExpressionLoader: Final[
+    Loader[None | i64 | str]
+] = _UnionLoader(
     (
         None_type,
-        CWLTypeLoader,
-        OutputRecordSchemaLoader,
-        OutputEnumSchemaLoader,
-        OutputArraySchemaLoader,
+        longtype,
         strtype,
-        array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
+        ExpressionLoader,
     )
 )
-typedsl_union_of_None_type_or_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
-    union_of_None_type_or_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
-    2,
-    "v1.1",
-)
-ExpressionTool_classLoader: Final = _EnumLoader(
-    ("ExpressionTool",), "ExpressionTool_class"
-)
-uri_ExpressionTool_classLoader_False_True_None_None: Final = _URILoader(
-    ExpressionTool_classLoader, False, True, None, None
-)
-array_of_ExpressionToolOutputParameterLoader: Final = _ArrayLoader(
-    ExpressionToolOutputParameterLoader
-)
-idmap_outputs_array_of_ExpressionToolOutputParameterLoader: Final = _IdMapLoader(
-    array_of_ExpressionToolOutputParameterLoader, "id", "type"
-)
-uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None: Final = (
-    _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 1, None)
-)
-union_of_None_type_or_LinkMergeMethodLoader: Final = _UnionLoader(
+union_of_None_type_or_OutputParameterTypeLoader: Final[
+    Loader[None | OutputParameterType]
+] = _UnionLoader(
     (
         None_type,
-        LinkMergeMethodLoader,
+        OutputParameterTypeLoader,
     )
 )
-uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_2_None: Final = (
-    _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 2, None)
+typedsl_union_of_None_type_or_OutputParameterTypeLoader_2: Final[
+    Loader[None | OutputParameterType]
+] = _TypeDSLLoader[None | OutputParameterType](
+    union_of_None_type_or_OutputParameterTypeLoader, 2, "v1.1"
 )
-array_of_WorkflowStepInputLoader: Final = _ArrayLoader(WorkflowStepInputLoader)
-idmap_in__array_of_WorkflowStepInputLoader: Final = _IdMapLoader(
-    array_of_WorkflowStepInputLoader, "id", "source"
+ExpressionTool_class: TypeAlias = Literal["ExpressionTool"]
+ExpressionTool_classLoader: Final[Loader[ExpressionTool_class]] = _EnumLoader[
+    ExpressionTool_class
+](("ExpressionTool",), "ExpressionTool_class")
+uri_ExpressionTool_classLoader_False_True_None_None: Final[
+    Loader[ExpressionTool_class]
+] = _URILoader(ExpressionTool_classLoader, False, True, None, None)
+array_of_ExpressionToolOutputParameterLoader: Final[
+    Loader[Sequence[ExpressionToolOutputParameter]]
+] = _ArrayLoader(ExpressionToolOutputParameterLoader)
+idmap_outputs_array_of_ExpressionToolOutputParameterLoader: Final[
+    Loader[Sequence[ExpressionToolOutputParameter]]
+] = _IdMapLoader(array_of_ExpressionToolOutputParameterLoader, "id", "type")
+uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 1, None)
+union_of_None_type_or_LinkMergeMethodLoader: Final[Loader[LinkMergeMethod | None]] = (
+    _UnionLoader(
+        (
+            None_type,
+            LinkMergeMethodLoader,
+        )
+    )
 )
-union_of_strtype_or_WorkflowStepOutputLoader: Final = _UnionLoader(
+uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_2_None: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 2, None)
+array_of_WorkflowStepInputLoader: Final[Loader[Sequence[WorkflowStepInput]]] = (
+    _ArrayLoader(WorkflowStepInputLoader)
+)
+idmap_in__array_of_WorkflowStepInputLoader: Final[
+    Loader[Sequence[WorkflowStepInput]]
+] = _IdMapLoader(array_of_WorkflowStepInputLoader, "id", "source")
+union_of_strtype_or_WorkflowStepOutputLoader: Final[
+    Loader[WorkflowStepOutput | str]
+] = _UnionLoader(
     (
         strtype,
         WorkflowStepOutputLoader,
     )
 )
-array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final = _ArrayLoader(
-    union_of_strtype_or_WorkflowStepOutputLoader
-)
-union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final = _UnionLoader(
-    (array_of_union_of_strtype_or_WorkflowStepOutputLoader,)
-)
-uri_union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader_True_False_None_None: (
-    Final
-) = _URILoader(
+array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final[
+    Loader[Sequence[WorkflowStepOutput | str]]
+] = _ArrayLoader(union_of_strtype_or_WorkflowStepOutputLoader)
+union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final[
+    Loader[Sequence[WorkflowStepOutput | str]]
+] = _UnionLoader((array_of_union_of_strtype_or_WorkflowStepOutputLoader,))
+uri_union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader_True_False_None_None: Final[
+    Loader[Sequence[WorkflowStepOutput | str]]
+] = _URILoader(
     union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader,
     True,
     False,
     None,
     None,
 )
-array_of_Any_type: Final = _ArrayLoader(Any_type)
-union_of_None_type_or_array_of_Any_type: Final = _UnionLoader(
-    (
-        None_type,
-        array_of_Any_type,
+array_of_Any_type: Final[Loader[Sequence[Any]]] = _ArrayLoader(Any_type)
+union_of_None_type_or_array_of_Any_type: Final[Loader[None | Sequence[Any]]] = (
+    _UnionLoader(
+        (
+            None_type,
+            array_of_Any_type,
+        )
     )
 )
-idmap_hints_union_of_None_type_or_array_of_Any_type: Final = _IdMapLoader(
-    union_of_None_type_or_array_of_Any_type, "class", "None"
-)
-union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _UnionLoader(
+idmap_hints_union_of_None_type_or_array_of_Any_type: Final[
+    Loader[None | Sequence[Any]]
+] = _IdMapLoader(union_of_None_type_or_array_of_Any_type, "class", "None")
+union_of_ProcessGeneratorLoader_or_WorkflowLoader_or_CommandLineToolLoader_or_ExpressionToolLoader: Final[
+    Loader[CommandLineTool | ExpressionTool | ProcessGenerator | Workflow]
+] = _UnionLoader(
     (
-        strtype,
+        ProcessGeneratorLoader,
+        WorkflowLoader,
         CommandLineToolLoader,
         ExpressionToolLoader,
-        WorkflowLoader,
-        ProcessGeneratorLoader,
     )
 )
-uri_union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader_False_False_None_None: (
-    Final
-) = _URILoader(
-    union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader,
-    False,
-    False,
-    None,
-    None,
-)
-uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_0_None: Final = (
-    _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 0, None)
-)
-union_of_None_type_or_ScatterMethodLoader: Final = _UnionLoader(
+union_of_strtype_or_ProcessProxyLoader: Final[Loader[Process | str]] = _UnionLoader(
     (
-        None_type,
-        ScatterMethodLoader,
+        strtype,
+        ProcessProxyLoader,
     )
 )
-uri_union_of_None_type_or_ScatterMethodLoader_False_True_None_None: Final = _URILoader(
-    union_of_None_type_or_ScatterMethodLoader, False, True, None, None
+uri_union_of_strtype_or_ProcessProxyLoader_False_False_None_None: Final[
+    Loader[Process | str]
+] = _URILoader(union_of_strtype_or_ProcessProxyLoader, False, False, None, None)
+uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_0_None: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 0, None)
+union_of_None_type_or_ScatterMethodLoader: Final[Loader[None | ScatterMethod]] = (
+    _UnionLoader(
+        (
+            None_type,
+            ScatterMethodLoader,
+        )
+    )
 )
-Workflow_classLoader: Final = _EnumLoader(("Workflow",), "Workflow_class")
-uri_Workflow_classLoader_False_True_None_None: Final = _URILoader(
-    Workflow_classLoader, False, True, None, None
+uri_union_of_None_type_or_ScatterMethodLoader_False_True_None_None: Final[
+    Loader[None | ScatterMethod]
+] = _URILoader(union_of_None_type_or_ScatterMethodLoader, False, True, None, None)
+Workflow_class: TypeAlias = Literal["Workflow"]
+Workflow_classLoader: Final[Loader[Workflow_class]] = _EnumLoader[Workflow_class](
+    ("Workflow",), "Workflow_class"
 )
-array_of_WorkflowOutputParameterLoader: Final = _ArrayLoader(
-    WorkflowOutputParameterLoader
+uri_Workflow_classLoader_False_True_None_None: Final[Loader[Workflow_class]] = (
+    _URILoader(Workflow_classLoader, False, True, None, None)
 )
-idmap_outputs_array_of_WorkflowOutputParameterLoader: Final = _IdMapLoader(
-    array_of_WorkflowOutputParameterLoader, "id", "type"
+array_of_WorkflowOutputParameterLoader: Final[
+    Loader[Sequence[WorkflowOutputParameter]]
+] = _ArrayLoader(WorkflowOutputParameterLoader)
+idmap_outputs_array_of_WorkflowOutputParameterLoader: Final[
+    Loader[Sequence[WorkflowOutputParameter]]
+] = _IdMapLoader(array_of_WorkflowOutputParameterLoader, "id", "type")
+array_of_WorkflowStepLoader: Final[Loader[Sequence[WorkflowStep]]] = _ArrayLoader(
+    WorkflowStepLoader
 )
-array_of_WorkflowStepLoader: Final = _ArrayLoader(WorkflowStepLoader)
-union_of_array_of_WorkflowStepLoader: Final = _UnionLoader(
-    (array_of_WorkflowStepLoader,)
+union_of_array_of_WorkflowStepLoader: Final[Loader[Sequence[WorkflowStep]]] = (
+    _UnionLoader((array_of_WorkflowStepLoader,))
 )
-idmap_steps_union_of_array_of_WorkflowStepLoader: Final = _IdMapLoader(
-    union_of_array_of_WorkflowStepLoader, "id", "None"
-)
-SubworkflowFeatureRequirement_classLoader: Final = _EnumLoader(
+idmap_steps_union_of_array_of_WorkflowStepLoader: Final[
+    Loader[Sequence[WorkflowStep]]
+] = _IdMapLoader(union_of_array_of_WorkflowStepLoader, "id", "None")
+SubworkflowFeatureRequirement_class: TypeAlias = Literal[
+    "SubworkflowFeatureRequirement"
+]
+SubworkflowFeatureRequirement_classLoader: Final[
+    Loader[SubworkflowFeatureRequirement_class]
+] = _EnumLoader[SubworkflowFeatureRequirement_class](
     ("SubworkflowFeatureRequirement",), "SubworkflowFeatureRequirement_class"
 )
-uri_SubworkflowFeatureRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    SubworkflowFeatureRequirement_classLoader, False, True, None, None
-)
-ScatterFeatureRequirement_classLoader: Final = _EnumLoader(
+uri_SubworkflowFeatureRequirement_classLoader_False_True_None_None: Final[
+    Loader[SubworkflowFeatureRequirement_class]
+] = _URILoader(SubworkflowFeatureRequirement_classLoader, False, True, None, None)
+ScatterFeatureRequirement_class: TypeAlias = Literal["ScatterFeatureRequirement"]
+ScatterFeatureRequirement_classLoader: Final[
+    Loader[ScatterFeatureRequirement_class]
+] = _EnumLoader[ScatterFeatureRequirement_class](
     ("ScatterFeatureRequirement",), "ScatterFeatureRequirement_class"
 )
-uri_ScatterFeatureRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    ScatterFeatureRequirement_classLoader, False, True, None, None
-)
-MultipleInputFeatureRequirement_classLoader: Final = _EnumLoader(
+uri_ScatterFeatureRequirement_classLoader_False_True_None_None: Final[
+    Loader[ScatterFeatureRequirement_class]
+] = _URILoader(ScatterFeatureRequirement_classLoader, False, True, None, None)
+MultipleInputFeatureRequirement_class: TypeAlias = Literal[
+    "MultipleInputFeatureRequirement"
+]
+MultipleInputFeatureRequirement_classLoader: Final[
+    Loader[MultipleInputFeatureRequirement_class]
+] = _EnumLoader[MultipleInputFeatureRequirement_class](
     ("MultipleInputFeatureRequirement",), "MultipleInputFeatureRequirement_class"
 )
-uri_MultipleInputFeatureRequirement_classLoader_False_True_None_None: Final = (
-    _URILoader(MultipleInputFeatureRequirement_classLoader, False, True, None, None)
-)
-StepInputExpressionRequirement_classLoader: Final = _EnumLoader(
+uri_MultipleInputFeatureRequirement_classLoader_False_True_None_None: Final[
+    Loader[MultipleInputFeatureRequirement_class]
+] = _URILoader(MultipleInputFeatureRequirement_classLoader, False, True, None, None)
+StepInputExpressionRequirement_class: TypeAlias = Literal[
+    "StepInputExpressionRequirement"
+]
+StepInputExpressionRequirement_classLoader: Final[
+    Loader[StepInputExpressionRequirement_class]
+] = _EnumLoader[StepInputExpressionRequirement_class](
     ("StepInputExpressionRequirement",), "StepInputExpressionRequirement_class"
 )
-uri_StepInputExpressionRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    StepInputExpressionRequirement_classLoader, False, True, None, None
+uri_StepInputExpressionRequirement_classLoader_False_True_None_None: Final[
+    Loader[StepInputExpressionRequirement_class]
+] = _URILoader(StepInputExpressionRequirement_classLoader, False, True, None, None)
+uri_strtype_False_True_None_None: Final[Loader[str]] = _URILoader(
+    strtype, False, True, None, None
 )
-uri_strtype_False_True_None_None: Final = _URILoader(strtype, False, True, None, None)
-LoadListingEnumLoader: Final = _EnumLoader(
+LoadListingEnum: TypeAlias = Literal["no_listing", "shallow_listing", "deep_listing"]
+LoadListingEnumLoader: Final[Loader[LoadListingEnum]] = _EnumLoader[LoadListingEnum](
     (
         "no_listing",
         "shallow_listing",
@@ -23622,44 +25650,48 @@ LoadListingEnumLoader: Final = _EnumLoader(
     ),
     "LoadListingEnum",
 )
-union_of_LoadListingEnumLoader: Final = _UnionLoader((LoadListingEnumLoader,))
-uri_array_of_strtype_False_False_0_None: Final = _URILoader(
+union_of_LoadListingEnumLoader: Final[Loader[LoadListingEnum]] = _UnionLoader(
+    (LoadListingEnumLoader,)
+)
+uri_array_of_strtype_False_False_0_None: Final[Loader[Sequence[str]]] = _URILoader(
     array_of_strtype, False, False, 0, None
 )
-union_of_inttype_or_strtype: Final = _UnionLoader(
+union_of_longtype_or_strtype: Final[Loader[i64 | str]] = _UnionLoader(
     (
-        inttype,
+        longtype,
         strtype,
     )
 )
-union_of_booltype_or_strtype: Final = _UnionLoader(
+union_of_booltype_or_strtype: Final[Loader[bool | str]] = _UnionLoader(
     (
         booltype,
         strtype,
     )
 )
-union_of_inttype_or_ExpressionLoader: Final = _UnionLoader(
+union_of_inttype_or_ExpressionLoader: Final[Loader[i32 | str]] = _UnionLoader(
     (
         inttype,
         ExpressionLoader,
     )
 )
-union_of_strtype_or_array_of_strtype: Final = _UnionLoader(
+union_of_strtype_or_array_of_strtype: Final[Loader[Sequence[str] | str]] = _UnionLoader(
     (
         strtype,
         array_of_strtype,
     )
 )
-union_of_None_type_or_inttype_or_ExpressionLoader: Final = _UnionLoader(
-    (
-        None_type,
-        inttype,
-        ExpressionLoader,
+union_of_None_type_or_inttype_or_ExpressionLoader: Final[Loader[None | i32 | str]] = (
+    _UnionLoader(
+        (
+            None_type,
+            inttype,
+            ExpressionLoader,
+        )
     )
 )
-union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _UnionLoader(
+union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: Final[
+    Loader[CommandLineTool | ExpressionTool | ProcessGenerator | Workflow]
+] = _UnionLoader(
     (
         CommandLineToolLoader,
         ExpressionToolLoader,
@@ -23667,14 +25699,20 @@ union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_Proc
         ProcessGeneratorLoader,
     )
 )
-array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: Final[
+    Loader[Sequence[CommandLineTool | ExpressionTool | ProcessGenerator | Workflow]]
+] = _ArrayLoader(
     union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader
 )
-union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader_or_array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _UnionLoader(
+union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader_or_array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: Final[
+    Loader[
+        CommandLineTool
+        | ExpressionTool
+        | ProcessGenerator
+        | Sequence[CommandLineTool | ExpressionTool | ProcessGenerator | Workflow]
+        | Workflow
+    ]
+] = _UnionLoader(
     (
         CommandLineToolLoader,
         ExpressionToolLoader,
@@ -23688,16 +25726,16 @@ _loaders.update({
     "DocumentedLoader": None,
     "SchemaBaseLoader": None,
     "ParameterLoader": None,
-    "InputBindingLoader": None,
-    "OutputBindingLoader": None,
-    "InputSchemaLoader": union_of_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader,
+    "InputBindingLoader": CommandLineBindingLoader,
+    "OutputBindingLoader": CommandOutputBindingLoader,
+    "InputSchemaLoader": union_of_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_InputRecordSchemaLoader,
     "OutputSchemaLoader": None,
-    "ProcessRequirementLoader": union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_InplaceUpdateRequirementLoader_or_SecretsLoader_or_TimeLimitLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader,
-    "ProcessLoader": None,
+    "ProcessRequirementLoader": union_of_StepInputExpressionRequirementLoader_or_SchemaDefRequirementLoader_or_WorkReuseLoader_or_ShmSizeLoader_or_TimeLimitLoader_or_ScatterFeatureRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_CUDARequirementLoader_or_EnvVarRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_InlineJavascriptRequirementLoader_or_SoftwareRequirementLoader_or_InplaceUpdateRequirementLoader_or_InitialWorkDirRequirementLoader_or_NetworkAccessLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_MPIRequirementLoader_or_ResourceRequirementLoader_or_SecretsLoader_or_ShellCommandRequirementLoader,
+    "ProcessLoader": union_of_ProcessGeneratorLoader_or_WorkflowLoader_or_CommandLineToolLoader_or_ExpressionToolLoader,
     "SinkLoader": None,
 })
 
-CWLObjectTypeLoader.add_loaders(
+cast(_UnionLoader[CWLObjectType], CWLObjectTypeLoader).add_loaders(
     (
         booltype,
         inttype,
@@ -23707,6 +25745,52 @@ CWLObjectTypeLoader.add_loaders(
         DirectoryLoader,
         array_of_union_of_None_type_or_CWLObjectTypeLoader,
         map_of_union_of_None_type_or_CWLObjectTypeLoader,
+    )
+)
+cast(_UnionLoader[InputParameterType], InputParameterTypeLoader).add_loaders(
+    (
+        CWLTypeLoader,
+        InputRecordSchemaLoader,
+        InputEnumSchemaLoader,
+        InputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
+    )
+)
+cast(_UnionLoader[OutputParameterType], OutputParameterTypeLoader).add_loaders(
+    (
+        CWLTypeLoader,
+        OutputRecordSchemaLoader,
+        OutputEnumSchemaLoader,
+        OutputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
+    )
+)
+cast(
+    _UnionLoader[CommandInputParameterType], CommandInputParameterTypeLoader
+).add_loaders(
+    (
+        CWLTypeLoader,
+        CommandInputRecordSchemaLoader,
+        CommandInputEnumSchemaLoader,
+        CommandInputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
+    )
+)
+cast(
+    _UnionLoader[CommandOutputParameterType], CommandOutputParameterTypeLoader
+).add_loaders(
+    (
+        CWLTypeLoader,
+        stdoutLoader,
+        stderrLoader,
+        CommandOutputRecordSchemaLoader,
+        CommandOutputEnumSchemaLoader,
+        CommandOutputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     )
 )
 

--- a/src/cwl_utils/parser/cwl_v1_0_utils.py
+++ b/src/cwl_utils/parser/cwl_v1_0_utils.py
@@ -1,29 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 import hashlib
 import logging
-from collections import namedtuple
-from collections.abc import MutableMapping, MutableSequence
+from collections.abc import MutableMapping, MutableSequence, Sequence
 from io import StringIO
 from pathlib import Path
-from typing import IO, Any, cast
+from typing import IO, Any, cast, Literal
 from urllib.parse import urldefrag
 
 from schema_salad.exceptions import ValidationException
 from schema_salad.metaschema import RecordSchema, ArraySchema
 from schema_salad.runtime import shortname, LoadingOptions, file_uri, save
 from schema_salad.sourceline import SourceLine, add_lc_filename
-from schema_salad.utils import aslist, json_dumps, yaml_no_ts
+from schema_salad.utils import aslist, json_dumps, yaml_no_ts, flatten
 
 import cwl_utils.parser
 import cwl_utils.parser.cwl_v1_0 as cwl
 import cwl_utils.parser.utils
+from cwl_utils.types import SrcSink
 from cwl_utils.utils import yaml_dumps
 
 CONTENT_LIMIT: int = 64 * 1024
 
 _logger = logging.getLogger("cwl_utils")
-
-SrcSink = namedtuple("SrcSink", ["src", "sink", "linkMerge", "message"])
 
 
 def _compare_type(type1: Any, type2: Any) -> bool:
@@ -112,11 +110,14 @@ def _inputfile_load(
 
 def check_all_types(
     src_dict: dict[str, Any],
-    sinks: MutableSequence[cwl.WorkflowStepInput | cwl.WorkflowOutputParameter],
+    sinks: Sequence[cwl.WorkflowStepInput | cwl.WorkflowOutputParameter],
     type_dict: dict[str, Any],
 ) -> dict[str, list[SrcSink]]:
     """Given a list of sinks, check if their types match with the types of their sources."""
-    validation: dict[str, list[SrcSink]] = {"warning": [], "exception": []}
+    validation: dict[str, list[SrcSink]] = {
+        "warning": [],
+        "exception": [],
+    }
     for sink in sinks:
         match sink:
             case cwl.WorkflowOutputParameter():
@@ -258,21 +259,36 @@ def load_inputfile_by_yaml(
     return result
 
 
+def to_input_array(type_: cwl.InputParameterType) -> cwl.InputArraySchema:
+    return cwl.InputArraySchema(type_="array", items=type_)
+
+
+def to_output_array(type_: cwl.OutputParameterType) -> cwl.OutputArraySchema:
+    return cwl.OutputArraySchema(type_="array", items=type_)
+
+
 def type_for_step_input(
     step: cwl.WorkflowStep,
     in_: cwl.WorkflowStepInput,
-) -> Any:
+) -> (
+    Literal["Any"]
+    | cwl_utils.parser.InputParameterType
+    | cwl_utils.parser.CommandInputParameterType
+):
     """Determine the type for the given step input."""
     if in_.valueFrom is not None:
         return "Any"
-    step_run = cwl_utils.parser.utils.load_step(step)
-    cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
-    if step_run and step_run.inputs:
+    if step_run := cwl_utils.parser.utils.load_step(step):
+        cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
         for step_input in step_run.inputs:
-            if cast(str, step_input.id).split("#")[-1] == in_.id.split("#")[-1]:
-                input_type = step_input.type_
-                if step.scatter is not None and in_.id in aslist(step.scatter):
-                    input_type = ArraySchema(items=input_type, type_="array")
+            if step_input.id.split("#")[-1] == in_.id.split("#")[-1]:
+                if (input_type := step_input.type_) is None:
+                    raise Exception(f"Step output {step_input.id} has null type")
+                else:
+                    if step.scatter is not None and in_.id in aslist(step.scatter):
+                        input_type = cwl_utils.parser.utils.to_input_array(
+                            input_type, step_run.cwlVersion or "v1.0"
+                        )
                 return input_type
     return "Any"
 
@@ -280,24 +296,33 @@ def type_for_step_input(
 def type_for_step_output(
     step: cwl.WorkflowStep,
     sourcename: str,
-) -> Any:
+) -> (
+    Literal["Any"]
+    | cwl_utils.parser.OutputParameterType
+    | cwl_utils.parser.CommandOutputParameterType
+):
     """Determine the type for the given step output."""
-    step_run = cwl_utils.parser.utils.load_step(step)
-    cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
-    if step_run and step_run.outputs:
+    if step_run := cwl_utils.parser.utils.load_step(step):
+        cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
         for step_output in step_run.outputs:
             if (
                 step_output.id.split("#")[-1].split("/")[-1]
                 == sourcename.split("#")[-1].split("/")[-1]
             ):
-                output_type = step_output.type_
-                if step.scatter is not None:
-                    if step.scatterMethod == "nested_crossproduct":
-                        for _ in range(len(aslist(step.scatter))):
-                            output_type = ArraySchema(items=output_type, type_="array")
-                    else:
-                        output_type = ArraySchema(items=output_type, type_="array")
-                return output_type
+                if (output_type := step_output.type_) is None:
+                    raise Exception(f"Step output {step_output.id} has null type")
+                else:
+                    if step.scatter is not None:
+                        if step.scatterMethod == "nested_crossproduct":
+                            for _ in range(len(aslist(step.scatter))):
+                                output_type = cwl_utils.parser.utils.to_output_array(
+                                    output_type, step_run.cwlVersion or "v1.0"
+                                )
+                        else:
+                            output_type = cwl_utils.parser.utils.to_output_array(
+                                output_type, step_run.cwlVersion or "v1.0"
+                            )
+                    return output_type
     raise ValidationException(
         "param {} not found in {}.".format(
             sourcename,
@@ -308,35 +333,37 @@ def type_for_step_output(
 
 def type_for_source(
     process: cwl.CommandLineTool | cwl.Workflow | cwl.ExpressionTool,
-    sourcenames: str | list[str],
-    parent: cwl.Workflow | None = None,
+    sourcenames: str | Sequence[str],
+    parent: cwl_utils.parser.Workflow | None = None,
     linkMerge: str | None = None,
-) -> Any:
+    loaded_steps: dict[str, cwl_utils.parser.Process] | None = None,
+) -> cwl_utils.parser.ParameterTypeOrArraySchema:
     """Determine the type for the given sourcenames."""
     scatter_context: list[tuple[int, str] | None] = []
     params = cwl_utils.parser.utils.param_for_source_id(
-        process, sourcenames, parent, scatter_context
+        process, sourcenames, parent, scatter_context, loaded_steps
     )
     if not isinstance(params, MutableSequence):
-        new_type = params.type_
-        if scatter_context[0] is not None:
-            if scatter_context[0][1] == "nested_crossproduct":
-                for _ in range(scatter_context[0][0]):
+        if params.type_ is None:
+            raise Exception(f"Parameter {params.id} has null type")
+        else:
+            new_type: cwl_utils.parser.ParameterTypeOrArraySchema = params.type_
+            if scatter_context[0] is not None:
+                if scatter_context[0][1] == "nested_crossproduct":
+                    for _ in range(scatter_context[0][0]):
+                        new_type = ArraySchema(items=new_type, type_="array")
+                else:
                     new_type = ArraySchema(items=new_type, type_="array")
-            else:
+            if linkMerge == "merge_nested":
                 new_type = ArraySchema(items=new_type, type_="array")
-        if linkMerge == "merge_nested":
-            new_type = ArraySchema(items=new_type, type_="array")
-        elif linkMerge == "merge_flattened":
-            new_type = cwl_utils.parser.utils.merge_flatten_type(new_type)
-        return new_type
-    new_type = []
+            elif linkMerge == "merge_flattened":
+                new_type = cwl_utils.parser.utils.merge_flatten_type(new_type)
+            return new_type
+    new_types: list[cwl_utils.parser.ParameterType | ArraySchema] = []
     for p, sc in zip(params, scatter_context):
-        if isinstance(p, str) and not any(_compare_type(t, p) for t in new_type):
-            cur_type = p
-        elif hasattr(p, "type_") and not any(
-            _compare_type(t, p.type_) for t in new_type
-        ):
+        if isinstance(p, str) and not any(_compare_type(t, p) for t in new_types):
+            cur_type: cwl_utils.parser.ParameterType | ArraySchema | None = p
+        elif p is not None and not any(_compare_type(t, p.type_) for t in new_types):
             cur_type = p.type_
         else:
             cur_type = None
@@ -347,13 +374,18 @@ def type_for_source(
                         cur_type = ArraySchema(items=cur_type, type_="array")
                 else:
                     cur_type = ArraySchema(items=cur_type, type_="array")
-            new_type.append(cur_type)
-    if len(new_type) == 1:
-        new_type = new_type[0]
+            new_types.append(cur_type)
+    if len(new_types) == 1:
+        final_type: cwl_utils.parser.ParameterTypeOrArraySchema = new_types[0]
+    else:
+        final_type = cast(
+            cwl_utils.parser.ParameterTypeOrArraySchema,
+            flatten(new_types),
+        )
     if linkMerge == "merge_nested":
-        return ArraySchema(items=new_type, type_="array")
+        return ArraySchema(items=final_type, type_="array")
     elif linkMerge == "merge_flattened":
-        return cwl_utils.parser.utils.merge_flatten_type(new_type)
+        return cwl_utils.parser.utils.merge_flatten_type(final_type)
     elif isinstance(sourcenames, list) and len(sourcenames) > 1:
-        return ArraySchema(items=new_type, type_="array")
-    return new_type
+        return ArraySchema(items=final_type, type_="array")
+    return final_type

--- a/src/cwl_utils/parser/cwl_v1_1.py
+++ b/src/cwl_utils/parser/cwl_v1_1.py
@@ -27,12 +27,15 @@ else:
 import schema_salad.metaschema
 
 import copy
-from collections.abc import MutableSequence, Sequence, MutableMapping
+from collections.abc import Mapping, Sequence, MutableSequence, MutableMapping
 from io import StringIO
 from itertools import chain
-from typing import Any, Final, cast, Generic
+from typing import Any, Final, cast
+from typing import Literal, TypeAlias  # pylint: disable=unused-import # noqa: F401
 from urllib.parse import urldefrag, urlsplit, urlunsplit
 
+from mypy_extensions import i32, i64, trait  # pylint: disable=unused-import # noqa: F401
+from mypy_extensions import mypyc_attr
 from ruamel.yaml.comments import CommentedMap
 
 from schema_salad.exceptions import ValidationException, SchemaSaladException
@@ -42,16 +45,19 @@ from schema_salad.runtime import (
     extract_type,
     SaveableType,
     Loader,
+    FieldType,
+    EnumFieldType,
 )
 from schema_salad.sourceline import SourceLine, add_lc_filename
 from schema_salad.utils import yaml_no_ts  # requires schema-salad v8.2+
 
-_loaders: Final[dict[str, Loader | None]] = {}
+_loaders: Final[dict[str, Loader[Any] | None]] = {}
 _vocab: Final[dict[str, str]] = {}
 _rvocab: Final[dict[str, str]] = {}
 
 
-class _AnyLoader(Loader):
+@mypyc_attr(native_class=True)
+class _AnyLoader(Loader[Any]):
     def load(
         self,
         doc: Any,
@@ -65,8 +71,9 @@ class _AnyLoader(Loader):
         raise ValidationException("Expected non-null")
 
 
-class _PrimitiveLoader(Loader):
-    def __init__(self, tp: type | tuple[type[str], type[str]]) -> None:
+@mypyc_attr(native_class=True)
+class _PrimitiveLoader(Loader[FieldType]):
+    def __init__(self, tp: type[FieldType]) -> None:
         self.tp: Final = tp
 
     def load(
@@ -76,7 +83,7 @@ class _PrimitiveLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if not isinstance(doc, self.tp):
             raise ValidationException(f"Expected a {self.tp} but got {doc.__class__.__name__}")
         return doc
@@ -85,8 +92,9 @@ class _PrimitiveLoader(Loader):
         return str(self.tp)
 
 
-class _ArrayLoader(Loader):
-    def __init__(self, items: Loader) -> None:
+@mypyc_attr(native_class=True)
+class _ArrayLoader(Loader[Sequence[FieldType]]):
+    def __init__(self, items: Loader[FieldType]) -> None:
         self.items: Final = items
 
     def load(
@@ -96,9 +104,9 @@ class _ArrayLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> list[Any]:
+    ) -> list[FieldType]:
         if not isinstance(doc, MutableSequence):
-            raise ValidationException(
+            raise SourceLine(doc, None, ValidationException).makeError(
                 f"Value is a {convert_typing(extract_type(type(doc)))}, "
                 f"but valid type for this field is an array."
             )
@@ -142,10 +150,11 @@ class _ArrayLoader(Loader):
         return f"array<{self.items}>"
 
 
-class _MapLoader(Loader):
+@mypyc_attr(native_class=True)
+class _MapLoader(Loader[Mapping[str, FieldType]]):
     def __init__(
         self,
-        values: Loader,
+        values: Loader[FieldType],
         name: str | None = None,
         container: str | None = None,
         no_link_check: bool | None = None,
@@ -162,7 +171,7 @@ class _MapLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> dict[str, Any]:
+    ) -> dict[str, FieldType]:
         if not isinstance(doc, MutableMapping):
             raise ValidationException(f"Expected a map, was {type(doc)}")
         if self.container is not None or self.no_link_check is not None:
@@ -185,8 +194,9 @@ class _MapLoader(Loader):
         return self.name if self.name is not None else f"map<string, {self.values}>"
 
 
-class _EnumLoader(Loader):
-    def __init__(self, symbols: Sequence[str], name: str) -> None:
+@mypyc_attr(native_class=True)
+class _EnumLoader(Loader[EnumFieldType]):
+    def __init__(self, symbols: tuple[EnumFieldType, ...], name: str) -> None:
         self.symbols: Final = symbols
         self.name: Final = name
 
@@ -197,17 +207,18 @@ class _EnumLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> str:
+    ) -> EnumFieldType:
         if doc in self.symbols:
-            return cast(str, doc)
+            return cast(EnumFieldType, doc)
         raise ValidationException(f"Expected one of {self.symbols}")
 
     def __repr__(self) -> str:
         return self.name
 
 
-class _SecondaryDSLLoader(Loader):
-    def __init__(self, inner: Loader) -> None:
+@mypyc_attr(native_class=True)
+class _SecondaryDSLLoader(Loader[FieldType]):
+    def __init__(self, inner: Loader[FieldType]) -> None:
         self.inner: Final = inner
 
     def load(
@@ -217,7 +228,7 @@ class _SecondaryDSLLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         r: Final[list[dict[str, Any]]] = []
         match doc:
             case MutableSequence() as dlist:
@@ -279,7 +290,8 @@ class _SecondaryDSLLoader(Loader):
         return self.inner.load(r, baseuri, loadingOptions, docRoot, lc=lc)
 
 
-class _RecordLoader(Loader, Generic[SaveableType]):
+@mypyc_attr(native_class=True)
+class _RecordLoader(Loader[SaveableType]):
     def __init__(
         self,
         classtype: type[SaveableType],
@@ -299,7 +311,7 @@ class _RecordLoader(Loader, Generic[SaveableType]):
         lc: Any | None = None,
     ) -> SaveableType:
         if not isinstance(doc, MutableMapping):
-            raise ValidationException(
+            raise SourceLine(doc, None, ValidationException).makeError(
                 f"Value is a {convert_typing(extract_type(type(doc)))}, "
                 f"but valid type for this field is an object."
             )
@@ -313,7 +325,8 @@ class _RecordLoader(Loader, Generic[SaveableType]):
         return str(self.classtype.__name__)
 
 
-class _ExpressionLoader(Loader):
+@mypyc_attr(native_class=True)
+class _ExpressionLoader(Loader[str]):
     def __init__(self, items: type[str]) -> None:
         self.items: Final = items
 
@@ -326,7 +339,7 @@ class _ExpressionLoader(Loader):
         lc: Any | None = None,
     ) -> str:
         if not isinstance(doc, str):
-            raise ValidationException(
+            raise SourceLine(doc, None, ValidationException).makeError(
                 f"Value is a {convert_typing(extract_type(type(doc)))}, "
                 f"but valid type for this field is a str."
             )
@@ -334,12 +347,13 @@ class _ExpressionLoader(Loader):
             return doc
 
 
-class _UnionLoader(Loader):
-    def __init__(self, alternates: Sequence[Loader], name: str | None = None) -> None:
+@mypyc_attr(native_class=True)
+class _UnionLoader(Loader[FieldType]):
+    def __init__(self, alternates: Sequence[Loader[FieldType]], name: str | None = None) -> None:
         self.alternates = alternates
         self.name: Final = name
 
-    def add_loaders(self, loaders: Sequence[Loader]) -> None:
+    def add_loaders(self, loaders: Sequence[Loader[FieldType]]) -> None:
         self.alternates = tuple(loader for loader in chain(self.alternates, loaders))
 
     def load(
@@ -349,7 +363,7 @@ class _UnionLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         errors: Final = []
 
         if lc is None:
@@ -424,10 +438,11 @@ class _UnionLoader(Loader):
         return self.name if self.name is not None else " | ".join(str(a) for a in self.alternates)
 
 
-class _URILoader(Loader):
+@mypyc_attr(native_class=True)
+class _URILoader(Loader[FieldType]):
     def __init__(
         self,
-        inner: Loader,
+        inner: Loader[FieldType],
         scoped_id: bool,
         vocab_term: bool,
         scoped_ref: int | None,
@@ -446,7 +461,7 @@ class _URILoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if self.no_link_check is not None:
             loadingOptions = LoadingOptions(
                 copyfrom=loadingOptions, no_link_check=self.no_link_check
@@ -493,10 +508,11 @@ class _URILoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
-class _TypeDSLLoader(Loader):
+@mypyc_attr(native_class=True)
+class _TypeDSLLoader(Loader[FieldType]):
     def __init__(
         self,
-        inner: Loader,
+        inner: Loader[FieldType],
         refScope: int | None,
         salad_version: str,
     ) -> None:
@@ -567,7 +583,7 @@ class _TypeDSLLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if isinstance(doc, MutableSequence):
             r: Final[list[Any]] = []
             for d in doc:
@@ -589,8 +605,9 @@ class _TypeDSLLoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
-class _IdMapLoader(Loader):
-    def __init__(self, inner: Loader, mapSubject: str, mapPredicate: str | None) -> None:
+@mypyc_attr(native_class=True)
+class _IdMapLoader(Loader[FieldType]):
+    def __init__(self, inner: Loader[FieldType], mapSubject: str, mapPredicate: str | None) -> None:
         self.inner: Final = inner
         self.mapSubject: Final = mapSubject
         self.mapPredicate: Final = mapPredicate
@@ -602,7 +619,7 @@ class _IdMapLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if isinstance(doc, MutableMapping):
             r: Final[list[Any]] = []
             for k in doc.keys():
@@ -628,7 +645,8 @@ class _IdMapLoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
-class _ProxyLoader(Loader):
+@mypyc_attr(native_class=True)
+class _ProxyLoader(Loader[FieldType]):
     def __init__(self, name: str) -> None:
         self.name: Final = name
 
@@ -639,25 +657,25 @@ class _ProxyLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any | None:
+    ) -> FieldType:
         if (
             self.name in loadingOptions.loaders
             and (loader := loadingOptions.loaders.get(self.name)) is not None
         ):
-            return loader.load(doc, baseuri, loadingOptions, lc=lc)
+            return cast(Loader[FieldType], loader).load(doc, baseuri, loadingOptions, lc=lc)
         elif self.name in _loaders and (loader := _loaders.get(self.name)) is not None:
-            return loader.load(doc, baseuri, loadingOptions, lc=lc)
+            return cast(Loader[FieldType], loader).load(doc, baseuri, loadingOptions, lc=lc)
         else:
             raise ValidationException(f"No Loader instance available for {self.name}")
 
 
 def _document_load(
-    loader: Loader,
+    loader: Loader[FieldType],
     doc: str | MutableMapping[str, Any] | MutableSequence[Any],
     baseuri: str,
     loadingOptions: LoadingOptions,
     addl_metadata_fields: MutableSequence[str] | None = None,
-) -> tuple[Any, LoadingOptions]:
+) -> tuple[FieldType, LoadingOptions]:
     if isinstance(doc, str):
         return _document_load_by_url(
             loader,
@@ -723,11 +741,11 @@ def _document_load(
 
 
 def _document_load_by_url(
-    loader: Loader,
+    loader: Loader[FieldType],
     url: str,
     loadingOptions: LoadingOptions,
     addl_metadata_fields: MutableSequence[str] | None = None,
-) -> tuple[Any, LoadingOptions]:
+) -> tuple[FieldType, LoadingOptions]:
     if url in loadingOptions.idx:
         return loadingOptions.idx[url]
 
@@ -823,11 +841,11 @@ def _expand_url(
 
 def _load_field(
     val: Any | None,
-    fieldtype: Loader,
+    fieldtype: Loader[FieldType],
     baseuri: str,
     loadingOptions: LoadingOptions,
     lc: Any | None = None,
-) -> Any:
+) -> FieldType:
     """Load field."""
     if isinstance(val, MutableMapping):
         if "$import" in val:
@@ -854,25 +872,8 @@ def parser_info() -> str:
     return "org.w3id.cwl.v1_1"
 
 
+@mypyc_attr(native_class=True)
 class CWLArraySchema(schema_salad.metaschema.ArraySchema):
-    def __init__(
-        self,
-        items: Any,
-        type_: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.items = items
-        self.type_ = type_
-
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CWLArraySchema):
             return bool(self.items == other.items and self.type_ == other.type_)
@@ -1050,17 +1051,10 @@ class CWLArraySchema(schema_salad.metaschema.ArraySchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["items", "type"])
-
-
-class CWLRecordField(schema_salad.metaschema.RecordField):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
+        items: CWLArraySchema | CWLRecordSchema | PrimitiveType | Sequence[CWLArraySchema | CWLRecordSchema | PrimitiveType | schema_salad.metaschema.EnumSchema | str] | schema_salad.metaschema.EnumSchema | str,
+        type_: Array_name,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -1069,12 +1063,18 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.items = items
         self.type_ = type_
+
+    attrs: ClassVar[Collection[str]] = frozenset(["items", "type"])
+
+
+@mypyc_attr(native_class=True)
+class CWLRecordField(schema_salad.metaschema.RecordField):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CWLRecordField):
@@ -1149,15 +1149,62 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -1278,13 +1325,13 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -1299,7 +1346,10 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -1318,14 +1368,11 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["doc", "name", "type"])
-
-
-class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
     def __init__(
         self,
-        type_: Any,
-        fields: Any | None = None,
+        name: str,
+        type_: CWLArraySchema | CWLRecordSchema | PrimitiveType | Sequence[CWLArraySchema | CWLRecordSchema | PrimitiveType | schema_salad.metaschema.EnumSchema | str] | schema_salad.metaschema.EnumSchema | str,
+        doc: None | Sequence[str] | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -1334,12 +1381,18 @@ class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.fields = fields
+        self.doc = doc
+        self.name = name
         self.type_ = type_
 
+    attrs: ClassVar[Collection[str]] = frozenset(["doc", "name", "type"])
+
+
+@mypyc_attr(native_class=True)
+class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CWLRecordSchema):
             return bool(self.fields == other.fields and self.type_ == other.type_)
@@ -1517,9 +1570,28 @@ class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        type_: Record_name,
+        fields: None | Sequence[CWLRecordField] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.fields = fields
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(["fields", "type"])
 
 
+@mypyc_attr(native_class=True)
 class File(Saveable):
     """
     Represents a file (or group of files when ``secondaryFiles`` is provided) that will be accessible by tools using standard POSIX file system call API such as open(2) and read(2).
@@ -1547,43 +1619,6 @@ class File(Saveable):
     An ExpressionTool may forward file references from input to output by using the same value for ``location``.
 
     """
-
-    def __init__(
-        self,
-        location: Any | None = None,
-        path: Any | None = None,
-        basename: Any | None = None,
-        dirname: Any | None = None,
-        nameroot: Any | None = None,
-        nameext: Any | None = None,
-        checksum: Any | None = None,
-        size: Any | None = None,
-        secondaryFiles: Any | None = None,
-        format: Any | None = None,
-        contents: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "File"
-        self.location = location
-        self.path = path
-        self.basename = basename
-        self.dirname = dirname
-        self.nameroot = nameroot
-        self.nameext = nameext
-        self.checksum = checksum
-        self.size = size
-        self.secondaryFiles = secondaryFiles
-        self.format = format
-        self.contents = contents
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, File):
@@ -1986,7 +2021,7 @@ class File(Saveable):
             try:
                 size = _load_field(
                     _doc.get("size"),
-                    union_of_None_type_or_inttype,
+                    union_of_None_type_or_inttype_or_longtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("size")
@@ -2284,6 +2319,43 @@ class File(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        location: None | str = None,
+        path: None | str = None,
+        basename: None | str = None,
+        dirname: None | str = None,
+        nameroot: None | str = None,
+        nameext: None | str = None,
+        checksum: None | str = None,
+        size: None | i32 | i64 = None,
+        secondaryFiles: None | Sequence[Directory | File] = None,
+        format: None | str = None,
+        contents: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "File"
+        self.location = location
+        self.path = path
+        self.basename = basename
+        self.dirname = dirname
+        self.nameroot = nameroot
+        self.nameext = nameext
+        self.checksum = checksum
+        self.size = size
+        self.secondaryFiles = secondaryFiles
+        self.format = format
+        self.contents = contents
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -2302,6 +2374,7 @@ class File(Saveable):
     )
 
 
+@mypyc_attr(native_class=True)
 class Directory(Saveable):
     """
     Represents a directory to present to a command line tool.
@@ -2325,29 +2398,6 @@ class Directory(Saveable):
     Name conflicts (the same ``basename`` appearing multiple times in ``listing`` or in any entry in ``secondaryFiles`` in the listing) is a fatal error.
 
     """
-
-    def __init__(
-        self,
-        location: Any | None = None,
-        path: Any | None = None,
-        basename: Any | None = None,
-        listing: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "Directory"
-        self.location = location
-        self.path = path
-        self.basename = basename
-        self.listing = listing
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Directory):
@@ -2662,39 +2712,78 @@ class Directory(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        location: None | str = None,
+        path: None | str = None,
+        basename: None | str = None,
+        listing: None | Sequence[Directory | File] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "Directory"
+        self.location = location
+        self.path = path
+        self.basename = basename
+        self.listing = listing
+
     attrs: ClassVar[Collection[str]] = frozenset(
         ["class", "location", "path", "basename", "listing"]
     )
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Labeled(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Identified(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class IdentifierRequired(Identified):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class LoadContents(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class FieldBase(Labeled):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class InputFormat(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class OutputFormat(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Parameter(FieldBase, schema_salad.metaschema.Documented, IdentifierRequired):
     """
     Define an input or output parameter to a process.
@@ -2704,23 +2793,8 @@ class Parameter(FieldBase, schema_salad.metaschema.Documented, IdentifierRequire
     pass
 
 
+@mypyc_attr(native_class=True)
 class InputBinding(Saveable):
-    def __init__(
-        self,
-        loadContents: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.loadContents = loadContents
-
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputBinding):
             return bool(self.loadContents == other.loadContents)
@@ -2848,35 +2922,9 @@ class InputBinding(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["loadContents"])
-
-
-class IOSchema(Labeled, schema_salad.metaschema.Documented):
-    pass
-
-
-class InputSchema(IOSchema):
-    pass
-
-
-class OutputSchema(IOSchema):
-    pass
-
-
-class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        format: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
+        loadContents: None | bool = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -2885,18 +2933,35 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.type_ = type_
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.format = format
         self.loadContents = loadContents
-        self.loadListing = loadListing
+
+    attrs: ClassVar[Collection[str]] = frozenset(["loadContents"])
+
+
+@mypyc_attr(native_class=True)
+@trait
+class IOSchema(Labeled, schema_salad.metaschema.Documented):
+    pass
+
+
+@mypyc_attr(native_class=True)
+@trait
+class InputSchema(IOSchema):
+    pass
+
+
+@mypyc_attr(native_class=True)
+@trait
+class OutputSchema(IOSchema):
+    pass
+
+
+@mypyc_attr(native_class=True)
+class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputRecordField):
@@ -2989,15 +3054,62 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -3400,8 +3512,8 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             label=label,
             secondaryFiles=secondaryFiles,
@@ -3412,7 +3524,7 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -3427,7 +3539,10 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -3481,6 +3596,38 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        name: str,
+        type_: CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        format: None | Sequence[str] | str = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.doc = doc
+        self.name = name
+        self.type_ = type_
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.format = format
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "doc",
@@ -3496,32 +3643,9 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
     )
 
 
+@mypyc_attr(native_class=True)
 class InputRecordSchema(CWLRecordSchema, InputSchema):
     name: str
-
-    def __init__(
-        self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.fields = fields
-        self.type_ = type_
-        self.label = label
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputRecordSchema):
@@ -3598,15 +3722,61 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -3821,15 +3991,15 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -3844,7 +4014,10 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -3871,21 +4044,13 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["fields", "type", "label", "doc", "name"]
-    )
-
-
-class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[InputRecordField] = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -3894,14 +4059,23 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
         self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["fields", "type", "label", "doc", "name"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputEnumSchema):
@@ -3978,15 +4152,61 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -4210,7 +4430,7 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -4225,7 +4445,10 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -4251,21 +4474,13 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "doc"]
-    )
-
-
-class InputArraySchema(CWLArraySchema, InputSchema):
-    name: str
-
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -4274,14 +4489,23 @@ class InputArraySchema(CWLArraySchema, InputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "doc"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class InputArraySchema(CWLArraySchema, InputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputArraySchema):
@@ -4358,15 +4582,61 @@ class InputArraySchema(CWLArraySchema, InputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("items") is None:
                 raise ValidationException("missing required field `items`", None, [])
@@ -4582,15 +4852,15 @@ class InputArraySchema(CWLArraySchema, InputSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             items=items,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -4605,7 +4875,10 @@ class InputArraySchema(CWLArraySchema, InputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.items is not None:
             u = save_relative_uri(self.items, self.name, False, 2, relative_uris)
@@ -4631,23 +4904,13 @@ class InputArraySchema(CWLArraySchema, InputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["items", "type", "label", "doc", "name"]
-    )
-
-
-class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        format: Any | None = None,
+        items: CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -4656,16 +4919,23 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.items = items
         self.type_ = type_
         self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.format = format
+        self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["items", "type", "label", "doc", "name"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputRecordField):
@@ -4754,15 +5024,62 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -5071,8 +5388,8 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             label=label,
             secondaryFiles=secondaryFiles,
@@ -5081,7 +5398,7 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -5096,7 +5413,10 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -5136,21 +5456,15 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["doc", "name", "type", "label", "secondaryFiles", "streamable", "format"]
-    )
-
-
-class OutputRecordSchema(CWLRecordSchema, OutputSchema):
-    name: str
-
     def __init__(
         self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
+        name: str,
+        type_: CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | Sequence[CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        format: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -5159,14 +5473,25 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.fields = fields
+        self.doc = doc
+        self.name = name
         self.type_ = type_
         self.label = label
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.format = format
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["doc", "name", "type", "label", "secondaryFiles", "streamable", "format"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputRecordSchema(CWLRecordSchema, OutputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputRecordSchema):
@@ -5243,15 +5568,61 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -5466,15 +5837,15 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -5489,7 +5860,10 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -5516,21 +5890,13 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["fields", "type", "label", "doc", "name"]
-    )
-
-
-class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[OutputRecordField] = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -5539,14 +5905,23 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
         self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["fields", "type", "label", "doc", "name"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputEnumSchema):
@@ -5623,15 +5998,61 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -5855,7 +6276,7 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -5870,7 +6291,10 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -5896,21 +6320,13 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "doc"]
-    )
-
-
-class OutputArraySchema(CWLArraySchema, OutputSchema):
-    name: str
-
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -5919,14 +6335,23 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "doc"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputArraySchema(CWLArraySchema, OutputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputArraySchema):
@@ -6003,15 +6428,61 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("items") is None:
                 raise ValidationException("missing required field `items`", None, [])
@@ -6227,15 +6698,15 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             items=items,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -6250,7 +6721,10 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.items is not None:
             u = save_relative_uri(self.items, self.name, False, 2, relative_uris)
@@ -6276,19 +6750,49 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        items: CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | Sequence[CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.items = items
+        self.type_ = type_
+        self.label = label
+        self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
     attrs: ClassVar[Collection[str]] = frozenset(
         ["items", "type", "label", "doc", "name"]
     )
 
 
+@mypyc_attr(native_class=True)
+@trait
 class InputParameter(Parameter, InputFormat, LoadContents):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class OutputParameter(Parameter, OutputFormat):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class ProcessRequirement(Saveable):
     """
     A process requirement declares a prerequisite that may or must be fulfilled before executing a process.  See ```Process.hints`` <#process>`__ and ```Process.requirements`` <#process>`__.
@@ -6300,6 +6804,8 @@ class ProcessRequirement(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Process(Identified, Labeled, schema_salad.metaschema.Documented):
     """
     The base executable type in CWL is the ``Process`` object defined by the document.  Note that the ``Process`` object is abstract and cannot be directly executed.
@@ -6309,28 +6815,12 @@ class Process(Identified, Labeled, schema_salad.metaschema.Documented):
     pass
 
 
+@mypyc_attr(native_class=True)
 class InlineJavascriptRequirement(ProcessRequirement):
     """
     Indicates that the workflow platform must support inline Javascript expressions. If this requirement is not present, the workflow platform must not perform expression interpolatation.
 
     """
-
-    def __init__(
-        self,
-        expressionLib: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "InlineJavascriptRequirement"
-        self.expressionLib = expressionLib
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InlineJavascriptRequirement):
@@ -6489,22 +6979,9 @@ class InlineJavascriptRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "expressionLib"])
-
-
-class CommandInputSchema(Saveable):
-    pass
-
-
-class SchemaDefRequirement(ProcessRequirement):
-    """
-    This field consists of an array of type definitions which must be used when interpreting the ``inputs`` and ``outputs`` fields.  When a ``type`` field contain a IRI, the implementation must check if the type is defined in ``schemaDefs`` and use that definition.  If the type is not found in ``schemaDefs``, it is an error.  The entries in ``schemaDefs`` must be processed in the order listed such that later schema definitions may refer to earlier schema definitions.
-
-    """
-
     def __init__(
         self,
-        types: Any,
+        expressionLib: None | Sequence[str] = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -6513,11 +6990,27 @@ class SchemaDefRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "SchemaDefRequirement"
-        self.types = types
+        self.class_: Final[str] = "InlineJavascriptRequirement"
+        self.expressionLib = expressionLib
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "expressionLib"])
+
+
+@mypyc_attr(native_class=True)
+@trait
+class CommandInputSchema(Saveable):
+    pass
+
+
+@mypyc_attr(native_class=True)
+class SchemaDefRequirement(ProcessRequirement):
+    """
+    This field consists of an array of type definitions which must be used when interpreting the ``inputs`` and ``outputs`` fields.  When a ``type`` field contain a IRI, the implementation must check if the type is defined in ``schemaDefs`` and use that definition.  If the type is not found in ``schemaDefs``, it is an error.  The entries in ``schemaDefs`` must be processed in the order listed such that later schema definitions may refer to earlier schema definitions.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SchemaDefRequirement):
@@ -6564,7 +7057,7 @@ class SchemaDefRequirement(ProcessRequirement):
 
             types = _load_field(
                 _doc.get("types"),
-                array_of_CommandInputSchema,
+                array_of_CommandInputSchemaProxyLoader,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("types")
@@ -6671,14 +7164,9 @@ class SchemaDefRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "types"])
-
-
-class SecondaryFileSchema(Saveable):
     def __init__(
         self,
-        pattern: Any,
-        required: Any | None = None,
+        types: Sequence[CommandInputSchema],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -6687,12 +7175,17 @@ class SecondaryFileSchema(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.pattern = pattern
-        self.required = required
+        self.class_: Final[str] = "SchemaDefRequirement"
+        self.types = types
 
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "types"])
+
+
+@mypyc_attr(native_class=True)
+class SecondaryFileSchema(Saveable):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SecondaryFileSchema):
             return bool(
@@ -6872,18 +7365,10 @@ class SecondaryFileSchema(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["pattern", "required"])
-
-
-class LoadListingRequirement(ProcessRequirement):
-    """
-    Specify the desired behavior for loading the ``listing`` field of a Directory object for use by expressions.
-
-    """
-
     def __init__(
         self,
-        loadListing: Any | None = None,
+        pattern: str,
+        required: None | bool | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -6892,11 +7377,21 @@ class LoadListingRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "LoadListingRequirement"
-        self.loadListing = loadListing
+        self.pattern = pattern
+        self.required = required
+
+    attrs: ClassVar[Collection[str]] = frozenset(["pattern", "required"])
+
+
+@mypyc_attr(native_class=True)
+class LoadListingRequirement(ProcessRequirement):
+    """
+    Specify the desired behavior for loading the ``listing`` field of a Directory object for use by expressions.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, LoadListingRequirement):
@@ -7054,19 +7549,9 @@ class LoadListingRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "loadListing"])
-
-
-class EnvironmentDef(Saveable):
-    """
-    Define an environment variable that will be set in the runtime environment by the workflow platform when executing the command line tool.  May be the result of executing an expression, such as getting a parameter from input.
-
-    """
-
     def __init__(
         self,
-        envName: Any,
-        envValue: Any,
+        loadListing: LoadListingEnum | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -7075,11 +7560,21 @@ class EnvironmentDef(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.envName = envName
-        self.envValue = envValue
+        self.class_: Final[str] = "LoadListingRequirement"
+        self.loadListing = loadListing
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "loadListing"])
+
+
+@mypyc_attr(native_class=True)
+class EnvironmentDef(Saveable):
+    """
+    Define an environment variable that will be set in the runtime environment by the workflow platform when executing the command line tool.  May be the result of executing an expression, such as getting a parameter from input.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, EnvironmentDef):
@@ -7261,9 +7756,28 @@ class EnvironmentDef(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        envName: str,
+        envValue: str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.envName = envName
+        self.envValue = envValue
+
     attrs: ClassVar[Collection[str]] = frozenset(["envName", "envValue"])
 
 
+@mypyc_attr(native_class=True)
 class CommandLineBinding(InputBinding):
     """
     When listed under ``inputBinding`` in the input schema, the term "value" refers to the the corresponding value in the input object.  For binding objects listed in ``CommandLineTool.arguments``, the term "value" refers to the effective value after evaluating ``valueFrom``.
@@ -7287,34 +7801,6 @@ class CommandLineBinding(InputBinding):
     - **null**: Add nothing.
 
     """
-
-    def __init__(
-        self,
-        loadContents: Any | None = None,
-        position: Any | None = None,
-        prefix: Any | None = None,
-        separate: Any | None = None,
-        itemSeparator: Any | None = None,
-        valueFrom: Any | None = None,
-        shellQuote: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.loadContents = loadContents
-        self.position = position
-        self.prefix = prefix
-        self.separate = separate
-        self.itemSeparator = itemSeparator
-        self.valueFrom = valueFrom
-        self.shellQuote = shellQuote
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandLineBinding):
@@ -7782,6 +8268,34 @@ class CommandLineBinding(InputBinding):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        loadContents: None | bool = None,
+        position: None | i32 | str = None,
+        prefix: None | str = None,
+        separate: None | bool = None,
+        itemSeparator: None | str = None,
+        valueFrom: None | str = None,
+        shellQuote: None | bool = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.loadContents = loadContents
+        self.position = position
+        self.prefix = prefix
+        self.separate = separate
+        self.itemSeparator = itemSeparator
+        self.valueFrom = valueFrom
+        self.shellQuote = shellQuote
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "loadContents",
@@ -7795,6 +8309,7 @@ class CommandLineBinding(InputBinding):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandOutputBinding(LoadContents):
     """
     Describes how to generate an output parameter based on the files produced by a CommandLineTool.
@@ -7807,28 +8322,6 @@ class CommandOutputBinding(LoadContents):
     - secondaryFiles
 
     """
-
-    def __init__(
-        self,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        glob: Any | None = None,
-        outputEval: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.loadContents = loadContents
-        self.loadListing = loadListing
-        self.glob = glob
-        self.outputEval = outputEval
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputBinding):
@@ -8124,30 +8617,12 @@ class CommandOutputBinding(LoadContents):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["loadContents", "loadListing", "glob", "outputEval"]
-    )
-
-
-class CommandLineBindable(Saveable):
-    pass
-
-
-class CommandInputRecordField(InputRecordField, CommandLineBindable):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        format: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        inputBinding: Any | None = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        glob: None | Sequence[str] | str = None,
+        outputEval: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -8156,19 +8631,28 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.type_ = type_
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.format = format
         self.loadContents = loadContents
         self.loadListing = loadListing
-        self.inputBinding = inputBinding
+        self.glob = glob
+        self.outputEval = outputEval
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["loadContents", "loadListing", "glob", "outputEval"]
+    )
+
+
+@mypyc_attr(native_class=True)
+@trait
+class CommandLineBindable(Saveable):
+    pass
+
+
+@mypyc_attr(native_class=True)
+class CommandInputRecordField(InputRecordField, CommandLineBindable):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputRecordField):
@@ -8263,15 +8747,62 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -8721,8 +9252,8 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             label=label,
             secondaryFiles=secondaryFiles,
@@ -8734,7 +9265,7 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -8749,7 +9280,10 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -8810,6 +9344,40 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        name: str,
+        type_: CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | Sequence[CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        format: None | Sequence[str] | str = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        inputBinding: CommandLineBinding | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.doc = doc
+        self.name = name
+        self.type_ = type_
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.format = format
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+        self.inputBinding = inputBinding
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "doc",
@@ -8826,36 +9394,11 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandInputRecordSchema(
     InputRecordSchema, CommandInputSchema, CommandLineBindable
 ):
     name: str
-
-    def __init__(
-        self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
-        inputBinding: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.fields = fields
-        self.type_ = type_
-        self.label = label
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.inputBinding = inputBinding
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputRecordSchema):
@@ -8942,15 +9485,61 @@ class CommandInputRecordSchema(
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -9212,16 +9801,16 @@ class CommandInputRecordSchema(
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             inputBinding=inputBinding,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -9236,7 +9825,10 @@ class CommandInputRecordSchema(
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -9270,22 +9862,14 @@ class CommandInputRecordSchema(
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["fields", "type", "label", "doc", "name", "inputBinding"]
-    )
-
-
-class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBindable):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        inputBinding: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[CommandInputRecordField] = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
+        inputBinding: CommandLineBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -9294,15 +9878,24 @@ class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBin
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
         self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
         self.inputBinding = inputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["fields", "type", "label", "doc", "name", "inputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBindable):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputEnumSchema):
@@ -9389,15 +9982,61 @@ class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBin
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -9669,7 +10308,7 @@ class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBin
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -9684,7 +10323,10 @@ class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBin
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -9717,24 +10359,14 @@ class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBin
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "doc", "inputBinding"]
-    )
-
-
-class CommandInputArraySchema(
-    InputArraySchema, CommandInputSchema, CommandLineBindable
-):
-    name: str
-
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
-        inputBinding: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        inputBinding: CommandLineBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -9743,15 +10375,26 @@ class CommandInputArraySchema(
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
         self.inputBinding = inputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "doc", "inputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandInputArraySchema(
+    InputArraySchema, CommandInputSchema, CommandLineBindable
+):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputArraySchema):
@@ -9831,15 +10474,61 @@ class CommandInputArraySchema(
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("items") is None:
                 raise ValidationException("missing required field `items`", None, [])
@@ -10102,16 +10791,16 @@ class CommandInputArraySchema(
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             items=items,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             inputBinding=inputBinding,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -10126,7 +10815,10 @@ class CommandInputArraySchema(
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.items is not None:
             u = save_relative_uri(self.items, self.name, False, 2, relative_uris)
@@ -10159,24 +10851,14 @@ class CommandInputArraySchema(
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["items", "type", "label", "doc", "name", "inputBinding"]
-    )
-
-
-class CommandOutputRecordField(OutputRecordField):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        format: Any | None = None,
-        outputBinding: Any | None = None,
+        items: CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | Sequence[CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
+        inputBinding: CommandLineBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -10185,17 +10867,24 @@ class CommandOutputRecordField(OutputRecordField):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.items = items
         self.type_ = type_
         self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.format = format
-        self.outputBinding = outputBinding
+        self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.inputBinding = inputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["items", "type", "label", "doc", "name", "inputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandOutputRecordField(OutputRecordField):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputRecordField):
@@ -10286,15 +10975,62 @@ class CommandOutputRecordField(OutputRecordField):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -10650,8 +11386,8 @@ class CommandOutputRecordField(OutputRecordField):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             label=label,
             secondaryFiles=secondaryFiles,
@@ -10661,7 +11397,7 @@ class CommandOutputRecordField(OutputRecordField):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -10676,7 +11412,10 @@ class CommandOutputRecordField(OutputRecordField):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -10723,6 +11462,36 @@ class CommandOutputRecordField(OutputRecordField):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        name: str,
+        type_: CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | Sequence[CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        format: None | str = None,
+        outputBinding: CommandOutputBinding | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.doc = doc
+        self.name = name
+        self.type_ = type_
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.format = format
+        self.outputBinding = outputBinding
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "doc",
@@ -10737,32 +11506,9 @@ class CommandOutputRecordField(OutputRecordField):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandOutputRecordSchema(OutputRecordSchema):
     name: str
-
-    def __init__(
-        self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.fields = fields
-        self.type_ = type_
-        self.label = label
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputRecordSchema):
@@ -10839,15 +11585,61 @@ class CommandOutputRecordSchema(OutputRecordSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -11062,15 +11854,15 @@ class CommandOutputRecordSchema(OutputRecordSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -11085,7 +11877,10 @@ class CommandOutputRecordSchema(OutputRecordSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -11112,21 +11907,13 @@ class CommandOutputRecordSchema(OutputRecordSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["fields", "type", "label", "doc", "name"]
-    )
-
-
-class CommandOutputEnumSchema(OutputEnumSchema):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[CommandOutputRecordField] = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -11135,14 +11922,23 @@ class CommandOutputEnumSchema(OutputEnumSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
         self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["fields", "type", "label", "doc", "name"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandOutputEnumSchema(OutputEnumSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputEnumSchema):
@@ -11219,15 +12015,61 @@ class CommandOutputEnumSchema(OutputEnumSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -11451,7 +12293,7 @@ class CommandOutputEnumSchema(OutputEnumSchema):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -11466,7 +12308,10 @@ class CommandOutputEnumSchema(OutputEnumSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -11492,21 +12337,13 @@ class CommandOutputEnumSchema(OutputEnumSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "doc"]
-    )
-
-
-class CommandOutputArraySchema(OutputArraySchema):
-    name: str
-
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -11515,14 +12352,23 @@ class CommandOutputArraySchema(OutputArraySchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "doc"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandOutputArraySchema(OutputArraySchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputArraySchema):
@@ -11599,15 +12445,61 @@ class CommandOutputArraySchema(OutputArraySchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("items") is None:
                 raise ValidationException("missing required field `items`", None, [])
@@ -11823,15 +12715,15 @@ class CommandOutputArraySchema(OutputArraySchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             items=items,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -11846,7 +12738,10 @@ class CommandOutputArraySchema(OutputArraySchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.items is not None:
             u = save_relative_uri(self.items, self.name, False, 2, relative_uris)
@@ -11872,32 +12767,13 @@ class CommandOutputArraySchema(OutputArraySchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["items", "type", "label", "doc", "name"]
-    )
-
-
-class CommandInputParameter(InputParameter):
-    """
-    An input parameter for a CommandLineTool.
-
-    """
-
-    id: str
-
     def __init__(
         self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        default: Any | None = None,
-        inputBinding: Any | None = None,
+        items: CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | Sequence[CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -11906,20 +12782,28 @@ class CommandInputParameter(InputParameter):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.loadContents = loadContents
-        self.loadListing = loadListing
-        self.default = default
+        self.items = items
         self.type_ = type_
-        self.inputBinding = inputBinding
+        self.label = label
+        self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["items", "type", "label", "doc", "name"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandInputParameter(InputParameter):
+    """
+    An input parameter for a CommandLineTool.
+
+    """
+
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputParameter):
@@ -12016,15 +12900,62 @@ class CommandInputParameter(InputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -12407,7 +13338,7 @@ class CommandInputParameter(InputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_stdinLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2,
+                typedsl_CommandInputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -12521,11 +13452,11 @@ class CommandInputParameter(InputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             loadContents=loadContents,
             loadListing=loadListing,
@@ -12535,7 +13466,7 @@ class CommandInputParameter(InputParameter):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -12550,7 +13481,10 @@ class CommandInputParameter(InputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -12615,6 +13549,42 @@ class CommandInputParameter(InputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        type_: CommandInputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | Sequence[str] | str = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        default: CWLObjectType | None = None,
+        inputBinding: CommandLineBinding | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+        self.default = default
+        self.type_ = type_
+        self.inputBinding = inputBinding
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -12632,6 +13602,7 @@ class CommandInputParameter(InputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandOutputParameter(OutputParameter):
     """
     An output parameter for a CommandLineTool.
@@ -12639,36 +13610,6 @@ class CommandOutputParameter(OutputParameter):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        outputBinding: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.type_ = type_
-        self.outputBinding = outputBinding
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputParameter):
@@ -12759,15 +13700,62 @@ class CommandOutputParameter(OutputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -13009,7 +13997,7 @@ class CommandOutputParameter(OutputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2,
+                typedsl_CommandOutputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -13123,18 +14111,18 @@ class CommandOutputParameter(OutputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             type_=type_,
             outputBinding=outputBinding,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -13149,7 +14137,10 @@ class CommandOutputParameter(OutputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -13196,6 +14187,36 @@ class CommandOutputParameter(OutputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        type_: CommandOutputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | str = None,
+        outputBinding: CommandOutputBinding | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.type_ = type_
+        self.outputBinding = outputBinding
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -13210,6 +14231,7 @@ class CommandOutputParameter(OutputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandLineTool(Process):
     """
     This defines the schema of the CWL Command Line Tool Description document.
@@ -13217,53 +14239,6 @@ class CommandLineTool(Process):
     """
 
     id: str
-
-    def __init__(
-        self,
-        inputs: Any,
-        outputs: Any,
-        id: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        cwlVersion: Any | None = None,
-        baseCommand: Any | None = None,
-        arguments: Any | None = None,
-        stdin: Any | None = None,
-        stderr: Any | None = None,
-        stdout: Any | None = None,
-        successCodes: Any | None = None,
-        temporaryFailCodes: Any | None = None,
-        permanentFailCodes: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.label = label
-        self.doc = doc
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.cwlVersion = cwlVersion
-        self.class_: Final[str] = "CommandLineTool"
-        self.baseCommand = baseCommand
-        self.arguments = arguments
-        self.stdin = stdin
-        self.stderr = stderr
-        self.stdout = stdout
-        self.successCodes = successCodes
-        self.temporaryFailCodes = temporaryFailCodes
-        self.permanentFailCodes = permanentFailCodes
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandLineTool):
@@ -13372,15 +14347,61 @@ class CommandLineTool(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -13593,7 +14614,7 @@ class CommandLineTool(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -13640,7 +14661,7 @@ class CommandLineTool(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -14149,7 +15170,7 @@ class CommandLineTool(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -14164,7 +15185,10 @@ class CommandLineTool(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -14259,6 +15283,53 @@ class CommandLineTool(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[CommandInputParameter],
+        outputs: Sequence[CommandOutputParameter],
+        id: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        cwlVersion: CWLVersion | None = None,
+        baseCommand: None | Sequence[str] | str = None,
+        arguments: None | Sequence[CommandLineBinding | str] = None,
+        stdin: None | str = None,
+        stderr: None | str = None,
+        stdout: None | str = None,
+        successCodes: None | Sequence[i32] = None,
+        temporaryFailCodes: None | Sequence[i32] = None,
+        permanentFailCodes: None | Sequence[i32] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.label = label
+        self.doc = doc
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.cwlVersion = cwlVersion
+        self.class_: Final[str] = "CommandLineTool"
+        self.baseCommand = baseCommand
+        self.arguments = arguments
+        self.stdin = stdin
+        self.stderr = stderr
+        self.stdout = stdout
+        self.successCodes = successCodes
+        self.temporaryFailCodes = temporaryFailCodes
+        self.permanentFailCodes = permanentFailCodes
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -14282,6 +15353,7 @@ class CommandLineTool(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class DockerRequirement(ProcessRequirement):
     """
     Indicates that a workflow component should be run in a `Docker <http://docker.com>`__ or Docker-compatible (such as `Singularity <https://www.sylabs.io/>`__ and `udocker <https://github.com/indigo-dc/udocker>`__) container environment and specifies how to fetch or build the image.
@@ -14306,33 +15378,6 @@ class DockerRequirement(ProcessRequirement):
     If `EnvVarRequirement <#EnvVarRequirement>`__ is specified alongside a DockerRequirement, the environment variables must be provided to Docker using ``--env`` or ``--env-file`` and interact with the container's preexisting environment as defined by Docker.
 
     """
-
-    def __init__(
-        self,
-        dockerPull: Any | None = None,
-        dockerLoad: Any | None = None,
-        dockerFile: Any | None = None,
-        dockerImport: Any | None = None,
-        dockerImageId: Any | None = None,
-        dockerOutputDirectory: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "DockerRequirement"
-        self.dockerPull = dockerPull
-        self.dockerLoad = dockerLoad
-        self.dockerFile = dockerFile
-        self.dockerImport = dockerImport
-        self.dockerImageId = dockerImageId
-        self.dockerOutputDirectory = dockerOutputDirectory
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, DockerRequirement):
@@ -14781,6 +15826,33 @@ class DockerRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        dockerPull: None | str = None,
+        dockerLoad: None | str = None,
+        dockerFile: None | str = None,
+        dockerImport: None | str = None,
+        dockerImageId: None | str = None,
+        dockerOutputDirectory: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "DockerRequirement"
+        self.dockerPull = dockerPull
+        self.dockerLoad = dockerLoad
+        self.dockerFile = dockerFile
+        self.dockerImport = dockerImport
+        self.dockerImageId = dockerImageId
+        self.dockerOutputDirectory = dockerOutputDirectory
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -14794,28 +15866,12 @@ class DockerRequirement(ProcessRequirement):
     )
 
 
+@mypyc_attr(native_class=True)
 class SoftwareRequirement(ProcessRequirement):
     """
     A list of software packages that should be configured in the environment of the defined process.
 
     """
-
-    def __init__(
-        self,
-        packages: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "SoftwareRequirement"
-        self.packages = packages
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SoftwareRequirement):
@@ -14969,15 +16025,9 @@ class SoftwareRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "packages"])
-
-
-class SoftwarePackage(Saveable):
     def __init__(
         self,
-        package: Any,
-        version: Any | None = None,
-        specs: Any | None = None,
+        packages: Sequence[SoftwarePackage],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -14986,13 +16036,17 @@ class SoftwarePackage(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.package = package
-        self.version = version
-        self.specs = specs
+        self.class_: Final[str] = "SoftwareRequirement"
+        self.packages = packages
 
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "packages"])
+
+
+@mypyc_attr(native_class=True)
+class SoftwarePackage(Saveable):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SoftwarePackage):
             return bool(
@@ -15225,20 +16279,11 @@ class SoftwarePackage(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["package", "version", "specs"])
-
-
-class Dirent(Saveable):
-    """
-    Define a file or subdirectory that must be placed in the designated output directory prior to executing the command line tool.  May be the result of executing an expression, such as building a configuration file from a template.
-
-    """
-
     def __init__(
         self,
-        entry: Any,
-        entryname: Any | None = None,
-        writable: Any | None = None,
+        package: str,
+        version: None | Sequence[str] = None,
+        specs: None | Sequence[str] = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -15247,12 +16292,22 @@ class Dirent(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.entryname = entryname
-        self.entry = entry
-        self.writable = writable
+        self.package = package
+        self.version = version
+        self.specs = specs
+
+    attrs: ClassVar[Collection[str]] = frozenset(["package", "version", "specs"])
+
+
+@mypyc_attr(native_class=True)
+class Dirent(Saveable):
+    """
+    Define a file or subdirectory that must be placed in the designated output directory prior to executing the command line tool.  May be the result of executing an expression, such as building a configuration file from a template.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Dirent):
@@ -15490,18 +16545,11 @@ class Dirent(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["entryname", "entry", "writable"])
-
-
-class InitialWorkDirRequirement(ProcessRequirement):
-    """
-    Define a list of files and subdirectories that must be created by the workflow platform in the designated output directory prior to executing the command line tool.
-
-    """
-
     def __init__(
         self,
-        listing: Any,
+        entry: str,
+        entryname: None | str = None,
+        writable: None | bool = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -15510,11 +16558,22 @@ class InitialWorkDirRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "InitialWorkDirRequirement"
-        self.listing = listing
+        self.entryname = entryname
+        self.entry = entry
+        self.writable = writable
+
+    attrs: ClassVar[Collection[str]] = frozenset(["entryname", "entry", "writable"])
+
+
+@mypyc_attr(native_class=True)
+class InitialWorkDirRequirement(ProcessRequirement):
+    """
+    Define a list of files and subdirectories that must be created by the workflow platform in the designated output directory prior to executing the command line tool.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InitialWorkDirRequirement):
@@ -15668,18 +16727,9 @@ class InitialWorkDirRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "listing"])
-
-
-class EnvVarRequirement(ProcessRequirement):
-    """
-    Define a list of environment variables which will be set in the execution environment of the tool.  See ``EnvironmentDef`` for details.
-
-    """
-
     def __init__(
         self,
-        envDef: Any,
+        listing: Sequence[Directory | Dirent | File | None | Sequence[Directory | File] | str] | str,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -15688,11 +16738,21 @@ class EnvVarRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "EnvVarRequirement"
-        self.envDef = envDef
+        self.class_: Final[str] = "InitialWorkDirRequirement"
+        self.listing = listing
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "listing"])
+
+
+@mypyc_attr(native_class=True)
+class EnvVarRequirement(ProcessRequirement):
+    """
+    Define a list of environment variables which will be set in the execution environment of the tool.  See ``EnvironmentDef`` for details.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, EnvVarRequirement):
@@ -15846,17 +16906,9 @@ class EnvVarRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "envDef"])
-
-
-class ShellCommandRequirement(ProcessRequirement):
-    """
-    Modify the behavior of CommandLineTool to generate a single string containing a shell command line.  Each item in the argument list must be joined into a string separated by single spaces and quoted to prevent interpretation by the shell, unless ``CommandLineBinding`` for that argument contains ``shellQuote: false``.  If ``shellQuote: false`` is specified, the argument is joined into the command string without quoting, which allows the use of shell metacharacters such as ``|`` for pipes.
-
-    """
-
     def __init__(
         self,
+        envDef: Sequence[EnvironmentDef],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -15865,10 +16917,21 @@ class ShellCommandRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ShellCommandRequirement"
+        self.class_: Final[str] = "EnvVarRequirement"
+        self.envDef = envDef
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "envDef"])
+
+
+@mypyc_attr(native_class=True)
+class ShellCommandRequirement(ProcessRequirement):
+    """
+    Modify the behavior of CommandLineTool to generate a single string containing a shell command line.  Each item in the argument list must be joined into a string separated by single spaces and quoted to prevent interpretation by the shell, unless ``CommandLineBinding`` for that argument contains ``shellQuote: false``.  If ``shellQuote: false`` is specified, the argument is joined into the command string without quoting, which allows the use of shell metacharacters such as ``|`` for pipes.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ShellCommandRequirement):
@@ -15967,9 +17030,25 @@ class ShellCommandRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "ShellCommandRequirement"
+
     attrs: ClassVar[Collection[str]] = frozenset(["class"])
 
 
+@mypyc_attr(native_class=True)
 class ResourceRequirement(ProcessRequirement):
     """
     Specify basic hardware resource requirements.
@@ -15987,37 +17066,6 @@ class ResourceRequirement(ProcessRequirement):
     If neither "min" nor "max" is specified for a resource, use the default values below.
 
     """
-
-    def __init__(
-        self,
-        coresMin: Any | None = None,
-        coresMax: Any | None = None,
-        ramMin: Any | None = None,
-        ramMax: Any | None = None,
-        tmpdirMin: Any | None = None,
-        tmpdirMax: Any | None = None,
-        outdirMin: Any | None = None,
-        outdirMax: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ResourceRequirement"
-        self.coresMin = coresMin
-        self.coresMax = coresMax
-        self.ramMin = ramMin
-        self.ramMax = ramMax
-        self.tmpdirMin = tmpdirMin
-        self.tmpdirMax = tmpdirMax
-        self.outdirMin = outdirMin
-        self.outdirMax = outdirMax
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ResourceRequirement):
@@ -16085,7 +17133,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 coresMin = _load_field(
                     _doc.get("coresMin"),
-                    union_of_None_type_or_inttype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("coresMin")
@@ -16132,7 +17180,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 coresMax = _load_field(
                     _doc.get("coresMax"),
-                    union_of_None_type_or_inttype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("coresMax")
@@ -16179,7 +17227,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 ramMin = _load_field(
                     _doc.get("ramMin"),
-                    union_of_None_type_or_inttype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("ramMin")
@@ -16226,7 +17274,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 ramMax = _load_field(
                     _doc.get("ramMax"),
-                    union_of_None_type_or_inttype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("ramMax")
@@ -16273,7 +17321,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 tmpdirMin = _load_field(
                     _doc.get("tmpdirMin"),
-                    union_of_None_type_or_inttype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("tmpdirMin")
@@ -16320,7 +17368,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 tmpdirMax = _load_field(
                     _doc.get("tmpdirMax"),
-                    union_of_None_type_or_inttype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("tmpdirMax")
@@ -16367,7 +17415,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 outdirMin = _load_field(
                     _doc.get("outdirMin"),
-                    union_of_None_type_or_inttype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outdirMin")
@@ -16414,7 +17462,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 outdirMax = _load_field(
                     _doc.get("outdirMax"),
-                    union_of_None_type_or_inttype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outdirMax")
@@ -16568,6 +17616,37 @@ class ResourceRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        coresMin: None | i32 | i64 | str = None,
+        coresMax: None | i32 | i64 | str = None,
+        ramMin: None | i32 | i64 | str = None,
+        ramMax: None | i32 | i64 | str = None,
+        tmpdirMin: None | i32 | i64 | str = None,
+        tmpdirMax: None | i32 | i64 | str = None,
+        outdirMin: None | i32 | i64 | str = None,
+        outdirMax: None | i32 | i64 | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "ResourceRequirement"
+        self.coresMin = coresMin
+        self.coresMax = coresMax
+        self.ramMin = ramMin
+        self.ramMax = ramMax
+        self.tmpdirMin = tmpdirMin
+        self.tmpdirMax = tmpdirMax
+        self.outdirMin = outdirMin
+        self.outdirMax = outdirMax
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -16583,6 +17662,7 @@ class ResourceRequirement(ProcessRequirement):
     )
 
 
+@mypyc_attr(native_class=True)
 class WorkReuse(ProcessRequirement):
     """
     For implementations that support reusing output from past work (on the assumption that same code and same input produce same results), control whether to enable or disable the reuse behavior for a particular tool or step (to accommodate situations where that assumption is incorrect).  A reused step is not executed but instead returns the same output as the original execution.
@@ -16590,23 +17670,6 @@ class WorkReuse(ProcessRequirement):
     If ``enableReuse`` is not specified, correct tools should assume it is enabled by default.
 
     """
-
-    def __init__(
-        self,
-        enableReuse: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "WorkReuse"
-        self.enableReuse = enableReuse
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkReuse):
@@ -16765,9 +17828,27 @@ class WorkReuse(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        enableReuse: bool | str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "WorkReuse"
+        self.enableReuse = enableReuse
+
     attrs: ClassVar[Collection[str]] = frozenset(["class", "enableReuse"])
 
 
+@mypyc_attr(native_class=True)
 class NetworkAccess(ProcessRequirement):
     """
     Indicate whether a process requires outgoing IPv4/IPv6 network access.  Choice of IPv4 or IPv6 is implementation and site specific, correct tools must support both.
@@ -16779,23 +17860,6 @@ class NetworkAccess(ProcessRequirement):
     Enabling network access does not imply a publicly routable IP address or the ability to accept inbound connections.
 
     """
-
-    def __init__(
-        self,
-        networkAccess: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "NetworkAccess"
-        self.networkAccess = networkAccess
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, NetworkAccess):
@@ -16955,9 +18019,27 @@ class NetworkAccess(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        networkAccess: bool | str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "NetworkAccess"
+        self.networkAccess = networkAccess
+
     attrs: ClassVar[Collection[str]] = frozenset(["class", "networkAccess"])
 
 
+@mypyc_attr(native_class=True)
 class InplaceUpdateRequirement(ProcessRequirement):
     """
     If ``inplaceUpdate`` is true, then an implementation supporting this feature may permit tools to directly update files with ``writable: true`` in InitialWorkDirRequirement.  That is, as an optimization, files may be destructively modified in place as opposed to copied and updated.
@@ -16971,23 +18053,6 @@ class InplaceUpdateRequirement(ProcessRequirement):
     Users and implementers should be aware that workflows that destructively modify inputs may not be repeatable or reproducible. In particular, enabling this feature implies that WorkReuse should not be enabled.
 
     """
-
-    def __init__(
-        self,
-        inplaceUpdate: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "InplaceUpdateRequirement"
-        self.inplaceUpdate = inplaceUpdate
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InplaceUpdateRequirement):
@@ -17147,18 +18212,9 @@ class InplaceUpdateRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "inplaceUpdate"])
-
-
-class ToolTimeLimit(ProcessRequirement):
-    """
-    Set an upper limit on the execution time of a CommandLineTool. A CommandLineTool whose execution duration exceeds the time limit may be preemptively terminated and considered failed. May also be used by batch systems to make scheduling decisions. The execution duration excludes external operations, such as staging of files, pulling a docker image etc, and only counts wall-time for the execution of the command line itself.
-
-    """
-
     def __init__(
         self,
-        timelimit: Any,
+        inplaceUpdate: bool,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -17167,11 +18223,21 @@ class ToolTimeLimit(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ToolTimeLimit"
-        self.timelimit = timelimit
+        self.class_: Final[str] = "InplaceUpdateRequirement"
+        self.inplaceUpdate = inplaceUpdate
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "inplaceUpdate"])
+
+
+@mypyc_attr(native_class=True)
+class ToolTimeLimit(ProcessRequirement):
+    """
+    Set an upper limit on the execution time of a CommandLineTool. A CommandLineTool whose execution duration exceeds the time limit may be preemptively terminated and considered failed. May also be used by batch systems to make scheduling decisions. The execution duration excludes external operations, such as staging of files, pulling a docker image etc, and only counts wall-time for the execution of the command line itself.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ToolTimeLimit):
@@ -17220,7 +18286,7 @@ class ToolTimeLimit(ProcessRequirement):
 
             timelimit = _load_field(
                 _doc.get("timelimit"),
-                union_of_inttype_or_ExpressionLoader,
+                union_of_inttype_or_longtype_or_ExpressionLoader,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("timelimit")
@@ -17330,21 +18396,9 @@ class ToolTimeLimit(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "timelimit"])
-
-
-class ExpressionToolOutputParameter(OutputParameter):
-    id: str
-
     def __init__(
         self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
+        timelimit: i32 | i64 | str,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -17353,16 +18407,18 @@ class ExpressionToolOutputParameter(OutputParameter):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.type_ = type_
+        self.class_: Final[str] = "ToolTimeLimit"
+        self.timelimit = timelimit
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "timelimit"])
+
+
+@mypyc_attr(native_class=True)
+class ExpressionToolOutputParameter(OutputParameter):
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ExpressionToolOutputParameter):
@@ -17451,15 +18507,62 @@ class ExpressionToolOutputParameter(OutputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -17701,7 +18804,7 @@ class ExpressionToolOutputParameter(OutputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2,
+                typedsl_OutputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -17768,17 +18871,17 @@ class ExpressionToolOutputParameter(OutputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             type_=type_,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -17793,7 +18896,10 @@ class ExpressionToolOutputParameter(OutputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -17833,27 +18939,15 @@ class ExpressionToolOutputParameter(OutputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["label", "secondaryFiles", "streamable", "doc", "id", "format", "type"]
-    )
-
-
-class WorkflowInputParameter(InputParameter):
-    id: str
-
     def __init__(
         self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        default: Any | None = None,
-        inputBinding: Any | None = None,
+        id: str,
+        type_: OutputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -17862,20 +18956,25 @@ class WorkflowInputParameter(InputParameter):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
         self.label = label
         self.secondaryFiles = secondaryFiles
         self.streamable = streamable
         self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.id = id
         self.format = format
-        self.loadContents = loadContents
-        self.loadListing = loadListing
-        self.default = default
         self.type_ = type_
-        self.inputBinding = inputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["label", "secondaryFiles", "streamable", "doc", "id", "format", "type"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class WorkflowInputParameter(InputParameter):
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowInputParameter):
@@ -17972,15 +19071,62 @@ class WorkflowInputParameter(InputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -18363,7 +19509,7 @@ class WorkflowInputParameter(InputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2,
+                typedsl_InputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -18477,11 +19623,11 @@ class WorkflowInputParameter(InputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             loadContents=loadContents,
             loadListing=loadListing,
@@ -18491,7 +19637,7 @@ class WorkflowInputParameter(InputParameter):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -18506,7 +19652,10 @@ class WorkflowInputParameter(InputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -18571,6 +19720,42 @@ class WorkflowInputParameter(InputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        type_: InputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | Sequence[str] | str = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        default: CWLObjectType | None = None,
+        inputBinding: InputBinding | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+        self.default = default
+        self.type_ = type_
+        self.inputBinding = inputBinding
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -18588,6 +19773,7 @@ class WorkflowInputParameter(InputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class ExpressionTool(Process):
     """
     An ExpressionTool is a type of Process object that can be run by itself or as a Workflow step. It executes a pure Javascript expression that has access to the same input parameters as a workflow. It is meant to be used sparingly as a way to isolate complex Javascript expressions that need to operate on input data and produce some result; perhaps just a rearrangement of the inputs. No Docker software container is required or allowed.
@@ -18595,39 +19781,6 @@ class ExpressionTool(Process):
     """
 
     id: str
-
-    def __init__(
-        self,
-        inputs: Any,
-        outputs: Any,
-        expression: Any,
-        id: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        cwlVersion: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.label = label
-        self.doc = doc
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.cwlVersion = cwlVersion
-        self.class_: Final[str] = "ExpressionTool"
-        self.expression = expression
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ExpressionTool):
@@ -18722,15 +19875,61 @@ class ExpressionTool(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -18943,7 +20142,7 @@ class ExpressionTool(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -18990,7 +20189,7 @@ class ExpressionTool(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -19164,7 +20363,7 @@ class ExpressionTool(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -19179,7 +20378,10 @@ class ExpressionTool(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -19237,6 +20439,39 @@ class ExpressionTool(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[WorkflowInputParameter],
+        outputs: Sequence[ExpressionToolOutputParameter],
+        expression: str,
+        id: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        cwlVersion: CWLVersion | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.label = label
+        self.doc = doc
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.cwlVersion = cwlVersion
+        self.class_: Final[str] = "ExpressionTool"
+        self.expression = expression
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -19253,6 +20488,7 @@ class ExpressionTool(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class WorkflowOutputParameter(OutputParameter):
     """
     Describe an output parameter of a workflow.  The parameter must be connected to one or more parameters defined in the workflow that will provide the value of the output parameter. It is legal to connect a WorkflowInputParameter to a WorkflowOutputParameter.
@@ -19260,38 +20496,6 @@ class WorkflowOutputParameter(OutputParameter):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        outputSource: Any | None = None,
-        linkMerge: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.outputSource = outputSource
-        self.linkMerge = linkMerge
-        self.type_ = type_
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowOutputParameter):
@@ -19384,15 +20588,62 @@ class WorkflowOutputParameter(OutputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -19795,11 +21046,11 @@ class WorkflowOutputParameter(OutputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             outputSource=outputSource,
             linkMerge=linkMerge,
@@ -19807,7 +21058,7 @@ class WorkflowOutputParameter(OutputParameter):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -19822,7 +21073,10 @@ class WorkflowOutputParameter(OutputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -19869,6 +21123,38 @@ class WorkflowOutputParameter(OutputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        type_: CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | Sequence[CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str] | str,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | str = None,
+        outputSource: None | Sequence[str] | str = None,
+        linkMerge: LinkMergeMethod | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.outputSource = outputSource
+        self.linkMerge = linkMerge
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -19884,10 +21170,13 @@ class WorkflowOutputParameter(OutputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Sink(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
 class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
     """
     The input of a workflow step connects an upstream parameter (from the workflow inputs, or the outputs of other workflows steps) with the input parameters of the process specified by the ``run`` field. Only input parameters declared by the target process will be passed through at runtime to the process though additional parameters may be specified (for use within ``valueFrom`` expressions for instance) - unconnected or unused parameters do not represent an error condition.
@@ -19916,36 +21205,6 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        source: Any | None = None,
-        linkMerge: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        label: Any | None = None,
-        default: Any | None = None,
-        valueFrom: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.source = source
-        self.linkMerge = linkMerge
-        self.loadContents = loadContents
-        self.loadListing = loadListing
-        self.label = label
-        self.default = default
-        self.valueFrom = valueFrom
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowStepInput):
@@ -20036,15 +21295,62 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         source = None
         if "source" in _doc:
             try:
@@ -20410,7 +21716,7 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -20425,7 +21731,10 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.source is not None:
             u = save_relative_uri(self.source, self.id, False, 2, relative_uris)
@@ -20469,6 +21778,36 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        source: None | Sequence[str] | str = None,
+        linkMerge: LinkMergeMethod | None = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        label: None | str = None,
+        default: CWLObjectType | None = None,
+        valueFrom: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id
+        self.source = source
+        self.linkMerge = linkMerge
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+        self.label = label
+        self.default = default
+        self.valueFrom = valueFrom
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -20483,6 +21822,7 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
     )
 
 
+@mypyc_attr(native_class=True)
 class WorkflowStepOutput(IdentifierRequired):
     """
     Associate an output parameter of the underlying process with a workflow parameter.  The workflow parameter (given in the ``id`` field) be may be used as a ``source`` to connect with input parameters of other workflow steps, or with an output parameter of the process.
@@ -20492,22 +21832,6 @@ class WorkflowStepOutput(IdentifierRequired):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowStepOutput):
@@ -20578,15 +21902,62 @@ class WorkflowStepOutput(IdentifierRequired):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         extension_fields: MutableMapping[str, Any] = {}
         for k in _doc.keys():
             if k not in cls.attrs:
@@ -20614,7 +21985,7 @@ class WorkflowStepOutput(IdentifierRequired):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -20629,7 +22000,10 @@ class WorkflowStepOutput(IdentifierRequired):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
 
         # top refers to the directory level
@@ -20640,9 +22014,26 @@ class WorkflowStepOutput(IdentifierRequired):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id
+
     attrs: ClassVar[Collection[str]] = frozenset(["id"])
 
 
+@mypyc_attr(native_class=True)
 class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Documented):
     """
     A workflow step is an executable element of a workflow.  It specifies the underlying process implementation (such as ``CommandLineTool`` or another ``Workflow``) in the ``run`` field and connects the input and output parameters of the underlying process to workflow parameters.
@@ -20678,40 +22069,6 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        in_: Any,
-        out: Any,
-        run: Any,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        scatter: Any | None = None,
-        scatterMethod: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.label = label
-        self.doc = doc
-        self.in_ = in_
-        self.out = out
-        self.requirements = requirements
-        self.hints = hints
-        self.run = run
-        self.scatter = scatter
-        self.scatterMethod = scatterMethod
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowStep):
@@ -20806,15 +22163,62 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -21010,7 +22414,7 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -21107,7 +22511,7 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
 
             run = _load_field(
                 _doc.get("run"),
-                uri_union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader_False_False_None_None,
+                uri_union_of_strtype_or_ProcessProxyLoader_False_False_None_None,
                 subscope_baseuri,
                 loadingOptions,
                 lc=_doc.get("run")
@@ -21281,7 +22685,7 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -21296,7 +22700,10 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -21344,6 +22751,40 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        in_: Sequence[WorkflowStepInput],
+        out: Sequence[WorkflowStepOutput | str],
+        run: Process | str,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any] = None,
+        scatter: None | Sequence[str] | str = None,
+        scatterMethod: None | ScatterMethod = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id
+        self.label = label
+        self.doc = doc
+        self.in_ = in_
+        self.out = out
+        self.requirements = requirements
+        self.hints = hints
+        self.run = run
+        self.scatter = scatter
+        self.scatterMethod = scatterMethod
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -21360,6 +22801,7 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
     )
 
 
+@mypyc_attr(native_class=True)
 class Workflow(Process):
     """
     A workflow describes a set of **steps** and the **dependencies** between those steps.  When a step produces output that will be consumed by a second step, the first step is a dependency of the second step.
@@ -21389,39 +22831,6 @@ class Workflow(Process):
     """
 
     id: str
-
-    def __init__(
-        self,
-        inputs: Any,
-        outputs: Any,
-        steps: Any,
-        id: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        cwlVersion: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.label = label
-        self.doc = doc
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.cwlVersion = cwlVersion
-        self.class_: Final[str] = "Workflow"
-        self.steps = steps
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Workflow):
@@ -21516,15 +22925,61 @@ class Workflow(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -21737,7 +23192,7 @@ class Workflow(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -21784,7 +23239,7 @@ class Workflow(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -21958,7 +23413,7 @@ class Workflow(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -21973,7 +23428,10 @@ class Workflow(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -22028,6 +23486,39 @@ class Workflow(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[WorkflowInputParameter],
+        outputs: Sequence[WorkflowOutputParameter],
+        steps: Sequence[WorkflowStep],
+        id: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        cwlVersion: CWLVersion | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.label = label
+        self.doc = doc
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.cwlVersion = cwlVersion
+        self.class_: Final[str] = "Workflow"
+        self.steps = steps
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -22044,26 +23535,12 @@ class Workflow(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class SubworkflowFeatureRequirement(ProcessRequirement):
     """
     Indicates that the workflow platform must support nested workflows in the ``run`` field of `WorkflowStep <#WorkflowStep>`__.
 
     """
-
-    def __init__(
-        self,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "SubworkflowFeatureRequirement"
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SubworkflowFeatureRequirement):
@@ -22162,15 +23639,6 @@ class SubworkflowFeatureRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class ScatterFeatureRequirement(ProcessRequirement):
-    """
-    Indicates that the workflow platform must support the ``scatter`` and ``scatterMethod`` fields of `WorkflowStep <#WorkflowStep>`__.
-
-    """
-
     def __init__(
         self,
         extension_fields: MutableMapping[str, Any] | None = None,
@@ -22181,10 +23649,20 @@ class ScatterFeatureRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ScatterFeatureRequirement"
+        self.class_: Final[str] = "SubworkflowFeatureRequirement"
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class ScatterFeatureRequirement(ProcessRequirement):
+    """
+    Indicates that the workflow platform must support the ``scatter`` and ``scatterMethod`` fields of `WorkflowStep <#WorkflowStep>`__.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ScatterFeatureRequirement):
@@ -22283,15 +23761,6 @@ class ScatterFeatureRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class MultipleInputFeatureRequirement(ProcessRequirement):
-    """
-    Indicates that the workflow platform must support multiple inbound data links listed in the ``source`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
-
-    """
-
     def __init__(
         self,
         extension_fields: MutableMapping[str, Any] | None = None,
@@ -22302,10 +23771,20 @@ class MultipleInputFeatureRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "MultipleInputFeatureRequirement"
+        self.class_: Final[str] = "ScatterFeatureRequirement"
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class MultipleInputFeatureRequirement(ProcessRequirement):
+    """
+    Indicates that the workflow platform must support multiple inbound data links listed in the ``source`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, MultipleInputFeatureRequirement):
@@ -22404,15 +23883,6 @@ class MultipleInputFeatureRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class StepInputExpressionRequirement(ProcessRequirement):
-    """
-    Indicate that the workflow platform must support the ``valueFrom`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
-
-    """
-
     def __init__(
         self,
         extension_fields: MutableMapping[str, Any] | None = None,
@@ -22423,10 +23893,20 @@ class StepInputExpressionRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "StepInputExpressionRequirement"
+        self.class_: Final[str] = "MultipleInputFeatureRequirement"
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class StepInputExpressionRequirement(ProcessRequirement):
+    """
+    Indicate that the workflow platform must support the ``valueFrom`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, StepInputExpressionRequirement):
@@ -22525,13 +24005,8 @@ class StepInputExpressionRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class Secrets(ProcessRequirement):
     def __init__(
         self,
-        secrets: Any,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -22540,12 +24015,16 @@ class Secrets(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "Secrets"
-        self.secrets = secrets
+        self.class_: Final[str] = "StepInputExpressionRequirement"
 
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class Secrets(ProcessRequirement):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Secrets):
             return bool(self.class_ == other.class_ and self.secrets == other.secrets)
@@ -22697,23 +24176,9 @@ class Secrets(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "secrets"])
-
-
-class ProcessGenerator(Process):
-    id: str
-
     def __init__(
         self,
-        inputs: Any,
-        outputs: Any,
-        run: Any,
-        id: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        cwlVersion: Any | None = None,
+        secrets: Sequence[str],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -22722,19 +24187,18 @@ class ProcessGenerator(Process):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.label = label
-        self.doc = doc
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.cwlVersion = cwlVersion
-        self.class_: Final[str] = "ProcessGenerator"
-        self.run = run
+        self.class_: Final[str] = "Secrets"
+        self.secrets = secrets
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "secrets"])
+
+
+@mypyc_attr(native_class=True)
+class ProcessGenerator(Process):
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ProcessGenerator):
@@ -22829,15 +24293,61 @@ class ProcessGenerator(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -23050,7 +24560,7 @@ class ProcessGenerator(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -23097,7 +24607,7 @@ class ProcessGenerator(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -23194,7 +24704,7 @@ class ProcessGenerator(Process):
 
             run = _load_field(
                 _doc.get("run"),
-                uri_union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader_False_False_None_None,
+                uri_union_of_strtype_or_ProcessProxyLoader_False_False_None_None,
                 subscope_baseuri,
                 loadingOptions,
                 lc=_doc.get("run")
@@ -23273,7 +24783,7 @@ class ProcessGenerator(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -23288,7 +24798,10 @@ class ProcessGenerator(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -23342,6 +24855,39 @@ class ProcessGenerator(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[WorkflowInputParameter],
+        outputs: Sequence[ExpressionToolOutputParameter],
+        run: Process | str,
+        id: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        cwlVersion: CWLVersion | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.label = label
+        self.doc = doc
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.cwlVersion = cwlVersion
+        self.class_: Final[str] = "ProcessGenerator"
+        self.run = run
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -23358,28 +24904,12 @@ class ProcessGenerator(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class MPIRequirement(ProcessRequirement):
     """
     Indicates that a process requires an MPI runtime.
 
     """
-
-    def __init__(
-        self,
-        processes: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "MPIRequirement"
-        self.processes = processes
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, MPIRequirement):
@@ -23538,21 +25068,9 @@ class MPIRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "processes"])
-
-
-class CUDARequirement(ProcessRequirement):
-    """
-    Require support for NVIDA CUDA (GPU hardware acceleration).
-
-    """
-
     def __init__(
         self,
-        cudaComputeCapability: Any,
-        cudaVersionMin: Any,
-        cudaDeviceCountMax: Any | None = None,
-        cudaDeviceCountMin: Any | None = None,
+        processes: i32 | str,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -23561,14 +25079,21 @@ class CUDARequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "CUDARequirement"
-        self.cudaComputeCapability = cudaComputeCapability
-        self.cudaDeviceCountMax = cudaDeviceCountMax
-        self.cudaDeviceCountMin = cudaDeviceCountMin
-        self.cudaVersionMin = cudaVersionMin
+        self.class_: Final[str] = "MPIRequirement"
+        self.processes = processes
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "processes"])
+
+
+@mypyc_attr(native_class=True)
+class CUDARequirement(ProcessRequirement):
+    """
+    Require support for NVIDA CUDA (GPU hardware acceleration).
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CUDARequirement):
@@ -23905,6 +25430,29 @@ class CUDARequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        cudaComputeCapability: Sequence[str] | str,
+        cudaVersionMin: str,
+        cudaDeviceCountMax: None | i32 | str = None,
+        cudaDeviceCountMin: None | i32 | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "CUDARequirement"
+        self.cudaComputeCapability = cudaComputeCapability
+        self.cudaDeviceCountMax = cudaDeviceCountMax
+        self.cudaDeviceCountMin = cudaDeviceCountMin
+        self.cudaVersionMin = cudaVersionMin
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -23916,24 +25464,8 @@ class CUDARequirement(ProcessRequirement):
     )
 
 
+@mypyc_attr(native_class=True)
 class ShmSize(ProcessRequirement):
-    def __init__(
-        self,
-        shmSize: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ShmSize"
-        self.shmSize = shmSize
-
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ShmSize):
             return bool(self.class_ == other.class_ and self.shmSize == other.shmSize)
@@ -24086,6 +25618,23 @@ class ShmSize(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        shmSize: str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "ShmSize"
+        self.shmSize = shmSize
+
     attrs: ClassVar[Collection[str]] = frozenset(["class", "shmSize"])
 
 
@@ -24103,6 +25652,7 @@ _vocab.update({
     "CommandInputArraySchema": "https://w3id.org/cwl/cwl#CommandInputArraySchema",
     "CommandInputEnumSchema": "https://w3id.org/cwl/cwl#CommandInputEnumSchema",
     "CommandInputParameter": "https://w3id.org/cwl/cwl#CommandInputParameter",
+    "CommandInputParameterType": "https://w3id.org/cwl/cwl#CommandInputParameterType",
     "CommandInputRecordField": "https://w3id.org/cwl/cwl#CommandInputRecordField",
     "CommandInputRecordSchema": "https://w3id.org/cwl/cwl#CommandInputRecordSchema",
     "CommandInputSchema": "https://w3id.org/cwl/cwl#CommandInputSchema",
@@ -24113,6 +25663,7 @@ _vocab.update({
     "CommandOutputBinding": "https://w3id.org/cwl/cwl#CommandOutputBinding",
     "CommandOutputEnumSchema": "https://w3id.org/cwl/cwl#CommandOutputEnumSchema",
     "CommandOutputParameter": "https://w3id.org/cwl/cwl#CommandOutputParameter",
+    "CommandOutputParameterType": "https://w3id.org/cwl/cwl#CommandOutputParameterType",
     "CommandOutputRecordField": "https://w3id.org/cwl/cwl#CommandOutputRecordField",
     "CommandOutputRecordSchema": "https://w3id.org/cwl/cwl#CommandOutputRecordSchema",
     "Directory": "https://w3id.org/cwl/cwl#Directory",
@@ -24139,6 +25690,7 @@ _vocab.update({
     "InputEnumSchema": "https://w3id.org/cwl/cwl#InputEnumSchema",
     "InputFormat": "https://w3id.org/cwl/cwl#InputFormat",
     "InputParameter": "https://w3id.org/cwl/cwl#InputParameter",
+    "InputParameterType": "https://w3id.org/cwl/cwl#InputParameterType",
     "InputRecordField": "https://w3id.org/cwl/cwl#InputRecordField",
     "InputRecordSchema": "https://w3id.org/cwl/cwl#InputRecordSchema",
     "InputSchema": "https://w3id.org/cwl/cwl#InputSchema",
@@ -24155,6 +25707,7 @@ _vocab.update({
     "OutputEnumSchema": "https://w3id.org/cwl/cwl#OutputEnumSchema",
     "OutputFormat": "https://w3id.org/cwl/cwl#OutputFormat",
     "OutputParameter": "https://w3id.org/cwl/cwl#OutputParameter",
+    "OutputParameterType": "https://w3id.org/cwl/cwl#OutputParameterType",
     "OutputRecordField": "https://w3id.org/cwl/cwl#OutputRecordField",
     "OutputRecordSchema": "https://w3id.org/cwl/cwl#OutputRecordSchema",
     "OutputSchema": "https://w3id.org/cwl/cwl#OutputSchema",
@@ -24226,6 +25779,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#CommandInputArraySchema": "CommandInputArraySchema",
     "https://w3id.org/cwl/cwl#CommandInputEnumSchema": "CommandInputEnumSchema",
     "https://w3id.org/cwl/cwl#CommandInputParameter": "CommandInputParameter",
+    "https://w3id.org/cwl/cwl#CommandInputParameterType": "CommandInputParameterType",
     "https://w3id.org/cwl/cwl#CommandInputRecordField": "CommandInputRecordField",
     "https://w3id.org/cwl/cwl#CommandInputRecordSchema": "CommandInputRecordSchema",
     "https://w3id.org/cwl/cwl#CommandInputSchema": "CommandInputSchema",
@@ -24236,6 +25790,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#CommandOutputBinding": "CommandOutputBinding",
     "https://w3id.org/cwl/cwl#CommandOutputEnumSchema": "CommandOutputEnumSchema",
     "https://w3id.org/cwl/cwl#CommandOutputParameter": "CommandOutputParameter",
+    "https://w3id.org/cwl/cwl#CommandOutputParameterType": "CommandOutputParameterType",
     "https://w3id.org/cwl/cwl#CommandOutputRecordField": "CommandOutputRecordField",
     "https://w3id.org/cwl/cwl#CommandOutputRecordSchema": "CommandOutputRecordSchema",
     "https://w3id.org/cwl/cwl#Directory": "Directory",
@@ -24262,6 +25817,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#InputEnumSchema": "InputEnumSchema",
     "https://w3id.org/cwl/cwl#InputFormat": "InputFormat",
     "https://w3id.org/cwl/cwl#InputParameter": "InputParameter",
+    "https://w3id.org/cwl/cwl#InputParameterType": "InputParameterType",
     "https://w3id.org/cwl/cwl#InputRecordField": "InputRecordField",
     "https://w3id.org/cwl/cwl#InputRecordSchema": "InputRecordSchema",
     "https://w3id.org/cwl/cwl#InputSchema": "InputSchema",
@@ -24278,6 +25834,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#OutputEnumSchema": "OutputEnumSchema",
     "https://w3id.org/cwl/cwl#OutputFormat": "OutputFormat",
     "https://w3id.org/cwl/cwl#OutputParameter": "OutputParameter",
+    "https://w3id.org/cwl/cwl#OutputParameterType": "OutputParameterType",
     "https://w3id.org/cwl/cwl#OutputRecordField": "OutputRecordField",
     "https://w3id.org/cwl/cwl#OutputRecordSchema": "OutputRecordSchema",
     "https://w3id.org/cwl/cwl#OutputSchema": "OutputSchema",
@@ -24336,14 +25893,20 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#v1.1": "v1.1",
 })
 
-strtype: Final = _PrimitiveLoader(str)
-inttype: Final = _PrimitiveLoader(int)
-floattype: Final = _PrimitiveLoader(float)
-booltype: Final = _PrimitiveLoader(bool)
-None_type: Final = _PrimitiveLoader(type(None))
-Any_type: Final = _AnyLoader()
-DocumentedProxyLoader: Final = _ProxyLoader("DocumentedLoader")
-PrimitiveTypeLoader: Final = _EnumLoader(
+strtype: Final[Loader[str]] = _PrimitiveLoader(str)
+inttype: Final[Loader[i32]] = _PrimitiveLoader(i32)
+longtype: Final[Loader[i64]] = _PrimitiveLoader(i64)
+floattype: Final[Loader[float]] = _PrimitiveLoader(float)
+booltype: Final[Loader[bool]] = _PrimitiveLoader(bool)
+None_type: Final[Loader[None]] = _PrimitiveLoader(type(None))
+Any_type: Final[Loader[Any]] = _AnyLoader()
+DocumentedProxyLoader: Final[Loader[schema_salad.metaschema.Documented]] = _ProxyLoader(
+    "DocumentedLoader"
+)
+PrimitiveType: TypeAlias = Literal[
+    "null", "boolean", "int", "long", "float", "double", "string"
+]
+PrimitiveTypeLoader: Final[Loader[PrimitiveType]] = _EnumLoader[PrimitiveType](
     (
         "null",
         "boolean",
@@ -24374,25 +25937,33 @@ double: double precision (64-bit) IEEE 754 floating-point number
 
 string: Unicode character sequence
 """
-AnyLoader: Final = _EnumLoader(("Any",), "Any")
+Any_: TypeAlias = Literal["Any"]
+Any_Loader: Final[Loader[Any_]] = _EnumLoader[Any_](("Any",), "Any_")
 """
 The **Any** type validates for any non-null value.
 """
-RecordFieldLoader: Final = _RecordLoader(
+RecordFieldLoader: Final[Loader[schema_salad.metaschema.RecordField]] = _RecordLoader(
     schema_salad.metaschema.RecordField, None, None
 )
-RecordSchemaLoader: Final = _RecordLoader(
+RecordSchemaLoader: Final[Loader[schema_salad.metaschema.RecordSchema]] = _RecordLoader(
     schema_salad.metaschema.RecordSchema, None, None
 )
-EnumSchemaLoader: Final = _RecordLoader(schema_salad.metaschema.EnumSchema, None, None)
-ArraySchemaLoader: Final = _RecordLoader(
+EnumSchemaLoader: Final[Loader[schema_salad.metaschema.EnumSchema]] = _RecordLoader(
+    schema_salad.metaschema.EnumSchema, None, None
+)
+ArraySchemaLoader: Final[Loader[schema_salad.metaschema.ArraySchema]] = _RecordLoader(
     schema_salad.metaschema.ArraySchema, None, None
 )
-MapSchemaLoader: Final = _RecordLoader(schema_salad.metaschema.MapSchema, None, None)
-UnionSchemaLoader: Final = _RecordLoader(
+MapSchemaLoader: Final[Loader[schema_salad.metaschema.MapSchema]] = _RecordLoader(
+    schema_salad.metaschema.MapSchema, None, None
+)
+UnionSchemaLoader: Final[Loader[schema_salad.metaschema.UnionSchema]] = _RecordLoader(
     schema_salad.metaschema.UnionSchema, None, None
 )
-CWLTypeLoader: Final = _EnumLoader(
+CWLType: TypeAlias = Literal[
+    "null", "boolean", "int", "long", "float", "double", "string", "File", "Directory"
+]
+CWLTypeLoader: Final[Loader[CWLType]] = _EnumLoader[CWLType](
     (
         "null",
         "boolean",
@@ -24413,118 +25984,51 @@ File: A File object
 
 Directory: A Directory object
 """
-CWLArraySchemaLoader: Final = _RecordLoader(CWLArraySchema, None, None)
-CWLRecordFieldLoader: Final = _RecordLoader(CWLRecordField, None, None)
-CWLRecordSchemaLoader: Final = _RecordLoader(CWLRecordSchema, None, None)
-FileLoader: Final = _RecordLoader(File, None, None)
-DirectoryLoader: Final = _RecordLoader(Directory, None, None)
-CWLObjectTypeLoader: Final = _UnionLoader((), "CWLObjectTypeLoader")
-union_of_None_type_or_CWLObjectTypeLoader: Final = _UnionLoader(
-    (
-        None_type,
-        CWLObjectTypeLoader,
-    )
+CWLArraySchemaLoader: Final[Loader[CWLArraySchema]] = _RecordLoader(
+    CWLArraySchema, None, None
 )
-array_of_union_of_None_type_or_CWLObjectTypeLoader: Final = _ArrayLoader(
-    union_of_None_type_or_CWLObjectTypeLoader
+CWLRecordFieldLoader: Final[Loader[CWLRecordField]] = _RecordLoader(
+    CWLRecordField, None, None
 )
-map_of_union_of_None_type_or_CWLObjectTypeLoader: Final = _MapLoader(
-    union_of_None_type_or_CWLObjectTypeLoader, "None", None, None
+CWLRecordSchemaLoader: Final[Loader[CWLRecordSchema]] = _RecordLoader(
+    CWLRecordSchema, None, None
 )
-InlineJavascriptRequirementLoader: Final = _RecordLoader(
-    InlineJavascriptRequirement, None, None
+FileLoader: Final[Loader[File]] = _RecordLoader(File, None, None)
+DirectoryLoader: Final[Loader[Directory]] = _RecordLoader(Directory, None, None)
+CWLObjectTypeLoader: Final[Loader[CWLObjectType]] = _UnionLoader(
+    (), "CWLObjectTypeLoader"
 )
-SchemaDefRequirementLoader: Final = _RecordLoader(SchemaDefRequirement, None, None)
-LoadListingRequirementLoader: Final = _RecordLoader(LoadListingRequirement, None, None)
-DockerRequirementLoader: Final = _RecordLoader(DockerRequirement, None, None)
-SoftwareRequirementLoader: Final = _RecordLoader(SoftwareRequirement, None, None)
-InitialWorkDirRequirementLoader: Final = _RecordLoader(
-    InitialWorkDirRequirement, None, None
-)
-EnvVarRequirementLoader: Final = _RecordLoader(EnvVarRequirement, None, None)
-ShellCommandRequirementLoader: Final = _RecordLoader(
-    ShellCommandRequirement, None, None
-)
-ResourceRequirementLoader: Final = _RecordLoader(ResourceRequirement, None, None)
-WorkReuseLoader: Final = _RecordLoader(WorkReuse, None, None)
-NetworkAccessLoader: Final = _RecordLoader(NetworkAccess, None, None)
-InplaceUpdateRequirementLoader: Final = _RecordLoader(
-    InplaceUpdateRequirement, None, None
-)
-ToolTimeLimitLoader: Final = _RecordLoader(ToolTimeLimit, None, None)
-SubworkflowFeatureRequirementLoader: Final = _RecordLoader(
-    SubworkflowFeatureRequirement, None, None
-)
-ScatterFeatureRequirementLoader: Final = _RecordLoader(
-    ScatterFeatureRequirement, None, None
-)
-MultipleInputFeatureRequirementLoader: Final = _RecordLoader(
-    MultipleInputFeatureRequirement, None, None
-)
-StepInputExpressionRequirementLoader: Final = _RecordLoader(
-    StepInputExpressionRequirement, None, None
-)
-SecretsLoader: Final = _RecordLoader(Secrets, None, None)
-MPIRequirementLoader: Final = _RecordLoader(MPIRequirement, None, None)
-CUDARequirementLoader: Final = _RecordLoader(CUDARequirement, None, None)
-ShmSizeLoader: Final = _RecordLoader(ShmSize, None, None)
-union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader: (
-    Final
-) = _UnionLoader(
-    (
-        InlineJavascriptRequirementLoader,
-        SchemaDefRequirementLoader,
-        LoadListingRequirementLoader,
-        DockerRequirementLoader,
-        SoftwareRequirementLoader,
-        InitialWorkDirRequirementLoader,
-        EnvVarRequirementLoader,
-        ShellCommandRequirementLoader,
-        ResourceRequirementLoader,
-        WorkReuseLoader,
-        NetworkAccessLoader,
-        InplaceUpdateRequirementLoader,
-        ToolTimeLimitLoader,
-        SubworkflowFeatureRequirementLoader,
-        ScatterFeatureRequirementLoader,
-        MultipleInputFeatureRequirementLoader,
-        StepInputExpressionRequirementLoader,
-        SecretsLoader,
-        MPIRequirementLoader,
-        CUDARequirementLoader,
-        ShmSizeLoader,
-    )
-)
-ProcessRequirementProxyLoader: Final = _ProxyLoader("ProcessRequirementLoader")
-array_of_ProcessRequirement: Final = _ArrayLoader(ProcessRequirementProxyLoader)
-union_of_None_type_or_array_of_ProcessRequirement_or_CWLObjectTypeLoader: Final = (
+union_of_None_type_or_CWLObjectTypeLoader: Final[Loader[CWLObjectType | None]] = (
     _UnionLoader(
         (
             None_type,
-            array_of_ProcessRequirement,
             CWLObjectTypeLoader,
         )
     )
 )
-map_of_union_of_None_type_or_array_of_ProcessRequirement_or_CWLObjectTypeLoader: (
-    Final
-) = _MapLoader(
-    union_of_None_type_or_array_of_ProcessRequirement_or_CWLObjectTypeLoader,
-    "CWLInputFile",
-    "@list",
-    True,
+array_of_union_of_None_type_or_CWLObjectTypeLoader: Final[
+    Loader[Sequence[CWLObjectType | None]]
+] = _ArrayLoader(union_of_None_type_or_CWLObjectTypeLoader)
+map_of_union_of_None_type_or_CWLObjectTypeLoader: Final[
+    Loader[Mapping[str, CWLObjectType | None]]
+] = _MapLoader(union_of_None_type_or_CWLObjectTypeLoader, "None", None, None)
+CWLObjectType: TypeAlias = (
+    "Directory | File | Mapping[str, CWLObjectType | None] | Sequence[CWLObjectType | None] | bool | float | i32 | str"
 )
-CWLInputFileLoader: Final = (
-    map_of_union_of_None_type_or_array_of_ProcessRequirement_or_CWLObjectTypeLoader
+CWLVersion: TypeAlias = Literal["v1.1"]
+CWLVersionLoader: Final[Loader[CWLVersion]] = _EnumLoader[CWLVersion](
+    ("v1.1",), "CWLVersion"
 )
-CWLVersionLoader: Final = _EnumLoader(("v1.1",), "CWLVersion")
 """
 Current version symbol for CWL documents.
 """
-LabeledProxyLoader: Final = _ProxyLoader("LabeledLoader")
-IdentifiedProxyLoader: Final = _ProxyLoader("IdentifiedLoader")
-IdentifierRequiredProxyLoader: Final = _ProxyLoader("IdentifierRequiredLoader")
-LoadListingEnumLoader: Final = _EnumLoader(
+LabeledProxyLoader: Final[Loader[Labeled]] = _ProxyLoader("LabeledLoader")
+IdentifiedProxyLoader: Final[Loader[Identified]] = _ProxyLoader("IdentifiedLoader")
+IdentifierRequiredProxyLoader: Final[Loader[IdentifierRequired]] = _ProxyLoader(
+    "IdentifierRequiredLoader"
+)
+LoadListingEnum: TypeAlias = Literal["no_listing", "shallow_listing", "deep_listing"]
+LoadListingEnumLoader: Final[Loader[LoadListingEnum]] = _EnumLoader[LoadListingEnum](
     (
         "no_listing",
         "shallow_listing",
@@ -24541,58 +26045,174 @@ shallow_listing: Only load the top level listing, do not recurse into subdirecto
 
 deep_listing: Load the directory listing and recursively load all subdirectories as well.
 """
-LoadContentsProxyLoader: Final = _ProxyLoader("LoadContentsLoader")
-FieldBaseProxyLoader: Final = _ProxyLoader("FieldBaseLoader")
-InputFormatProxyLoader: Final = _ProxyLoader("InputFormatLoader")
-OutputFormatProxyLoader: Final = _ProxyLoader("OutputFormatLoader")
-ParameterProxyLoader: Final = _ProxyLoader("ParameterLoader")
-ExpressionLoader: Final = _ExpressionLoader(str)
-InputBindingLoader: Final = _RecordLoader(InputBinding, None, None)
-IOSchemaProxyLoader: Final = _ProxyLoader("IOSchemaLoader")
-InputSchemaProxyLoader: Final = _ProxyLoader("InputSchemaLoader")
-OutputSchemaProxyLoader: Final = _ProxyLoader("OutputSchemaLoader")
-InputRecordFieldLoader: Final = _RecordLoader(InputRecordField, None, None)
-InputRecordSchemaLoader: Final = _RecordLoader(InputRecordSchema, None, None)
-InputEnumSchemaLoader: Final = _RecordLoader(InputEnumSchema, None, None)
-InputArraySchemaLoader: Final = _RecordLoader(InputArraySchema, None, None)
-OutputRecordFieldLoader: Final = _RecordLoader(OutputRecordField, None, None)
-OutputRecordSchemaLoader: Final = _RecordLoader(OutputRecordSchema, None, None)
-OutputEnumSchemaLoader: Final = _RecordLoader(OutputEnumSchema, None, None)
-OutputArraySchemaLoader: Final = _RecordLoader(OutputArraySchema, None, None)
-InputParameterProxyLoader: Final = _ProxyLoader("InputParameterLoader")
-OutputParameterProxyLoader: Final = _ProxyLoader("OutputParameterLoader")
-ProcessProxyLoader: Final = _ProxyLoader("ProcessLoader")
-CommandInputSchemaProxyLoader: Final = _ProxyLoader("CommandInputSchemaLoader")
-SecondaryFileSchemaLoader: Final = _RecordLoader(SecondaryFileSchema, None, None)
-EnvironmentDefLoader: Final = _RecordLoader(EnvironmentDef, None, None)
-CommandLineBindingLoader: Final = _RecordLoader(CommandLineBinding, None, None)
-CommandOutputBindingLoader: Final = _RecordLoader(CommandOutputBinding, None, None)
-CommandLineBindableProxyLoader: Final = _ProxyLoader("CommandLineBindableLoader")
-CommandInputRecordFieldLoader: Final = _RecordLoader(
+LoadContentsProxyLoader: Final[Loader[LoadContents]] = _ProxyLoader(
+    "LoadContentsLoader"
+)
+FieldBaseProxyLoader: Final[Loader[FieldBase]] = _ProxyLoader("FieldBaseLoader")
+InputFormatProxyLoader: Final[Loader[InputFormat]] = _ProxyLoader("InputFormatLoader")
+OutputFormatProxyLoader: Final[Loader[OutputFormat]] = _ProxyLoader(
+    "OutputFormatLoader"
+)
+ParameterProxyLoader: Final[Loader[Parameter]] = _ProxyLoader("ParameterLoader")
+Expression: TypeAlias = Literal["ExpressionPlaceholder"]
+ExpressionLoader: Final[Loader[str]] = _ExpressionLoader(str)
+InputBindingLoader: Final[Loader[InputBinding]] = _RecordLoader(
+    InputBinding, None, None
+)
+IOSchemaProxyLoader: Final[Loader[IOSchema]] = _ProxyLoader("IOSchemaLoader")
+InputSchemaProxyLoader: Final[Loader[InputSchema]] = _ProxyLoader("InputSchemaLoader")
+OutputSchemaProxyLoader: Final[Loader[OutputSchema]] = _ProxyLoader(
+    "OutputSchemaLoader"
+)
+InputRecordFieldLoader: Final[Loader[InputRecordField]] = _RecordLoader(
+    InputRecordField, None, None
+)
+InputRecordSchemaLoader: Final[Loader[InputRecordSchema]] = _RecordLoader(
+    InputRecordSchema, None, None
+)
+InputEnumSchemaLoader: Final[Loader[InputEnumSchema]] = _RecordLoader(
+    InputEnumSchema, None, None
+)
+InputArraySchemaLoader: Final[Loader[InputArraySchema]] = _RecordLoader(
+    InputArraySchema, None, None
+)
+InputParameterTypeLoader: Final[Loader[InputParameterType]] = _UnionLoader(
+    (), "InputParameterTypeLoader"
+)
+union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: Final[
+    Loader[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        InputRecordSchemaLoader,
+        InputEnumSchemaLoader,
+        InputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype
+)
+InputParameterType: TypeAlias = (
+    CWLType
+    | InputArraySchema
+    | InputEnumSchema
+    | InputRecordSchema
+    | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+    | str
+)
+OutputRecordFieldLoader: Final[Loader[OutputRecordField]] = _RecordLoader(
+    OutputRecordField, None, None
+)
+OutputRecordSchemaLoader: Final[Loader[OutputRecordSchema]] = _RecordLoader(
+    OutputRecordSchema, None, None
+)
+OutputEnumSchemaLoader: Final[Loader[OutputEnumSchema]] = _RecordLoader(
+    OutputEnumSchema, None, None
+)
+OutputArraySchemaLoader: Final[Loader[OutputArraySchema]] = _RecordLoader(
+    OutputArraySchema, None, None
+)
+OutputParameterTypeLoader: Final[Loader[OutputParameterType]] = _UnionLoader(
+    (), "OutputParameterTypeLoader"
+)
+union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: Final[
+    Loader[CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        OutputRecordSchemaLoader,
+        OutputEnumSchemaLoader,
+        OutputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype
+)
+OutputParameterType: TypeAlias = (
+    CWLType
+    | OutputArraySchema
+    | OutputEnumSchema
+    | OutputRecordSchema
+    | Sequence[
+        CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+    ]
+    | str
+)
+InputParameterProxyLoader: Final[Loader[InputParameter]] = _ProxyLoader(
+    "InputParameterLoader"
+)
+OutputParameterProxyLoader: Final[Loader[OutputParameter]] = _ProxyLoader(
+    "OutputParameterLoader"
+)
+ProcessRequirementProxyLoader: Final[Loader[ProcessRequirement]] = _ProxyLoader(
+    "ProcessRequirementLoader"
+)
+ProcessProxyLoader: Final[Loader[Process]] = _ProxyLoader("ProcessLoader")
+InlineJavascriptRequirementLoader: Final[Loader[InlineJavascriptRequirement]] = (
+    _RecordLoader(InlineJavascriptRequirement, None, None)
+)
+CommandInputSchemaProxyLoader: Final[Loader[CommandInputSchema]] = _ProxyLoader(
+    "CommandInputSchemaLoader"
+)
+SchemaDefRequirementLoader: Final[Loader[SchemaDefRequirement]] = _RecordLoader(
+    SchemaDefRequirement, None, None
+)
+SecondaryFileSchemaLoader: Final[Loader[SecondaryFileSchema]] = _RecordLoader(
+    SecondaryFileSchema, None, None
+)
+LoadListingRequirementLoader: Final[Loader[LoadListingRequirement]] = _RecordLoader(
+    LoadListingRequirement, None, None
+)
+EnvironmentDefLoader: Final[Loader[EnvironmentDef]] = _RecordLoader(
+    EnvironmentDef, None, None
+)
+CommandLineBindingLoader: Final[Loader[CommandLineBinding]] = _RecordLoader(
+    CommandLineBinding, None, None
+)
+CommandOutputBindingLoader: Final[Loader[CommandOutputBinding]] = _RecordLoader(
+    CommandOutputBinding, None, None
+)
+CommandLineBindableProxyLoader: Final[Loader[CommandLineBindable]] = _ProxyLoader(
+    "CommandLineBindableLoader"
+)
+CommandInputRecordFieldLoader: Final[Loader[CommandInputRecordField]] = _RecordLoader(
     CommandInputRecordField, None, None
 )
-CommandInputRecordSchemaLoader: Final = _RecordLoader(
+CommandInputRecordSchemaLoader: Final[Loader[CommandInputRecordSchema]] = _RecordLoader(
     CommandInputRecordSchema, None, None
 )
-CommandInputEnumSchemaLoader: Final = _RecordLoader(CommandInputEnumSchema, None, None)
-CommandInputArraySchemaLoader: Final = _RecordLoader(
+CommandInputEnumSchemaLoader: Final[Loader[CommandInputEnumSchema]] = _RecordLoader(
+    CommandInputEnumSchema, None, None
+)
+CommandInputArraySchemaLoader: Final[Loader[CommandInputArraySchema]] = _RecordLoader(
     CommandInputArraySchema, None, None
 )
-CommandOutputRecordFieldLoader: Final = _RecordLoader(
+CommandOutputRecordFieldLoader: Final[Loader[CommandOutputRecordField]] = _RecordLoader(
     CommandOutputRecordField, None, None
 )
-CommandOutputRecordSchemaLoader: Final = _RecordLoader(
-    CommandOutputRecordSchema, None, None
+CommandOutputRecordSchemaLoader: Final[Loader[CommandOutputRecordSchema]] = (
+    _RecordLoader(CommandOutputRecordSchema, None, None)
 )
-CommandOutputEnumSchemaLoader: Final = _RecordLoader(
+CommandOutputEnumSchemaLoader: Final[Loader[CommandOutputEnumSchema]] = _RecordLoader(
     CommandOutputEnumSchema, None, None
 )
-CommandOutputArraySchemaLoader: Final = _RecordLoader(
+CommandOutputArraySchemaLoader: Final[Loader[CommandOutputArraySchema]] = _RecordLoader(
     CommandOutputArraySchema, None, None
 )
-CommandInputParameterLoader: Final = _RecordLoader(CommandInputParameter, None, None)
-CommandOutputParameterLoader: Final = _RecordLoader(CommandOutputParameter, None, None)
-stdinLoader: Final = _EnumLoader(("stdin",), "stdin")
+stdin: TypeAlias = Literal["stdin"]
+stdinLoader: Final[Loader[stdin]] = _EnumLoader[stdin](("stdin",), "stdin")
 """
 Only valid as a ``type`` for a ``CommandLineTool`` input with no ``inputBinding`` set. ``stdin`` must not be specified at the ``CommandLineTool`` level.
 
@@ -24616,7 +26236,8 @@ is equivalent to
 
    stdin: ${inputs.an_input_name.path}
 """
-stdoutLoader: Final = _EnumLoader(("stdout",), "stdout")
+stdout: TypeAlias = Literal["stdout"]
+stdoutLoader: Final[Loader[stdout]] = _EnumLoader[stdout](("stdout",), "stdout")
 """
 Only valid as a ``type`` for a ``CommandLineTool`` output with no ``outputBinding`` set.
 
@@ -24667,7 +26288,8 @@ is equivalent to
 
    stdout: random_stdout_filenameABCDEFG
 """
-stderrLoader: Final = _EnumLoader(("stderr",), "stderr")
+stderr: TypeAlias = Literal["stderr"]
+stderrLoader: Final[Loader[stderr]] = _EnumLoader[stderr](("stderr",), "stderr")
 """
 Only valid as a ``type`` for a ``CommandLineTool`` output with no ``outputBinding`` set.
 
@@ -24718,15 +26340,155 @@ is equivalent to
 
    stderr: random_stderr_filenameABCDEFG
 """
-CommandLineToolLoader: Final = _RecordLoader(CommandLineTool, None, None)
-SoftwarePackageLoader: Final = _RecordLoader(SoftwarePackage, None, None)
-DirentLoader: Final = _RecordLoader(Dirent, None, None)
-ExpressionToolOutputParameterLoader: Final = _RecordLoader(
-    ExpressionToolOutputParameter, None, None
+CommandInputParameterTypeLoader: Final[Loader[CommandInputParameterType]] = (
+    _UnionLoader((), "CommandInputParameterTypeLoader")
 )
-WorkflowInputParameterLoader: Final = _RecordLoader(WorkflowInputParameter, None, None)
-ExpressionToolLoader: Final = _RecordLoader(ExpressionTool, None, None)
-LinkMergeMethodLoader: Final = _EnumLoader(
+union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | str
+    ]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        CommandInputRecordSchemaLoader,
+        CommandInputEnumSchemaLoader,
+        CommandInputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype
+)
+CommandInputParameterType: TypeAlias = (
+    CWLType
+    | CommandInputArraySchema
+    | CommandInputEnumSchema
+    | CommandInputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | str
+    ]
+    | stdin
+    | str
+)
+CommandInputParameterLoader: Final[Loader[CommandInputParameter]] = _RecordLoader(
+    CommandInputParameter, None, None
+)
+CommandOutputParameterTypeLoader: Final[Loader[CommandOutputParameterType]] = (
+    _UnionLoader((), "CommandOutputParameterTypeLoader")
+)
+union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | str
+    ]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        CommandOutputRecordSchemaLoader,
+        CommandOutputEnumSchemaLoader,
+        CommandOutputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype
+)
+CommandOutputParameterType: TypeAlias = (
+    CWLType
+    | CommandOutputArraySchema
+    | CommandOutputEnumSchema
+    | CommandOutputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | str
+    ]
+    | stderr
+    | stdout
+    | str
+)
+CommandOutputParameterLoader: Final[Loader[CommandOutputParameter]] = _RecordLoader(
+    CommandOutputParameter, None, None
+)
+CommandLineToolLoader: Final[Loader[CommandLineTool]] = _RecordLoader(
+    CommandLineTool, None, None
+)
+DockerRequirementLoader: Final[Loader[DockerRequirement]] = _RecordLoader(
+    DockerRequirement, None, None
+)
+SoftwareRequirementLoader: Final[Loader[SoftwareRequirement]] = _RecordLoader(
+    SoftwareRequirement, None, None
+)
+SoftwarePackageLoader: Final[Loader[SoftwarePackage]] = _RecordLoader(
+    SoftwarePackage, None, None
+)
+DirentLoader: Final[Loader[Dirent]] = _RecordLoader(Dirent, None, None)
+InitialWorkDirRequirementLoader: Final[Loader[InitialWorkDirRequirement]] = (
+    _RecordLoader(InitialWorkDirRequirement, None, None)
+)
+EnvVarRequirementLoader: Final[Loader[EnvVarRequirement]] = _RecordLoader(
+    EnvVarRequirement, None, None
+)
+ShellCommandRequirementLoader: Final[Loader[ShellCommandRequirement]] = _RecordLoader(
+    ShellCommandRequirement, None, None
+)
+ResourceRequirementLoader: Final[Loader[ResourceRequirement]] = _RecordLoader(
+    ResourceRequirement, None, None
+)
+WorkReuseLoader: Final[Loader[WorkReuse]] = _RecordLoader(WorkReuse, None, None)
+NetworkAccessLoader: Final[Loader[NetworkAccess]] = _RecordLoader(
+    NetworkAccess, None, None
+)
+InplaceUpdateRequirementLoader: Final[Loader[InplaceUpdateRequirement]] = _RecordLoader(
+    InplaceUpdateRequirement, None, None
+)
+ToolTimeLimitLoader: Final[Loader[ToolTimeLimit]] = _RecordLoader(
+    ToolTimeLimit, None, None
+)
+ExpressionToolOutputParameterLoader: Final[Loader[ExpressionToolOutputParameter]] = (
+    _RecordLoader(ExpressionToolOutputParameter, None, None)
+)
+WorkflowInputParameterLoader: Final[Loader[WorkflowInputParameter]] = _RecordLoader(
+    WorkflowInputParameter, None, None
+)
+ExpressionToolLoader: Final[Loader[ExpressionTool]] = _RecordLoader(
+    ExpressionTool, None, None
+)
+LinkMergeMethod: TypeAlias = Literal["merge_nested", "merge_flattened"]
+LinkMergeMethodLoader: Final[Loader[LinkMergeMethod]] = _EnumLoader[LinkMergeMethod](
     (
         "merge_nested",
         "merge_flattened",
@@ -24736,13 +26498,20 @@ LinkMergeMethodLoader: Final = _EnumLoader(
 """
 The input link merge method, described in `WorkflowStepInput <#WorkflowStepInput>`__.
 """
-WorkflowOutputParameterLoader: Final = _RecordLoader(
+WorkflowOutputParameterLoader: Final[Loader[WorkflowOutputParameter]] = _RecordLoader(
     WorkflowOutputParameter, None, None
 )
-SinkProxyLoader: Final = _ProxyLoader("SinkLoader")
-WorkflowStepInputLoader: Final = _RecordLoader(WorkflowStepInput, None, None)
-WorkflowStepOutputLoader: Final = _RecordLoader(WorkflowStepOutput, None, None)
-ScatterMethodLoader: Final = _EnumLoader(
+SinkProxyLoader: Final[Loader[Sink]] = _ProxyLoader("SinkLoader")
+WorkflowStepInputLoader: Final[Loader[WorkflowStepInput]] = _RecordLoader(
+    WorkflowStepInput, None, None
+)
+WorkflowStepOutputLoader: Final[Loader[WorkflowStepOutput]] = _RecordLoader(
+    WorkflowStepOutput, None, None
+)
+ScatterMethod: TypeAlias = Literal[
+    "dotproduct", "nested_crossproduct", "flat_crossproduct"
+]
+ScatterMethodLoader: Final[Loader[ScatterMethod]] = _EnumLoader[ScatterMethod](
     (
         "dotproduct",
         "nested_crossproduct",
@@ -24753,21 +26522,121 @@ ScatterMethodLoader: Final = _EnumLoader(
 """
 The scatter method, as described in `workflow step scatter <#WorkflowStep>`__.
 """
-WorkflowStepLoader: Final = _RecordLoader(WorkflowStep, None, None)
-WorkflowLoader: Final = _RecordLoader(Workflow, None, None)
-ProcessGeneratorLoader: Final = _RecordLoader(ProcessGenerator, None, None)
-array_of_strtype: Final = _ArrayLoader(strtype)
-union_of_None_type_or_strtype_or_array_of_strtype: Final = _UnionLoader(
+WorkflowStepLoader: Final[Loader[WorkflowStep]] = _RecordLoader(
+    WorkflowStep, None, None
+)
+WorkflowLoader: Final[Loader[Workflow]] = _RecordLoader(Workflow, None, None)
+SubworkflowFeatureRequirementLoader: Final[Loader[SubworkflowFeatureRequirement]] = (
+    _RecordLoader(SubworkflowFeatureRequirement, None, None)
+)
+ScatterFeatureRequirementLoader: Final[Loader[ScatterFeatureRequirement]] = (
+    _RecordLoader(ScatterFeatureRequirement, None, None)
+)
+MultipleInputFeatureRequirementLoader: Final[
+    Loader[MultipleInputFeatureRequirement]
+] = _RecordLoader(MultipleInputFeatureRequirement, None, None)
+StepInputExpressionRequirementLoader: Final[Loader[StepInputExpressionRequirement]] = (
+    _RecordLoader(StepInputExpressionRequirement, None, None)
+)
+union_of_SoftwareRequirementLoader_or_ShellCommandRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_DockerRequirementLoader_or_InplaceUpdateRequirementLoader_or_SchemaDefRequirementLoader_or_ResourceRequirementLoader_or_ScatterFeatureRequirementLoader_or_InlineJavascriptRequirementLoader_or_ToolTimeLimitLoader_or_WorkReuseLoader_or_SubworkflowFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_LoadListingRequirementLoader_or_NetworkAccessLoader_or_EnvVarRequirementLoader_or_InitialWorkDirRequirementLoader: Final[
+    Loader[
+        DockerRequirement
+        | EnvVarRequirement
+        | InitialWorkDirRequirement
+        | InlineJavascriptRequirement
+        | InplaceUpdateRequirement
+        | LoadListingRequirement
+        | MultipleInputFeatureRequirement
+        | NetworkAccess
+        | ResourceRequirement
+        | ScatterFeatureRequirement
+        | SchemaDefRequirement
+        | ShellCommandRequirement
+        | SoftwareRequirement
+        | StepInputExpressionRequirement
+        | SubworkflowFeatureRequirement
+        | ToolTimeLimit
+        | WorkReuse
+    ]
+] = _UnionLoader(
+    (
+        SoftwareRequirementLoader,
+        ShellCommandRequirementLoader,
+        MultipleInputFeatureRequirementLoader,
+        DockerRequirementLoader,
+        InplaceUpdateRequirementLoader,
+        SchemaDefRequirementLoader,
+        ResourceRequirementLoader,
+        ScatterFeatureRequirementLoader,
+        InlineJavascriptRequirementLoader,
+        ToolTimeLimitLoader,
+        WorkReuseLoader,
+        SubworkflowFeatureRequirementLoader,
+        StepInputExpressionRequirementLoader,
+        LoadListingRequirementLoader,
+        NetworkAccessLoader,
+        EnvVarRequirementLoader,
+        InitialWorkDirRequirementLoader,
+    )
+)
+array_of_ProcessRequirementProxyLoader: Final[Loader[Sequence[ProcessRequirement]]] = (
+    _ArrayLoader(ProcessRequirementProxyLoader)
+)
+union_of_None_type_or_array_of_ProcessRequirementProxyLoader_or_CWLObjectTypeLoader: (
+    Final[Loader[CWLObjectType | None | Sequence[ProcessRequirement]]]
+) = _UnionLoader(
+    (
+        None_type,
+        array_of_ProcessRequirementProxyLoader,
+        CWLObjectTypeLoader,
+    )
+)
+map_of_union_of_None_type_or_array_of_ProcessRequirementProxyLoader_or_CWLObjectTypeLoader: Final[
+    Loader[Mapping[str, CWLObjectType | None | Sequence[ProcessRequirement]]]
+] = _MapLoader(
+    union_of_None_type_or_array_of_ProcessRequirementProxyLoader_or_CWLObjectTypeLoader,
+    "CWLInputFile",
+    "@list",
+    True,
+)
+CWLInputFileLoader: Final[
+    Loader[Mapping[str, CWLObjectType | None | Sequence[ProcessRequirement]]]
+] = map_of_union_of_None_type_or_array_of_ProcessRequirementProxyLoader_or_CWLObjectTypeLoader
+SecretsLoader: Final[Loader[Secrets]] = _RecordLoader(Secrets, None, None)
+ProcessGeneratorLoader: Final[Loader[ProcessGenerator]] = _RecordLoader(
+    ProcessGenerator, None, None
+)
+MPIRequirementLoader: Final[Loader[MPIRequirement]] = _RecordLoader(
+    MPIRequirement, None, None
+)
+CUDARequirementLoader: Final[Loader[CUDARequirement]] = _RecordLoader(
+    CUDARequirement, None, None
+)
+ShmSizeLoader: Final[Loader[ShmSize]] = _RecordLoader(ShmSize, None, None)
+array_of_strtype: Final[Loader[Sequence[str]]] = _ArrayLoader(strtype)
+union_of_None_type_or_strtype_or_array_of_strtype: Final[
+    Loader[None | Sequence[str] | str]
+] = _UnionLoader(
     (
         None_type,
         strtype,
         array_of_strtype,
     )
 )
-uri_strtype_True_False_None_None: Final = _URILoader(strtype, True, False, None, None)
-union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+uri_strtype_True_False_None_None: Final[Loader[str]] = _URILoader(
+    strtype, True, False, None, None
+)
+union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: Final[
+    Loader[
+        PrimitiveType
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         RecordSchemaLoader,
@@ -24778,14 +26647,41 @@ union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArrayS
         strtype,
     )
 )
-array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
     union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype
 )
-union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: Final[
+    Loader[
+        PrimitiveType
+        | Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         RecordSchemaLoader,
@@ -24797,57 +26693,141 @@ union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArrayS
         array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2: Final[
+    Loader[
+        PrimitiveType
+        | Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _TypeDSLLoader[
+    PrimitiveType
+    | Sequence[
+        PrimitiveType
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+    | schema_salad.metaschema.ArraySchema
+    | schema_salad.metaschema.EnumSchema
+    | schema_salad.metaschema.MapSchema
+    | schema_salad.metaschema.RecordSchema
+    | schema_salad.metaschema.UnionSchema
+    | str
+](
     union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_RecordFieldLoader: Final = _ArrayLoader(RecordFieldLoader)
-union_of_None_type_or_array_of_RecordFieldLoader: Final = _UnionLoader(
+array_of_RecordFieldLoader: Final[
+    Loader[Sequence[schema_salad.metaschema.RecordField]]
+] = _ArrayLoader(RecordFieldLoader)
+union_of_None_type_or_array_of_RecordFieldLoader: Final[
+    Loader[None | Sequence[schema_salad.metaschema.RecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_RecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader: Final = _IdMapLoader(
-    union_of_None_type_or_array_of_RecordFieldLoader, "name", "type"
+idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader: Final[
+    Loader[None | Sequence[schema_salad.metaschema.RecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_RecordFieldLoader, "name", "type")
+Record_name: TypeAlias = Literal["record"]
+Record_nameLoader: Final[Loader[Record_name]] = _EnumLoader[Record_name](
+    ("record",), "Record_name"
 )
-Record_nameLoader: Final = _EnumLoader(("record",), "Record_name")
-typedsl_Record_nameLoader_2: Final = _TypeDSLLoader(Record_nameLoader, 2, "v1.1")
-union_of_None_type_or_strtype: Final = _UnionLoader(
+typedsl_Record_nameLoader_2: Final[Loader[Record_name]] = _TypeDSLLoader[Record_name](
+    Record_nameLoader, 2, "v1.1"
+)
+union_of_None_type_or_strtype: Final[Loader[None | str]] = _UnionLoader(
     (
         None_type,
         strtype,
     )
 )
-uri_union_of_None_type_or_strtype_True_False_None_None: Final = _URILoader(
-    union_of_None_type_or_strtype, True, False, None, None
+uri_union_of_None_type_or_strtype_True_False_None_None: Final[Loader[None | str]] = (
+    _URILoader(union_of_None_type_or_strtype, True, False, None, None)
 )
-uri_array_of_strtype_True_False_None_None: Final = _URILoader(
+uri_array_of_strtype_True_False_None_None: Final[Loader[Sequence[str]]] = _URILoader(
     array_of_strtype, True, False, None, None
 )
-Enum_nameLoader: Final = _EnumLoader(("enum",), "Enum_name")
-typedsl_Enum_nameLoader_2: Final = _TypeDSLLoader(Enum_nameLoader, 2, "v1.1")
-uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+Enum_name: TypeAlias = Literal["enum"]
+Enum_nameLoader: Final[Loader[Enum_name]] = _EnumLoader[Enum_name](
+    ("enum",), "Enum_name"
+)
+typedsl_Enum_nameLoader_2: Final[Loader[Enum_name]] = _TypeDSLLoader[Enum_name](
+    Enum_nameLoader, 2, "v1.1"
+)
+uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        PrimitiveType
+        | Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _URILoader(
     union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-Array_nameLoader: Final = _EnumLoader(("array",), "Array_name")
-typedsl_Array_nameLoader_2: Final = _TypeDSLLoader(Array_nameLoader, 2, "v1.1")
-Map_nameLoader: Final = _EnumLoader(("map",), "Map_name")
-typedsl_Map_nameLoader_2: Final = _TypeDSLLoader(Map_nameLoader, 2, "v1.1")
-Union_nameLoader: Final = _EnumLoader(("union",), "Union_name")
-typedsl_Union_nameLoader_2: Final = _TypeDSLLoader(Union_nameLoader, 2, "v1.1")
-union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+Array_name: TypeAlias = Literal["array"]
+Array_nameLoader: Final[Loader[Array_name]] = _EnumLoader[Array_name](
+    ("array",), "Array_name"
+)
+typedsl_Array_nameLoader_2: Final[Loader[Array_name]] = _TypeDSLLoader[Array_name](
+    Array_nameLoader, 2, "v1.1"
+)
+Map_name: TypeAlias = Literal["map"]
+Map_nameLoader: Final[Loader[Map_name]] = _EnumLoader[Map_name](("map",), "Map_name")
+typedsl_Map_nameLoader_2: Final[Loader[Map_name]] = _TypeDSLLoader[Map_name](
+    Map_nameLoader, 2, "v1.1"
+)
+Union_name: TypeAlias = Literal["union"]
+Union_nameLoader: Final[Loader[Union_name]] = _EnumLoader[Union_name](
+    ("union",), "Union_name"
+)
+typedsl_Union_nameLoader_2: Final[Loader[Union_name]] = _TypeDSLLoader[Union_name](
+    Union_nameLoader, 2, "v1.1"
+)
+union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         CWLRecordSchemaLoader,
@@ -24856,14 +26836,35 @@ union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWL
         strtype,
     )
 )
-array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
     union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype
 )
-union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         CWLRecordSchemaLoader,
@@ -24873,65 +26874,114 @@ union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWL
         array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype,
     )
 )
-uri_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+uri_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _URILoader(
     union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-typedsl_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLArraySchema
+    | CWLRecordSchema
+    | PrimitiveType
+    | Sequence[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+    | schema_salad.metaschema.EnumSchema
+    | str
+](
     union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_CWLRecordFieldLoader: Final = _ArrayLoader(CWLRecordFieldLoader)
-union_of_None_type_or_array_of_CWLRecordFieldLoader: Final = _UnionLoader(
+array_of_CWLRecordFieldLoader: Final[Loader[Sequence[CWLRecordField]]] = _ArrayLoader(
+    CWLRecordFieldLoader
+)
+union_of_None_type_or_array_of_CWLRecordFieldLoader: Final[
+    Loader[None | Sequence[CWLRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_CWLRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_CWLRecordFieldLoader: Final = _IdMapLoader(
-    union_of_None_type_or_array_of_CWLRecordFieldLoader, "name", "type"
+idmap_fields_union_of_None_type_or_array_of_CWLRecordFieldLoader: Final[
+    Loader[None | Sequence[CWLRecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_CWLRecordFieldLoader, "name", "type")
+File_class: TypeAlias = Literal["File"]
+File_classLoader: Final[Loader[File_class]] = _EnumLoader[File_class](
+    ("File",), "File_class"
 )
-File_classLoader: Final = _EnumLoader(("File",), "File_class")
-uri_File_classLoader_False_True_None_None: Final = _URILoader(
+uri_File_classLoader_False_True_None_None: Final[Loader[File_class]] = _URILoader(
     File_classLoader, False, True, None, None
 )
-uri_union_of_None_type_or_strtype_False_False_None_None: Final = _URILoader(
-    union_of_None_type_or_strtype, False, False, None, None
+uri_union_of_None_type_or_strtype_False_False_None_None: Final[Loader[None | str]] = (
+    _URILoader(union_of_None_type_or_strtype, False, False, None, None)
 )
-union_of_None_type_or_inttype: Final = _UnionLoader(
-    (
-        None_type,
-        inttype,
+union_of_None_type_or_inttype_or_longtype: Final[Loader[None | i32 | i64]] = (
+    _UnionLoader(
+        (
+            None_type,
+            inttype,
+            longtype,
+        )
     )
 )
-union_of_FileLoader_or_DirectoryLoader: Final = _UnionLoader(
+union_of_FileLoader_or_DirectoryLoader: Final[Loader[Directory | File]] = _UnionLoader(
     (
         FileLoader,
         DirectoryLoader,
     )
 )
-array_of_union_of_FileLoader_or_DirectoryLoader: Final = _ArrayLoader(
-    union_of_FileLoader_or_DirectoryLoader
-)
-union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final = (
-    _UnionLoader(
-        (
-            None_type,
-            array_of_union_of_FileLoader_or_DirectoryLoader,
-        )
+array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[Sequence[Directory | File]]
+] = _ArrayLoader(union_of_FileLoader_or_DirectoryLoader)
+union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[None | Sequence[Directory | File]]
+] = _UnionLoader(
+    (
+        None_type,
+        array_of_union_of_FileLoader_or_DirectoryLoader,
     )
 )
-secondaryfilesdsl_union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader: (
-    Final
-) = _UnionLoader(
+secondaryfilesdsl_union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[None | Sequence[Directory | File]]
+] = _UnionLoader(
     (
         _SecondaryDSLLoader(
             union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader
@@ -24939,28 +26989,35 @@ secondaryfilesdsl_union_of_None_type_or_array_of_union_of_FileLoader_or_Director
         union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader,
     )
 )
-uri_union_of_None_type_or_strtype_True_False_None_True: Final = _URILoader(
-    union_of_None_type_or_strtype, True, False, None, True
+uri_union_of_None_type_or_strtype_True_False_None_True: Final[Loader[None | str]] = (
+    _URILoader(union_of_None_type_or_strtype, True, False, None, True)
 )
-Directory_classLoader: Final = _EnumLoader(("Directory",), "Directory_class")
-uri_Directory_classLoader_False_True_None_None: Final = _URILoader(
-    Directory_classLoader, False, True, None, None
+Directory_class: TypeAlias = Literal["Directory"]
+Directory_classLoader: Final[Loader[Directory_class]] = _EnumLoader[Directory_class](
+    ("Directory",), "Directory_class"
 )
-union_of_None_type_or_booltype: Final = _UnionLoader(
+uri_Directory_classLoader_False_True_None_None: Final[Loader[Directory_class]] = (
+    _URILoader(Directory_classLoader, False, True, None, None)
+)
+union_of_None_type_or_booltype: Final[Loader[None | bool]] = _UnionLoader(
     (
         None_type,
         booltype,
     )
 )
-union_of_None_type_or_LoadListingEnumLoader: Final = _UnionLoader(
-    (
-        None_type,
-        LoadListingEnumLoader,
+union_of_None_type_or_LoadListingEnumLoader: Final[Loader[LoadListingEnum | None]] = (
+    _UnionLoader(
+        (
+            None_type,
+            LoadListingEnumLoader,
+        )
     )
 )
-array_of_SecondaryFileSchemaLoader: Final = _ArrayLoader(SecondaryFileSchemaLoader)
+array_of_SecondaryFileSchemaLoader: Final[Loader[Sequence[SecondaryFileSchema]]] = (
+    _ArrayLoader(SecondaryFileSchemaLoader)
+)
 union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaLoader: (
-    Final
+    Final[Loader[None | SecondaryFileSchema | Sequence[SecondaryFileSchema]]]
 ) = _UnionLoader(
     (
         None_type,
@@ -24968,9 +27025,9 @@ union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaL
         array_of_SecondaryFileSchemaLoader,
     )
 )
-secondaryfilesdsl_union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaLoader: (
-    Final
-) = _UnionLoader(
+secondaryfilesdsl_union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaLoader: Final[
+    Loader[None | SecondaryFileSchema | Sequence[SecondaryFileSchema]]
+] = _UnionLoader(
     (
         _SecondaryDSLLoader(
             union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaLoader
@@ -24978,56 +27035,51 @@ secondaryfilesdsl_union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_Se
         union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaLoader,
     )
 )
-union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader: Final = (
-    _UnionLoader(
-        (
-            None_type,
-            strtype,
-            array_of_strtype,
-            ExpressionLoader,
-        )
+union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader: Final[
+    Loader[None | Sequence[str] | str]
+] = _UnionLoader(
+    (
+        None_type,
+        strtype,
+        array_of_strtype,
+        ExpressionLoader,
     )
 )
-uri_union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader_True_False_None_True: (
-    Final
-) = _URILoader(
+uri_union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader_True_False_None_True: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(
     union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader,
     True,
     False,
     None,
     True,
 )
-union_of_None_type_or_strtype_or_ExpressionLoader: Final = _UnionLoader(
-    (
-        None_type,
-        strtype,
-        ExpressionLoader,
+union_of_None_type_or_strtype_or_ExpressionLoader: Final[Loader[None | str]] = (
+    _UnionLoader(
+        (
+            None_type,
+            strtype,
+            ExpressionLoader,
+        )
     )
 )
-uri_union_of_None_type_or_strtype_or_ExpressionLoader_True_False_None_True: Final = (
-    _URILoader(
-        union_of_None_type_or_strtype_or_ExpressionLoader, True, False, None, True
-    )
+uri_union_of_None_type_or_strtype_or_ExpressionLoader_True_False_None_True: Final[
+    Loader[None | str]
+] = _URILoader(
+    union_of_None_type_or_strtype_or_ExpressionLoader, True, False, None, True
 )
-union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        InputRecordSchemaLoader,
-        InputEnumSchemaLoader,
-        InputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | InputArraySchema
+        | InputEnumSchema
+        | InputRecordSchema
+        | Sequence[
+            CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         InputRecordSchemaLoader,
@@ -25037,51 +27089,73 @@ union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_In
         array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | InputArraySchema
+        | InputEnumSchema
+        | InputRecordSchema
+        | Sequence[
+            CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | InputArraySchema
+    | InputEnumSchema
+    | InputRecordSchema
+    | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+    | str
+](
     union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_InputRecordFieldLoader: Final = _ArrayLoader(InputRecordFieldLoader)
-union_of_None_type_or_array_of_InputRecordFieldLoader: Final = _UnionLoader(
+array_of_InputRecordFieldLoader: Final[Loader[Sequence[InputRecordField]]] = (
+    _ArrayLoader(InputRecordFieldLoader)
+)
+union_of_None_type_or_array_of_InputRecordFieldLoader: Final[
+    Loader[None | Sequence[InputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_InputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_InputRecordFieldLoader: Final = (
-    _IdMapLoader(union_of_None_type_or_array_of_InputRecordFieldLoader, "name", "type")
-)
-uri_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+idmap_fields_union_of_None_type_or_array_of_InputRecordFieldLoader: Final[
+    Loader[None | Sequence[InputRecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_InputRecordFieldLoader, "name", "type")
+uri_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | InputArraySchema
+        | InputEnumSchema
+        | InputRecordSchema
+        | Sequence[
+            CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        OutputRecordSchemaLoader,
-        OutputEnumSchemaLoader,
-        OutputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | OutputArraySchema
+        | OutputEnumSchema
+        | OutputRecordSchema
+        | Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         OutputRecordSchemaLoader,
@@ -25091,218 +27165,302 @@ union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_
         array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | OutputArraySchema
+        | OutputEnumSchema
+        | OutputRecordSchema
+        | Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | OutputArraySchema
+    | OutputEnumSchema
+    | OutputRecordSchema
+    | Sequence[
+        CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+    ]
+    | str
+](
     union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_OutputRecordFieldLoader: Final = _ArrayLoader(OutputRecordFieldLoader)
-union_of_None_type_or_array_of_OutputRecordFieldLoader: Final = _UnionLoader(
+array_of_OutputRecordFieldLoader: Final[Loader[Sequence[OutputRecordField]]] = (
+    _ArrayLoader(OutputRecordFieldLoader)
+)
+union_of_None_type_or_array_of_OutputRecordFieldLoader: Final[
+    Loader[None | Sequence[OutputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_OutputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_OutputRecordFieldLoader: Final = (
-    _IdMapLoader(union_of_None_type_or_array_of_OutputRecordFieldLoader, "name", "type")
-)
-uri_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+idmap_fields_union_of_None_type_or_array_of_OutputRecordFieldLoader: Final[
+    Loader[None | Sequence[OutputRecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_OutputRecordFieldLoader, "name", "type")
+uri_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | OutputArraySchema
+        | OutputEnumSchema
+        | OutputRecordSchema
+        | Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_CommandInputParameterLoader_or_WorkflowInputParameterLoader: Final = (
-    _UnionLoader(
-        (
-            CommandInputParameterLoader,
-            WorkflowInputParameterLoader,
-        )
+union_of_CommandInputParameterLoader_or_WorkflowInputParameterLoader: Final[
+    Loader[CommandInputParameter | WorkflowInputParameter]
+] = _UnionLoader(
+    (
+        CommandInputParameterLoader,
+        WorkflowInputParameterLoader,
     )
 )
-array_of_InputParameter: Final = _ArrayLoader(InputParameterProxyLoader)
-idmap_inputs_array_of_InputParameter: Final = _IdMapLoader(
-    array_of_InputParameter, "id", "type"
+array_of_InputParameterProxyLoader: Final[Loader[Sequence[InputParameter]]] = (
+    _ArrayLoader(InputParameterProxyLoader)
 )
-union_of_CommandOutputParameterLoader_or_ExpressionToolOutputParameterLoader_or_WorkflowOutputParameterLoader: (
-    Final
-) = _UnionLoader(
+idmap_inputs_array_of_InputParameterProxyLoader: Final[
+    Loader[Sequence[InputParameter]]
+] = _IdMapLoader(array_of_InputParameterProxyLoader, "id", "type")
+union_of_WorkflowOutputParameterLoader_or_ExpressionToolOutputParameterLoader_or_CommandOutputParameterLoader: Final[
+    Loader[
+        CommandOutputParameter | ExpressionToolOutputParameter | WorkflowOutputParameter
+    ]
+] = _UnionLoader(
     (
-        CommandOutputParameterLoader,
-        ExpressionToolOutputParameterLoader,
         WorkflowOutputParameterLoader,
+        ExpressionToolOutputParameterLoader,
+        CommandOutputParameterLoader,
     )
 )
-array_of_OutputParameter: Final = _ArrayLoader(OutputParameterProxyLoader)
-idmap_outputs_array_of_OutputParameter: Final = _IdMapLoader(
-    array_of_OutputParameter, "id", "type"
+array_of_OutputParameterProxyLoader: Final[Loader[Sequence[OutputParameter]]] = (
+    _ArrayLoader(OutputParameterProxyLoader)
 )
-union_of_None_type_or_array_of_ProcessRequirement: Final = _UnionLoader(
+idmap_outputs_array_of_OutputParameterProxyLoader: Final[
+    Loader[Sequence[OutputParameter]]
+] = _IdMapLoader(array_of_OutputParameterProxyLoader, "id", "type")
+union_of_CUDARequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_EnvVarRequirementLoader_or_SoftwareRequirementLoader_or_ShellCommandRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_NetworkAccessLoader_or_ScatterFeatureRequirementLoader_or_ShmSizeLoader_or_InlineJavascriptRequirementLoader_or_WorkReuseLoader_or_SecretsLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_DockerRequirementLoader_or_MPIRequirementLoader_or_InitialWorkDirRequirementLoader: Final[
+    Loader[
+        CUDARequirement
+        | DockerRequirement
+        | EnvVarRequirement
+        | InitialWorkDirRequirement
+        | InlineJavascriptRequirement
+        | InplaceUpdateRequirement
+        | LoadListingRequirement
+        | MPIRequirement
+        | MultipleInputFeatureRequirement
+        | NetworkAccess
+        | ResourceRequirement
+        | ScatterFeatureRequirement
+        | SchemaDefRequirement
+        | Secrets
+        | ShellCommandRequirement
+        | ShmSize
+        | SoftwareRequirement
+        | StepInputExpressionRequirement
+        | SubworkflowFeatureRequirement
+        | ToolTimeLimit
+        | WorkReuse
+    ]
+] = _UnionLoader(
     (
-        None_type,
-        array_of_ProcessRequirement,
-    )
-)
-idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement: Final = (
-    _IdMapLoader(union_of_None_type_or_array_of_ProcessRequirement, "class", "None")
-)
-union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
-) = _UnionLoader(
-    (
-        InlineJavascriptRequirementLoader,
+        CUDARequirementLoader,
+        ResourceRequirementLoader,
+        SubworkflowFeatureRequirementLoader,
+        StepInputExpressionRequirementLoader,
+        EnvVarRequirementLoader,
+        SoftwareRequirementLoader,
+        ShellCommandRequirementLoader,
+        MultipleInputFeatureRequirementLoader,
         SchemaDefRequirementLoader,
         LoadListingRequirementLoader,
-        DockerRequirementLoader,
-        SoftwareRequirementLoader,
-        InitialWorkDirRequirementLoader,
-        EnvVarRequirementLoader,
-        ShellCommandRequirementLoader,
-        ResourceRequirementLoader,
-        WorkReuseLoader,
         NetworkAccessLoader,
+        ScatterFeatureRequirementLoader,
+        ShmSizeLoader,
+        InlineJavascriptRequirementLoader,
+        WorkReuseLoader,
+        SecretsLoader,
         InplaceUpdateRequirementLoader,
         ToolTimeLimitLoader,
-        SubworkflowFeatureRequirementLoader,
-        ScatterFeatureRequirementLoader,
-        MultipleInputFeatureRequirementLoader,
-        StepInputExpressionRequirementLoader,
-        SecretsLoader,
+        DockerRequirementLoader,
         MPIRequirementLoader,
-        CUDARequirementLoader,
-        ShmSizeLoader,
+        InitialWorkDirRequirementLoader,
+    )
+)
+union_of_None_type_or_array_of_ProcessRequirementProxyLoader: Final[
+    Loader[None | Sequence[ProcessRequirement]]
+] = _UnionLoader(
+    (
+        None_type,
+        array_of_ProcessRequirementProxyLoader,
+    )
+)
+idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader: Final[
+    Loader[None | Sequence[ProcessRequirement]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_ProcessRequirementProxyLoader, "class", "None"
+)
+union_of_ProcessRequirementProxyLoader_or_Any_type: Final[
+    Loader[Any | ProcessRequirement]
+] = _UnionLoader(
+    (
+        ProcessRequirementProxyLoader,
         Any_type,
     )
 )
-array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
-) = _ArrayLoader(
-    union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type
-)
-union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
+array_of_union_of_ProcessRequirementProxyLoader_or_Any_type: Final[
+    Loader[Sequence[Any | ProcessRequirement]]
+] = _ArrayLoader(union_of_ProcessRequirementProxyLoader_or_Any_type)
+union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type: (
+    Final[Loader[None | Sequence[Any | ProcessRequirement]]]
 ) = _UnionLoader(
     (
         None_type,
-        array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
+        array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
     )
 )
-idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
-) = _IdMapLoader(
-    union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader_or_Any_type,
+idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type: Final[
+    Loader[None | Sequence[Any | ProcessRequirement]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
     "class",
     "None",
 )
-union_of_None_type_or_CWLVersionLoader: Final = _UnionLoader(
+union_of_None_type_or_CWLVersionLoader: Final[Loader[CWLVersion | None]] = _UnionLoader(
     (
         None_type,
         CWLVersionLoader,
     )
 )
-uri_union_of_None_type_or_CWLVersionLoader_False_True_None_None: Final = _URILoader(
-    union_of_None_type_or_CWLVersionLoader, False, True, None, None
-)
-InlineJavascriptRequirement_classLoader: Final = _EnumLoader(
+uri_union_of_None_type_or_CWLVersionLoader_False_True_None_None: Final[
+    Loader[CWLVersion | None]
+] = _URILoader(union_of_None_type_or_CWLVersionLoader, False, True, None, None)
+InlineJavascriptRequirement_class: TypeAlias = Literal["InlineJavascriptRequirement"]
+InlineJavascriptRequirement_classLoader: Final[
+    Loader[InlineJavascriptRequirement_class]
+] = _EnumLoader[InlineJavascriptRequirement_class](
     ("InlineJavascriptRequirement",), "InlineJavascriptRequirement_class"
 )
-uri_InlineJavascriptRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    InlineJavascriptRequirement_classLoader, False, True, None, None
-)
-union_of_None_type_or_array_of_strtype: Final = _UnionLoader(
-    (
-        None_type,
-        array_of_strtype,
+uri_InlineJavascriptRequirement_classLoader_False_True_None_None: Final[
+    Loader[InlineJavascriptRequirement_class]
+] = _URILoader(InlineJavascriptRequirement_classLoader, False, True, None, None)
+union_of_None_type_or_array_of_strtype: Final[Loader[None | Sequence[str]]] = (
+    _UnionLoader(
+        (
+            None_type,
+            array_of_strtype,
+        )
     )
 )
-SchemaDefRequirement_classLoader: Final = _EnumLoader(
-    ("SchemaDefRequirement",), "SchemaDefRequirement_class"
+SchemaDefRequirement_class: TypeAlias = Literal["SchemaDefRequirement"]
+SchemaDefRequirement_classLoader: Final[Loader[SchemaDefRequirement_class]] = (
+    _EnumLoader[SchemaDefRequirement_class](
+        ("SchemaDefRequirement",), "SchemaDefRequirement_class"
+    )
 )
-uri_SchemaDefRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    SchemaDefRequirement_classLoader, False, True, None, None
-)
-union_of_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader: (
-    Final
-) = _UnionLoader(
+uri_SchemaDefRequirement_classLoader_False_True_None_None: Final[
+    Loader[SchemaDefRequirement_class]
+] = _URILoader(SchemaDefRequirement_classLoader, False, True, None, None)
+union_of_CommandInputArraySchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputRecordSchemaLoader: Final[
+    Loader[CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema]
+] = _UnionLoader(
     (
-        CommandInputRecordSchemaLoader,
-        CommandInputEnumSchemaLoader,
         CommandInputArraySchemaLoader,
+        CommandInputEnumSchemaLoader,
+        CommandInputRecordSchemaLoader,
     )
 )
-array_of_CommandInputSchema: Final = _ArrayLoader(CommandInputSchemaProxyLoader)
-union_of_strtype_or_ExpressionLoader: Final = _UnionLoader(
+array_of_CommandInputSchemaProxyLoader: Final[Loader[Sequence[CommandInputSchema]]] = (
+    _ArrayLoader(CommandInputSchemaProxyLoader)
+)
+union_of_strtype_or_ExpressionLoader: Final[Loader[str]] = _UnionLoader(
     (
         strtype,
         ExpressionLoader,
     )
 )
-union_of_None_type_or_booltype_or_ExpressionLoader: Final = _UnionLoader(
-    (
-        None_type,
-        booltype,
-        ExpressionLoader,
-    )
-)
-LoadListingRequirement_classLoader: Final = _EnumLoader(
-    ("LoadListingRequirement",), "LoadListingRequirement_class"
-)
-uri_LoadListingRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    LoadListingRequirement_classLoader, False, True, None, None
-)
-union_of_None_type_or_inttype_or_ExpressionLoader: Final = _UnionLoader(
-    (
-        None_type,
-        inttype,
-        ExpressionLoader,
-    )
-)
-union_of_None_type_or_strtype_or_ExpressionLoader_or_array_of_strtype: Final = (
+union_of_None_type_or_booltype_or_ExpressionLoader: Final[Loader[None | bool | str]] = (
     _UnionLoader(
         (
             None_type,
-            strtype,
+            booltype,
             ExpressionLoader,
-            array_of_strtype,
         )
     )
 )
-union_of_None_type_or_ExpressionLoader: Final = _UnionLoader(
+LoadListingRequirement_class: TypeAlias = Literal["LoadListingRequirement"]
+LoadListingRequirement_classLoader: Final[Loader[LoadListingRequirement_class]] = (
+    _EnumLoader[LoadListingRequirement_class](
+        ("LoadListingRequirement",), "LoadListingRequirement_class"
+    )
+)
+uri_LoadListingRequirement_classLoader_False_True_None_None: Final[
+    Loader[LoadListingRequirement_class]
+] = _URILoader(LoadListingRequirement_classLoader, False, True, None, None)
+union_of_None_type_or_inttype_or_ExpressionLoader: Final[Loader[None | i32 | str]] = (
+    _UnionLoader(
+        (
+            None_type,
+            inttype,
+            ExpressionLoader,
+        )
+    )
+)
+union_of_None_type_or_strtype_or_ExpressionLoader_or_array_of_strtype: Final[
+    Loader[None | Sequence[str] | str]
+] = _UnionLoader(
+    (
+        None_type,
+        strtype,
+        ExpressionLoader,
+        array_of_strtype,
+    )
+)
+union_of_None_type_or_ExpressionLoader: Final[Loader[None | str]] = _UnionLoader(
     (
         None_type,
         ExpressionLoader,
     )
 )
-union_of_None_type_or_CommandLineBindingLoader: Final = _UnionLoader(
+union_of_None_type_or_CommandLineBindingLoader: Final[
+    Loader[CommandLineBinding | None]
+] = _UnionLoader(
     (
         None_type,
         CommandLineBindingLoader,
     )
 )
-union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        CommandInputRecordSchemaLoader,
-        CommandInputEnumSchemaLoader,
-        CommandInputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         CommandInputRecordSchemaLoader,
@@ -25312,55 +27470,93 @@ union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSche
         array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | CommandInputArraySchema
+    | CommandInputEnumSchema
+    | CommandInputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | str
+    ]
+    | str
+](
     union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_CommandInputRecordFieldLoader: Final = _ArrayLoader(
-    CommandInputRecordFieldLoader
-)
-union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final = _UnionLoader(
+array_of_CommandInputRecordFieldLoader: Final[
+    Loader[Sequence[CommandInputRecordField]]
+] = _ArrayLoader(CommandInputRecordFieldLoader)
+union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandInputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_CommandInputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final = (
-    _IdMapLoader(
-        union_of_None_type_or_array_of_CommandInputRecordFieldLoader, "name", "type"
-    )
+idmap_fields_union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandInputRecordField]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_CommandInputRecordFieldLoader, "name", "type"
 )
-uri_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+uri_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        CommandOutputRecordSchemaLoader,
-        CommandOutputEnumSchemaLoader,
-        CommandOutputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         CommandOutputRecordSchemaLoader,
@@ -25370,152 +27566,178 @@ union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSc
         array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | CommandOutputArraySchema
+    | CommandOutputEnumSchema
+    | CommandOutputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | str
+    ]
+    | str
+](
     union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-union_of_None_type_or_CommandOutputBindingLoader: Final = _UnionLoader(
+union_of_None_type_or_CommandOutputBindingLoader: Final[
+    Loader[CommandOutputBinding | None]
+] = _UnionLoader(
     (
         None_type,
         CommandOutputBindingLoader,
     )
 )
-array_of_CommandOutputRecordFieldLoader: Final = _ArrayLoader(
-    CommandOutputRecordFieldLoader
-)
-union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final = _UnionLoader(
+array_of_CommandOutputRecordFieldLoader: Final[
+    Loader[Sequence[CommandOutputRecordField]]
+] = _ArrayLoader(CommandOutputRecordFieldLoader)
+union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandOutputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_CommandOutputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final = (
-    _IdMapLoader(
-        union_of_None_type_or_array_of_CommandOutputRecordFieldLoader, "name", "type"
-    )
+idmap_fields_union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandOutputRecordField]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_CommandOutputRecordFieldLoader, "name", "type"
 )
-uri_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+uri_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_CWLTypeLoader_or_stdinLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        stdinLoader,
-        CommandInputRecordSchemaLoader,
-        CommandInputEnumSchemaLoader,
-        CommandInputArraySchemaLoader,
-        strtype,
-        array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
+typedsl_CommandInputParameterTypeLoader_2: Final[Loader[CommandInputParameterType]] = (
+    _TypeDSLLoader[CommandInputParameterType](
+        CommandInputParameterTypeLoader, 2, "v1.1"
     )
 )
-typedsl_union_of_CWLTypeLoader_or_stdinLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
-    union_of_CWLTypeLoader_or_stdinLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
-    2,
-    "v1.1",
+typedsl_CommandOutputParameterTypeLoader_2: Final[
+    Loader[CommandOutputParameterType]
+] = _TypeDSLLoader[CommandOutputParameterType](
+    CommandOutputParameterTypeLoader, 2, "v1.1"
 )
-union_of_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        stdoutLoader,
-        stderrLoader,
-        CommandOutputRecordSchemaLoader,
-        CommandOutputEnumSchemaLoader,
-        CommandOutputArraySchemaLoader,
-        strtype,
-        array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
-    )
+CommandLineTool_class: TypeAlias = Literal["CommandLineTool"]
+CommandLineTool_classLoader: Final[Loader[CommandLineTool_class]] = _EnumLoader[
+    CommandLineTool_class
+](("CommandLineTool",), "CommandLineTool_class")
+uri_CommandLineTool_classLoader_False_True_None_None: Final[
+    Loader[CommandLineTool_class]
+] = _URILoader(CommandLineTool_classLoader, False, True, None, None)
+array_of_CommandInputParameterLoader: Final[Loader[Sequence[CommandInputParameter]]] = (
+    _ArrayLoader(CommandInputParameterLoader)
 )
-typedsl_union_of_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
-    union_of_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
-    2,
-    "v1.1",
-)
-CommandLineTool_classLoader: Final = _EnumLoader(
-    ("CommandLineTool",), "CommandLineTool_class"
-)
-uri_CommandLineTool_classLoader_False_True_None_None: Final = _URILoader(
-    CommandLineTool_classLoader, False, True, None, None
-)
-array_of_CommandInputParameterLoader: Final = _ArrayLoader(CommandInputParameterLoader)
-idmap_inputs_array_of_CommandInputParameterLoader: Final = _IdMapLoader(
-    array_of_CommandInputParameterLoader, "id", "type"
-)
-array_of_CommandOutputParameterLoader: Final = _ArrayLoader(
-    CommandOutputParameterLoader
-)
-idmap_outputs_array_of_CommandOutputParameterLoader: Final = _IdMapLoader(
-    array_of_CommandOutputParameterLoader, "id", "type"
-)
-union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final = _UnionLoader(
+idmap_inputs_array_of_CommandInputParameterLoader: Final[
+    Loader[Sequence[CommandInputParameter]]
+] = _IdMapLoader(array_of_CommandInputParameterLoader, "id", "type")
+array_of_CommandOutputParameterLoader: Final[
+    Loader[Sequence[CommandOutputParameter]]
+] = _ArrayLoader(CommandOutputParameterLoader)
+idmap_outputs_array_of_CommandOutputParameterLoader: Final[
+    Loader[Sequence[CommandOutputParameter]]
+] = _IdMapLoader(array_of_CommandOutputParameterLoader, "id", "type")
+union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final[
+    Loader[CommandLineBinding | str]
+] = _UnionLoader(
     (
         strtype,
         ExpressionLoader,
         CommandLineBindingLoader,
     )
 )
-array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final = (
-    _ArrayLoader(union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader)
-)
-union_of_None_type_or_array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: (
-    Final
-) = _UnionLoader(
+array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final[
+    Loader[Sequence[CommandLineBinding | str]]
+] = _ArrayLoader(union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader)
+union_of_None_type_or_array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final[
+    Loader[None | Sequence[CommandLineBinding | str]]
+] = _UnionLoader(
     (
         None_type,
         array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader,
     )
 )
-array_of_inttype: Final = _ArrayLoader(inttype)
-union_of_None_type_or_array_of_inttype: Final = _UnionLoader(
-    (
-        None_type,
-        array_of_inttype,
+array_of_inttype: Final[Loader[Sequence[i32]]] = _ArrayLoader(inttype)
+union_of_None_type_or_array_of_inttype: Final[Loader[None | Sequence[i32]]] = (
+    _UnionLoader(
+        (
+            None_type,
+            array_of_inttype,
+        )
     )
 )
-DockerRequirement_classLoader: Final = _EnumLoader(
-    ("DockerRequirement",), "DockerRequirement_class"
+DockerRequirement_class: TypeAlias = Literal["DockerRequirement"]
+DockerRequirement_classLoader: Final[Loader[DockerRequirement_class]] = _EnumLoader[
+    DockerRequirement_class
+](("DockerRequirement",), "DockerRequirement_class")
+uri_DockerRequirement_classLoader_False_True_None_None: Final[
+    Loader[DockerRequirement_class]
+] = _URILoader(DockerRequirement_classLoader, False, True, None, None)
+SoftwareRequirement_class: TypeAlias = Literal["SoftwareRequirement"]
+SoftwareRequirement_classLoader: Final[Loader[SoftwareRequirement_class]] = _EnumLoader[
+    SoftwareRequirement_class
+](("SoftwareRequirement",), "SoftwareRequirement_class")
+uri_SoftwareRequirement_classLoader_False_True_None_None: Final[
+    Loader[SoftwareRequirement_class]
+] = _URILoader(SoftwareRequirement_classLoader, False, True, None, None)
+array_of_SoftwarePackageLoader: Final[Loader[Sequence[SoftwarePackage]]] = _ArrayLoader(
+    SoftwarePackageLoader
 )
-uri_DockerRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    DockerRequirement_classLoader, False, True, None, None
-)
-SoftwareRequirement_classLoader: Final = _EnumLoader(
-    ("SoftwareRequirement",), "SoftwareRequirement_class"
-)
-uri_SoftwareRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    SoftwareRequirement_classLoader, False, True, None, None
-)
-array_of_SoftwarePackageLoader: Final = _ArrayLoader(SoftwarePackageLoader)
-idmap_packages_array_of_SoftwarePackageLoader: Final = _IdMapLoader(
-    array_of_SoftwarePackageLoader, "package", "specs"
-)
-uri_union_of_None_type_or_array_of_strtype_False_False_None_True: Final = _URILoader(
-    union_of_None_type_or_array_of_strtype, False, False, None, True
-)
-InitialWorkDirRequirement_classLoader: Final = _EnumLoader(
+idmap_packages_array_of_SoftwarePackageLoader: Final[
+    Loader[Sequence[SoftwarePackage]]
+] = _IdMapLoader(array_of_SoftwarePackageLoader, "package", "specs")
+uri_union_of_None_type_or_array_of_strtype_False_False_None_True: Final[
+    Loader[None | Sequence[str]]
+] = _URILoader(union_of_None_type_or_array_of_strtype, False, False, None, True)
+InitialWorkDirRequirement_class: TypeAlias = Literal["InitialWorkDirRequirement"]
+InitialWorkDirRequirement_classLoader: Final[
+    Loader[InitialWorkDirRequirement_class]
+] = _EnumLoader[InitialWorkDirRequirement_class](
     ("InitialWorkDirRequirement",), "InitialWorkDirRequirement_class"
 )
-uri_InitialWorkDirRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    InitialWorkDirRequirement_classLoader, False, True, None, None
-)
-union_of_None_type_or_FileLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader_or_DirectoryLoader_or_DirentLoader_or_ExpressionLoader: (
-    Final
-) = _UnionLoader(
+uri_InitialWorkDirRequirement_classLoader_False_True_None_None: Final[
+    Loader[InitialWorkDirRequirement_class]
+] = _URILoader(InitialWorkDirRequirement_classLoader, False, True, None, None)
+union_of_None_type_or_FileLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader_or_DirectoryLoader_or_DirentLoader_or_ExpressionLoader: Final[
+    Loader[Directory | Dirent | File | None | Sequence[Directory | File] | str]
+] = _UnionLoader(
     (
         None_type,
         FileLoader,
@@ -25525,232 +27747,314 @@ union_of_None_type_or_FileLoader_or_array_of_union_of_FileLoader_or_DirectoryLoa
         ExpressionLoader,
     )
 )
-array_of_union_of_None_type_or_FileLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader_or_DirectoryLoader_or_DirentLoader_or_ExpressionLoader: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_None_type_or_FileLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader_or_DirectoryLoader_or_DirentLoader_or_ExpressionLoader: Final[
+    Loader[
+        Sequence[Directory | Dirent | File | None | Sequence[Directory | File] | str]
+    ]
+] = _ArrayLoader(
     union_of_None_type_or_FileLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader_or_DirectoryLoader_or_DirentLoader_or_ExpressionLoader
 )
-union_of_array_of_union_of_None_type_or_FileLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader_or_DirectoryLoader_or_DirentLoader_or_ExpressionLoader_or_ExpressionLoader: (
-    Final
-) = _UnionLoader(
+union_of_array_of_union_of_None_type_or_FileLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader_or_DirectoryLoader_or_DirentLoader_or_ExpressionLoader_or_ExpressionLoader: Final[
+    Loader[
+        Sequence[Directory | Dirent | File | None | Sequence[Directory | File] | str]
+        | str
+    ]
+] = _UnionLoader(
     (
         array_of_union_of_None_type_or_FileLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader_or_DirectoryLoader_or_DirentLoader_or_ExpressionLoader,
         ExpressionLoader,
     )
 )
-EnvVarRequirement_classLoader: Final = _EnumLoader(
-    ("EnvVarRequirement",), "EnvVarRequirement_class"
+EnvVarRequirement_class: TypeAlias = Literal["EnvVarRequirement"]
+EnvVarRequirement_classLoader: Final[Loader[EnvVarRequirement_class]] = _EnumLoader[
+    EnvVarRequirement_class
+](("EnvVarRequirement",), "EnvVarRequirement_class")
+uri_EnvVarRequirement_classLoader_False_True_None_None: Final[
+    Loader[EnvVarRequirement_class]
+] = _URILoader(EnvVarRequirement_classLoader, False, True, None, None)
+array_of_EnvironmentDefLoader: Final[Loader[Sequence[EnvironmentDef]]] = _ArrayLoader(
+    EnvironmentDefLoader
 )
-uri_EnvVarRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    EnvVarRequirement_classLoader, False, True, None, None
+idmap_envDef_array_of_EnvironmentDefLoader: Final[Loader[Sequence[EnvironmentDef]]] = (
+    _IdMapLoader(array_of_EnvironmentDefLoader, "envName", "envValue")
 )
-array_of_EnvironmentDefLoader: Final = _ArrayLoader(EnvironmentDefLoader)
-idmap_envDef_array_of_EnvironmentDefLoader: Final = _IdMapLoader(
-    array_of_EnvironmentDefLoader, "envName", "envValue"
+ShellCommandRequirement_class: TypeAlias = Literal["ShellCommandRequirement"]
+ShellCommandRequirement_classLoader: Final[Loader[ShellCommandRequirement_class]] = (
+    _EnumLoader[ShellCommandRequirement_class](
+        ("ShellCommandRequirement",), "ShellCommandRequirement_class"
+    )
 )
-ShellCommandRequirement_classLoader: Final = _EnumLoader(
-    ("ShellCommandRequirement",), "ShellCommandRequirement_class"
+uri_ShellCommandRequirement_classLoader_False_True_None_None: Final[
+    Loader[ShellCommandRequirement_class]
+] = _URILoader(ShellCommandRequirement_classLoader, False, True, None, None)
+ResourceRequirement_class: TypeAlias = Literal["ResourceRequirement"]
+ResourceRequirement_classLoader: Final[Loader[ResourceRequirement_class]] = _EnumLoader[
+    ResourceRequirement_class
+](("ResourceRequirement",), "ResourceRequirement_class")
+uri_ResourceRequirement_classLoader_False_True_None_None: Final[
+    Loader[ResourceRequirement_class]
+] = _URILoader(ResourceRequirement_classLoader, False, True, None, None)
+union_of_None_type_or_inttype_or_longtype_or_ExpressionLoader: Final[
+    Loader[None | i32 | i64 | str]
+] = _UnionLoader(
+    (
+        None_type,
+        inttype,
+        longtype,
+        ExpressionLoader,
+    )
 )
-uri_ShellCommandRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    ShellCommandRequirement_classLoader, False, True, None, None
+WorkReuse_class: TypeAlias = Literal["WorkReuse"]
+WorkReuse_classLoader: Final[Loader[WorkReuse_class]] = _EnumLoader[WorkReuse_class](
+    ("WorkReuse",), "WorkReuse_class"
 )
-ResourceRequirement_classLoader: Final = _EnumLoader(
-    ("ResourceRequirement",), "ResourceRequirement_class"
+uri_WorkReuse_classLoader_False_True_None_None: Final[Loader[WorkReuse_class]] = (
+    _URILoader(WorkReuse_classLoader, False, True, None, None)
 )
-uri_ResourceRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    ResourceRequirement_classLoader, False, True, None, None
-)
-WorkReuse_classLoader: Final = _EnumLoader(("WorkReuse",), "WorkReuse_class")
-uri_WorkReuse_classLoader_False_True_None_None: Final = _URILoader(
-    WorkReuse_classLoader, False, True, None, None
-)
-union_of_booltype_or_ExpressionLoader: Final = _UnionLoader(
+union_of_booltype_or_ExpressionLoader: Final[Loader[bool | str]] = _UnionLoader(
     (
         booltype,
         ExpressionLoader,
     )
 )
-NetworkAccess_classLoader: Final = _EnumLoader(
-    ("NetworkAccess",), "NetworkAccess_class"
-)
-uri_NetworkAccess_classLoader_False_True_None_None: Final = _URILoader(
-    NetworkAccess_classLoader, False, True, None, None
-)
-InplaceUpdateRequirement_classLoader: Final = _EnumLoader(
-    ("InplaceUpdateRequirement",), "InplaceUpdateRequirement_class"
-)
-uri_InplaceUpdateRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    InplaceUpdateRequirement_classLoader, False, True, None, None
-)
-ToolTimeLimit_classLoader: Final = _EnumLoader(
-    ("ToolTimeLimit",), "ToolTimeLimit_class"
-)
-uri_ToolTimeLimit_classLoader_False_True_None_None: Final = _URILoader(
-    ToolTimeLimit_classLoader, False, True, None, None
-)
-union_of_inttype_or_ExpressionLoader: Final = _UnionLoader(
-    (
-        inttype,
-        ExpressionLoader,
+NetworkAccess_class: TypeAlias = Literal["NetworkAccess"]
+NetworkAccess_classLoader: Final[Loader[NetworkAccess_class]] = _EnumLoader[
+    NetworkAccess_class
+](("NetworkAccess",), "NetworkAccess_class")
+uri_NetworkAccess_classLoader_False_True_None_None: Final[
+    Loader[NetworkAccess_class]
+] = _URILoader(NetworkAccess_classLoader, False, True, None, None)
+InplaceUpdateRequirement_class: TypeAlias = Literal["InplaceUpdateRequirement"]
+InplaceUpdateRequirement_classLoader: Final[Loader[InplaceUpdateRequirement_class]] = (
+    _EnumLoader[InplaceUpdateRequirement_class](
+        ("InplaceUpdateRequirement",), "InplaceUpdateRequirement_class"
     )
 )
-union_of_None_type_or_InputBindingLoader: Final = _UnionLoader(
-    (
-        None_type,
-        InputBindingLoader,
+uri_InplaceUpdateRequirement_classLoader_False_True_None_None: Final[
+    Loader[InplaceUpdateRequirement_class]
+] = _URILoader(InplaceUpdateRequirement_classLoader, False, True, None, None)
+ToolTimeLimit_class: TypeAlias = Literal["ToolTimeLimit"]
+ToolTimeLimit_classLoader: Final[Loader[ToolTimeLimit_class]] = _EnumLoader[
+    ToolTimeLimit_class
+](("ToolTimeLimit",), "ToolTimeLimit_class")
+uri_ToolTimeLimit_classLoader_False_True_None_None: Final[
+    Loader[ToolTimeLimit_class]
+] = _URILoader(ToolTimeLimit_classLoader, False, True, None, None)
+union_of_inttype_or_longtype_or_ExpressionLoader: Final[Loader[i32 | i64 | str]] = (
+    _UnionLoader(
+        (
+            inttype,
+            longtype,
+            ExpressionLoader,
+        )
     )
 )
-ExpressionTool_classLoader: Final = _EnumLoader(
-    ("ExpressionTool",), "ExpressionTool_class"
+typedsl_OutputParameterTypeLoader_2: Final[Loader[OutputParameterType]] = (
+    _TypeDSLLoader[OutputParameterType](OutputParameterTypeLoader, 2, "v1.1")
 )
-uri_ExpressionTool_classLoader_False_True_None_None: Final = _URILoader(
-    ExpressionTool_classLoader, False, True, None, None
-)
-array_of_WorkflowInputParameterLoader: Final = _ArrayLoader(
-    WorkflowInputParameterLoader
-)
-idmap_inputs_array_of_WorkflowInputParameterLoader: Final = _IdMapLoader(
-    array_of_WorkflowInputParameterLoader, "id", "type"
-)
-array_of_ExpressionToolOutputParameterLoader: Final = _ArrayLoader(
-    ExpressionToolOutputParameterLoader
-)
-idmap_outputs_array_of_ExpressionToolOutputParameterLoader: Final = _IdMapLoader(
-    array_of_ExpressionToolOutputParameterLoader, "id", "type"
-)
-uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None: Final = (
-    _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 1, None)
-)
-union_of_None_type_or_LinkMergeMethodLoader: Final = _UnionLoader(
-    (
-        None_type,
-        LinkMergeMethodLoader,
+typedsl_InputParameterTypeLoader_2: Final[Loader[InputParameterType]] = _TypeDSLLoader[
+    InputParameterType
+](InputParameterTypeLoader, 2, "v1.1")
+union_of_None_type_or_InputBindingLoader: Final[Loader[InputBinding | None]] = (
+    _UnionLoader(
+        (
+            None_type,
+            InputBindingLoader,
+        )
     )
 )
-uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_2_None: Final = (
-    _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 2, None)
+ExpressionTool_class: TypeAlias = Literal["ExpressionTool"]
+ExpressionTool_classLoader: Final[Loader[ExpressionTool_class]] = _EnumLoader[
+    ExpressionTool_class
+](("ExpressionTool",), "ExpressionTool_class")
+uri_ExpressionTool_classLoader_False_True_None_None: Final[
+    Loader[ExpressionTool_class]
+] = _URILoader(ExpressionTool_classLoader, False, True, None, None)
+array_of_WorkflowInputParameterLoader: Final[
+    Loader[Sequence[WorkflowInputParameter]]
+] = _ArrayLoader(WorkflowInputParameterLoader)
+idmap_inputs_array_of_WorkflowInputParameterLoader: Final[
+    Loader[Sequence[WorkflowInputParameter]]
+] = _IdMapLoader(array_of_WorkflowInputParameterLoader, "id", "type")
+array_of_ExpressionToolOutputParameterLoader: Final[
+    Loader[Sequence[ExpressionToolOutputParameter]]
+] = _ArrayLoader(ExpressionToolOutputParameterLoader)
+idmap_outputs_array_of_ExpressionToolOutputParameterLoader: Final[
+    Loader[Sequence[ExpressionToolOutputParameter]]
+] = _IdMapLoader(array_of_ExpressionToolOutputParameterLoader, "id", "type")
+uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 1, None)
+union_of_None_type_or_LinkMergeMethodLoader: Final[Loader[LinkMergeMethod | None]] = (
+    _UnionLoader(
+        (
+            None_type,
+            LinkMergeMethodLoader,
+        )
+    )
 )
-array_of_WorkflowStepInputLoader: Final = _ArrayLoader(WorkflowStepInputLoader)
-idmap_in__array_of_WorkflowStepInputLoader: Final = _IdMapLoader(
-    array_of_WorkflowStepInputLoader, "id", "source"
+uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_2_None: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 2, None)
+array_of_WorkflowStepInputLoader: Final[Loader[Sequence[WorkflowStepInput]]] = (
+    _ArrayLoader(WorkflowStepInputLoader)
 )
-union_of_strtype_or_WorkflowStepOutputLoader: Final = _UnionLoader(
+idmap_in__array_of_WorkflowStepInputLoader: Final[
+    Loader[Sequence[WorkflowStepInput]]
+] = _IdMapLoader(array_of_WorkflowStepInputLoader, "id", "source")
+union_of_strtype_or_WorkflowStepOutputLoader: Final[
+    Loader[WorkflowStepOutput | str]
+] = _UnionLoader(
     (
         strtype,
         WorkflowStepOutputLoader,
     )
 )
-array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final = _ArrayLoader(
-    union_of_strtype_or_WorkflowStepOutputLoader
-)
-union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final = _UnionLoader(
-    (array_of_union_of_strtype_or_WorkflowStepOutputLoader,)
-)
-uri_union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader_True_False_None_None: (
-    Final
-) = _URILoader(
+array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final[
+    Loader[Sequence[WorkflowStepOutput | str]]
+] = _ArrayLoader(union_of_strtype_or_WorkflowStepOutputLoader)
+union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final[
+    Loader[Sequence[WorkflowStepOutput | str]]
+] = _UnionLoader((array_of_union_of_strtype_or_WorkflowStepOutputLoader,))
+uri_union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader_True_False_None_None: Final[
+    Loader[Sequence[WorkflowStepOutput | str]]
+] = _URILoader(
     union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader,
     True,
     False,
     None,
     None,
 )
-array_of_Any_type: Final = _ArrayLoader(Any_type)
-union_of_None_type_or_array_of_Any_type: Final = _UnionLoader(
-    (
-        None_type,
-        array_of_Any_type,
+array_of_Any_type: Final[Loader[Sequence[Any]]] = _ArrayLoader(Any_type)
+union_of_None_type_or_array_of_Any_type: Final[Loader[None | Sequence[Any]]] = (
+    _UnionLoader(
+        (
+            None_type,
+            array_of_Any_type,
+        )
     )
 )
-idmap_hints_union_of_None_type_or_array_of_Any_type: Final = _IdMapLoader(
-    union_of_None_type_or_array_of_Any_type, "class", "None"
-)
-union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _UnionLoader(
+idmap_hints_union_of_None_type_or_array_of_Any_type: Final[
+    Loader[None | Sequence[Any]]
+] = _IdMapLoader(union_of_None_type_or_array_of_Any_type, "class", "None")
+union_of_ProcessGeneratorLoader_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader: Final[
+    Loader[CommandLineTool | ExpressionTool | ProcessGenerator | Workflow]
+] = _UnionLoader(
     (
-        strtype,
+        ProcessGeneratorLoader,
         CommandLineToolLoader,
         ExpressionToolLoader,
         WorkflowLoader,
-        ProcessGeneratorLoader,
     )
 )
-uri_union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader_False_False_None_None: (
-    Final
-) = _URILoader(
-    union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader,
-    False,
-    False,
-    None,
-    None,
-)
-uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_0_None: Final = (
-    _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 0, None)
-)
-union_of_None_type_or_ScatterMethodLoader: Final = _UnionLoader(
+union_of_strtype_or_ProcessProxyLoader: Final[Loader[Process | str]] = _UnionLoader(
     (
-        None_type,
-        ScatterMethodLoader,
+        strtype,
+        ProcessProxyLoader,
     )
 )
-uri_union_of_None_type_or_ScatterMethodLoader_False_True_None_None: Final = _URILoader(
-    union_of_None_type_or_ScatterMethodLoader, False, True, None, None
+uri_union_of_strtype_or_ProcessProxyLoader_False_False_None_None: Final[
+    Loader[Process | str]
+] = _URILoader(union_of_strtype_or_ProcessProxyLoader, False, False, None, None)
+uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_0_None: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 0, None)
+union_of_None_type_or_ScatterMethodLoader: Final[Loader[None | ScatterMethod]] = (
+    _UnionLoader(
+        (
+            None_type,
+            ScatterMethodLoader,
+        )
+    )
 )
-Workflow_classLoader: Final = _EnumLoader(("Workflow",), "Workflow_class")
-uri_Workflow_classLoader_False_True_None_None: Final = _URILoader(
-    Workflow_classLoader, False, True, None, None
+uri_union_of_None_type_or_ScatterMethodLoader_False_True_None_None: Final[
+    Loader[None | ScatterMethod]
+] = _URILoader(union_of_None_type_or_ScatterMethodLoader, False, True, None, None)
+Workflow_class: TypeAlias = Literal["Workflow"]
+Workflow_classLoader: Final[Loader[Workflow_class]] = _EnumLoader[Workflow_class](
+    ("Workflow",), "Workflow_class"
 )
-array_of_WorkflowOutputParameterLoader: Final = _ArrayLoader(
-    WorkflowOutputParameterLoader
+uri_Workflow_classLoader_False_True_None_None: Final[Loader[Workflow_class]] = (
+    _URILoader(Workflow_classLoader, False, True, None, None)
 )
-idmap_outputs_array_of_WorkflowOutputParameterLoader: Final = _IdMapLoader(
-    array_of_WorkflowOutputParameterLoader, "id", "type"
+array_of_WorkflowOutputParameterLoader: Final[
+    Loader[Sequence[WorkflowOutputParameter]]
+] = _ArrayLoader(WorkflowOutputParameterLoader)
+idmap_outputs_array_of_WorkflowOutputParameterLoader: Final[
+    Loader[Sequence[WorkflowOutputParameter]]
+] = _IdMapLoader(array_of_WorkflowOutputParameterLoader, "id", "type")
+array_of_WorkflowStepLoader: Final[Loader[Sequence[WorkflowStep]]] = _ArrayLoader(
+    WorkflowStepLoader
 )
-array_of_WorkflowStepLoader: Final = _ArrayLoader(WorkflowStepLoader)
-union_of_array_of_WorkflowStepLoader: Final = _UnionLoader(
-    (array_of_WorkflowStepLoader,)
+union_of_array_of_WorkflowStepLoader: Final[Loader[Sequence[WorkflowStep]]] = (
+    _UnionLoader((array_of_WorkflowStepLoader,))
 )
-idmap_steps_union_of_array_of_WorkflowStepLoader: Final = _IdMapLoader(
-    union_of_array_of_WorkflowStepLoader, "id", "None"
-)
-SubworkflowFeatureRequirement_classLoader: Final = _EnumLoader(
+idmap_steps_union_of_array_of_WorkflowStepLoader: Final[
+    Loader[Sequence[WorkflowStep]]
+] = _IdMapLoader(union_of_array_of_WorkflowStepLoader, "id", "None")
+SubworkflowFeatureRequirement_class: TypeAlias = Literal[
+    "SubworkflowFeatureRequirement"
+]
+SubworkflowFeatureRequirement_classLoader: Final[
+    Loader[SubworkflowFeatureRequirement_class]
+] = _EnumLoader[SubworkflowFeatureRequirement_class](
     ("SubworkflowFeatureRequirement",), "SubworkflowFeatureRequirement_class"
 )
-uri_SubworkflowFeatureRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    SubworkflowFeatureRequirement_classLoader, False, True, None, None
-)
-ScatterFeatureRequirement_classLoader: Final = _EnumLoader(
+uri_SubworkflowFeatureRequirement_classLoader_False_True_None_None: Final[
+    Loader[SubworkflowFeatureRequirement_class]
+] = _URILoader(SubworkflowFeatureRequirement_classLoader, False, True, None, None)
+ScatterFeatureRequirement_class: TypeAlias = Literal["ScatterFeatureRequirement"]
+ScatterFeatureRequirement_classLoader: Final[
+    Loader[ScatterFeatureRequirement_class]
+] = _EnumLoader[ScatterFeatureRequirement_class](
     ("ScatterFeatureRequirement",), "ScatterFeatureRequirement_class"
 )
-uri_ScatterFeatureRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    ScatterFeatureRequirement_classLoader, False, True, None, None
-)
-MultipleInputFeatureRequirement_classLoader: Final = _EnumLoader(
+uri_ScatterFeatureRequirement_classLoader_False_True_None_None: Final[
+    Loader[ScatterFeatureRequirement_class]
+] = _URILoader(ScatterFeatureRequirement_classLoader, False, True, None, None)
+MultipleInputFeatureRequirement_class: TypeAlias = Literal[
+    "MultipleInputFeatureRequirement"
+]
+MultipleInputFeatureRequirement_classLoader: Final[
+    Loader[MultipleInputFeatureRequirement_class]
+] = _EnumLoader[MultipleInputFeatureRequirement_class](
     ("MultipleInputFeatureRequirement",), "MultipleInputFeatureRequirement_class"
 )
-uri_MultipleInputFeatureRequirement_classLoader_False_True_None_None: Final = (
-    _URILoader(MultipleInputFeatureRequirement_classLoader, False, True, None, None)
-)
-StepInputExpressionRequirement_classLoader: Final = _EnumLoader(
+uri_MultipleInputFeatureRequirement_classLoader_False_True_None_None: Final[
+    Loader[MultipleInputFeatureRequirement_class]
+] = _URILoader(MultipleInputFeatureRequirement_classLoader, False, True, None, None)
+StepInputExpressionRequirement_class: TypeAlias = Literal[
+    "StepInputExpressionRequirement"
+]
+StepInputExpressionRequirement_classLoader: Final[
+    Loader[StepInputExpressionRequirement_class]
+] = _EnumLoader[StepInputExpressionRequirement_class](
     ("StepInputExpressionRequirement",), "StepInputExpressionRequirement_class"
 )
-uri_StepInputExpressionRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    StepInputExpressionRequirement_classLoader, False, True, None, None
+uri_StepInputExpressionRequirement_classLoader_False_True_None_None: Final[
+    Loader[StepInputExpressionRequirement_class]
+] = _URILoader(StepInputExpressionRequirement_classLoader, False, True, None, None)
+uri_strtype_False_True_None_None: Final[Loader[str]] = _URILoader(
+    strtype, False, True, None, None
 )
-uri_strtype_False_True_None_None: Final = _URILoader(strtype, False, True, None, None)
-uri_array_of_strtype_False_False_0_None: Final = _URILoader(
+uri_array_of_strtype_False_False_0_None: Final[Loader[Sequence[str]]] = _URILoader(
     array_of_strtype, False, False, 0, None
 )
-union_of_strtype_or_array_of_strtype: Final = _UnionLoader(
+union_of_inttype_or_ExpressionLoader: Final[Loader[i32 | str]] = _UnionLoader(
+    (
+        inttype,
+        ExpressionLoader,
+    )
+)
+union_of_strtype_or_array_of_strtype: Final[Loader[Sequence[str] | str]] = _UnionLoader(
     (
         strtype,
         array_of_strtype,
     )
 )
-union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _UnionLoader(
+union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: Final[
+    Loader[CommandLineTool | ExpressionTool | ProcessGenerator | Workflow]
+] = _UnionLoader(
     (
         CommandLineToolLoader,
         ExpressionToolLoader,
@@ -25758,14 +28062,20 @@ union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_Proc
         ProcessGeneratorLoader,
     )
 )
-array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: Final[
+    Loader[Sequence[CommandLineTool | ExpressionTool | ProcessGenerator | Workflow]]
+] = _ArrayLoader(
     union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader
 )
-union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader_or_array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _UnionLoader(
+union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader_or_array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_ProcessGeneratorLoader: Final[
+    Loader[
+        CommandLineTool
+        | ExpressionTool
+        | ProcessGenerator
+        | Sequence[CommandLineTool | ExpressionTool | ProcessGenerator | Workflow]
+        | Workflow
+    ]
+] = _UnionLoader(
     (
         CommandLineToolLoader,
         ExpressionToolLoader,
@@ -25777,7 +28087,6 @@ union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_Proc
 
 _loaders.update({
     "DocumentedLoader": None,
-    "ProcessRequirementLoader": union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_ShmSizeLoader,
     "LabeledLoader": None,
     "IdentifiedLoader": None,
     "IdentifierRequiredLoader": None,
@@ -25790,14 +28099,15 @@ _loaders.update({
     "InputSchemaLoader": None,
     "OutputSchemaLoader": None,
     "InputParameterLoader": union_of_CommandInputParameterLoader_or_WorkflowInputParameterLoader,
-    "OutputParameterLoader": union_of_CommandOutputParameterLoader_or_ExpressionToolOutputParameterLoader_or_WorkflowOutputParameterLoader,
-    "ProcessLoader": None,
-    "CommandInputSchemaLoader": union_of_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader,
+    "OutputParameterLoader": union_of_WorkflowOutputParameterLoader_or_ExpressionToolOutputParameterLoader_or_CommandOutputParameterLoader,
+    "ProcessRequirementLoader": union_of_CUDARequirementLoader_or_ResourceRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_EnvVarRequirementLoader_or_SoftwareRequirementLoader_or_ShellCommandRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_NetworkAccessLoader_or_ScatterFeatureRequirementLoader_or_ShmSizeLoader_or_InlineJavascriptRequirementLoader_or_WorkReuseLoader_or_SecretsLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_DockerRequirementLoader_or_MPIRequirementLoader_or_InitialWorkDirRequirementLoader,
+    "ProcessLoader": union_of_ProcessGeneratorLoader_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader,
+    "CommandInputSchemaLoader": union_of_CommandInputArraySchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputRecordSchemaLoader,
     "CommandLineBindableLoader": None,
     "SinkLoader": None,
 })
 
-CWLObjectTypeLoader.add_loaders(
+cast(_UnionLoader[CWLObjectType], CWLObjectTypeLoader).add_loaders(
     (
         booltype,
         inttype,
@@ -25807,6 +28117,53 @@ CWLObjectTypeLoader.add_loaders(
         DirectoryLoader,
         array_of_union_of_None_type_or_CWLObjectTypeLoader,
         map_of_union_of_None_type_or_CWLObjectTypeLoader,
+    )
+)
+cast(_UnionLoader[InputParameterType], InputParameterTypeLoader).add_loaders(
+    (
+        CWLTypeLoader,
+        InputRecordSchemaLoader,
+        InputEnumSchemaLoader,
+        InputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
+    )
+)
+cast(_UnionLoader[OutputParameterType], OutputParameterTypeLoader).add_loaders(
+    (
+        CWLTypeLoader,
+        OutputRecordSchemaLoader,
+        OutputEnumSchemaLoader,
+        OutputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
+    )
+)
+cast(
+    _UnionLoader[CommandInputParameterType], CommandInputParameterTypeLoader
+).add_loaders(
+    (
+        CWLTypeLoader,
+        stdinLoader,
+        CommandInputRecordSchemaLoader,
+        CommandInputEnumSchemaLoader,
+        CommandInputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
+    )
+)
+cast(
+    _UnionLoader[CommandOutputParameterType], CommandOutputParameterTypeLoader
+).add_loaders(
+    (
+        CWLTypeLoader,
+        stdoutLoader,
+        stderrLoader,
+        CommandOutputRecordSchemaLoader,
+        CommandOutputEnumSchemaLoader,
+        CommandOutputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     )
 )
 

--- a/src/cwl_utils/parser/cwl_v1_1_utils.py
+++ b/src/cwl_utils/parser/cwl_v1_1_utils.py
@@ -1,29 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 import hashlib
 import logging
-from collections import namedtuple
-from collections.abc import MutableMapping, MutableSequence
+from collections.abc import MutableMapping, MutableSequence, Sequence
 from io import StringIO
 from pathlib import Path
-from typing import IO, Any, cast
+from typing import IO, Any, cast, Literal
 from urllib.parse import urldefrag
 
 from schema_salad.exceptions import ValidationException
 from schema_salad.metaschema import ArraySchema, RecordSchema
 from schema_salad.runtime import shortname, LoadingOptions, file_uri, save
 from schema_salad.sourceline import SourceLine, add_lc_filename
-from schema_salad.utils import aslist, json_dumps, yaml_no_ts
+from schema_salad.utils import aslist, json_dumps, yaml_no_ts, flatten
 
 import cwl_utils.parser
 import cwl_utils.parser.cwl_v1_1 as cwl
 import cwl_utils.parser.utils
+from cwl_utils.types import SrcSink
 from cwl_utils.utils import yaml_dumps
 
 CONTENT_LIMIT: int = 64 * 1024
 
 _logger = logging.getLogger("cwl_utils")
-
-SrcSink = namedtuple("SrcSink", ["src", "sink", "linkMerge", "message"])
 
 
 def _compare_records(
@@ -178,11 +176,14 @@ def can_assign_src_to_sink(src: Any, sink: Any, strict: bool = False) -> bool:
 
 def check_all_types(
     src_dict: dict[str, Any],
-    sinks: MutableSequence[cwl.WorkflowStepInput | cwl.WorkflowOutputParameter],
+    sinks: Sequence[cwl.WorkflowStepInput | cwl.WorkflowOutputParameter],
     type_dict: dict[str, Any],
 ) -> dict[str, list[SrcSink]]:
     """Given a list of sinks, check if their types match with the types of their sources."""
-    validation: dict[str, list[SrcSink]] = {"warning": [], "exception": []}
+    validation: dict[str, list[SrcSink]] = {
+        "warning": [],
+        "exception": [],
+    }
     for sink in sinks:
         match sink:
             case cwl.WorkflowOutputParameter():
@@ -276,8 +277,7 @@ def convert_stdstreams_to_files(clt: cwl.CommandLineTool) -> None:
                 )
             else:
                 clt.stdin = (
-                    "$(inputs.%s.path)"
-                    % cast(str, inp.id).rpartition("#")[2].split("/")[-1]
+                    "$(inputs.%s.path)" % inp.id.rpartition("#")[2].split("/")[-1]
                 )
                 inp.type_ = "File"
 
@@ -340,21 +340,36 @@ def load_inputfile_by_yaml(
     return result
 
 
+def to_input_array(type_: cwl.InputParameterType) -> cwl.InputArraySchema:
+    return cwl.InputArraySchema(type_="array", items=type_)
+
+
+def to_output_array(type_: cwl.OutputParameterType) -> cwl.OutputArraySchema:
+    return cwl.OutputArraySchema(type_="array", items=type_)
+
+
 def type_for_step_input(
     step: cwl.WorkflowStep,
     in_: cwl.WorkflowStepInput,
-) -> Any:
+) -> (
+    Literal["Any"]
+    | cwl_utils.parser.InputParameterType
+    | cwl_utils.parser.CommandInputParameterType
+):
     """Determine the type for the given step input."""
     if in_.valueFrom is not None:
         return "Any"
-    step_run = cwl_utils.parser.utils.load_step(step)
-    cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
-    if step_run and step_run.inputs:
+    if step_run := cwl_utils.parser.utils.load_step(step):
+        cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
         for step_input in step_run.inputs:
-            if cast(str, step_input.id).split("#")[-1] == in_.id.split("#")[-1]:
-                input_type = step_input.type_
-                if step.scatter is not None and in_.id in aslist(step.scatter):
-                    input_type = ArraySchema(items=input_type, type_="array")
+            if step_input.id.split("#")[-1] == in_.id.split("#")[-1]:
+                if (input_type := step_input.type_) is None:
+                    raise Exception(f"Step output {step_input.id} has null type")
+                else:
+                    if step.scatter is not None and in_.id in aslist(step.scatter):
+                        input_type = cwl_utils.parser.utils.to_input_array(
+                            input_type, step_run.cwlVersion or "v1.1"
+                        )
                 return input_type
     return "Any"
 
@@ -362,24 +377,33 @@ def type_for_step_input(
 def type_for_step_output(
     step: cwl.WorkflowStep,
     sourcename: str,
-) -> Any:
+) -> (
+    Literal["Any"]
+    | cwl_utils.parser.OutputParameterType
+    | cwl_utils.parser.CommandOutputParameterType
+):
     """Determine the type for the given step output."""
-    step_run = cwl_utils.parser.utils.load_step(step)
-    cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
-    if step_run and step_run.outputs:
+    if step_run := cwl_utils.parser.utils.load_step(step):
+        cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
         for output in step_run.outputs:
             if (
                 output.id.split("#")[-1].split("/")[-1]
                 == sourcename.split("#")[-1].split("/")[-1]
             ):
-                output_type = output.type_
-                if step.scatter is not None:
-                    if step.scatterMethod == "nested_crossproduct":
-                        for _ in range(len(aslist(step.scatter))):
-                            output_type = ArraySchema(items=output_type, type_="array")
-                    else:
-                        output_type = ArraySchema(items=output_type, type_="array")
-                return output_type
+                if (output_type := output.type_) is None:
+                    raise Exception(f"Step output {output.id} has null type")
+                else:
+                    if step.scatter is not None:
+                        if step.scatterMethod == "nested_crossproduct":
+                            for _ in range(len(aslist(step.scatter))):
+                                output_type = cwl_utils.parser.utils.to_output_array(
+                                    output_type, step_run.cwlVersion or "v1.1"
+                                )
+                        else:
+                            output_type = cwl_utils.parser.utils.to_output_array(
+                                output_type, step_run.cwlVersion or "v1.1"
+                            )
+                    return output_type
     raise ValidationException(
         "param {} not found in {}.".format(
             sourcename,
@@ -390,35 +414,37 @@ def type_for_step_output(
 
 def type_for_source(
     process: cwl.CommandLineTool | cwl.Workflow | cwl.ExpressionTool,
-    sourcenames: str | list[str],
-    parent: cwl.Workflow | None = None,
+    sourcenames: str | Sequence[str],
+    parent: cwl_utils.parser.Workflow | None = None,
     linkMerge: str | None = None,
-) -> Any:
+    loaded_steps: dict[str, cwl_utils.parser.Process] | None = None,
+) -> cwl_utils.parser.ParameterTypeOrArraySchema:
     """Determine the type for the given sourcenames."""
     scatter_context: list[tuple[int, str] | None] = []
     params = cwl_utils.parser.utils.param_for_source_id(
-        process, sourcenames, parent, scatter_context
+        process, sourcenames, parent, scatter_context, loaded_steps
     )
     if not isinstance(params, MutableSequence):
-        new_type = params.type_
-        if scatter_context[0] is not None:
-            if scatter_context[0][1] == "nested_crossproduct":
-                for _ in range(scatter_context[0][0]):
+        if params.type_ is None:
+            raise Exception(f"Parameter {params.id} has null type")
+        else:
+            new_type: cwl_utils.parser.ParameterTypeOrArraySchema = params.type_
+            if scatter_context[0] is not None:
+                if scatter_context[0][1] == "nested_crossproduct":
+                    for _ in range(scatter_context[0][0]):
+                        new_type = ArraySchema(items=new_type, type_="array")
+                else:
                     new_type = ArraySchema(items=new_type, type_="array")
-            else:
+            if linkMerge == "merge_nested":
                 new_type = ArraySchema(items=new_type, type_="array")
-        if linkMerge == "merge_nested":
-            new_type = ArraySchema(items=new_type, type_="array")
-        elif linkMerge == "merge_flattened":
-            new_type = cwl_utils.parser.utils.merge_flatten_type(new_type)
-        return new_type
-    new_type = []
+            elif linkMerge == "merge_flattened":
+                new_type = cwl_utils.parser.utils.merge_flatten_type(new_type)
+            return new_type
+    new_types: list[cwl_utils.parser.ParameterType | ArraySchema] = []
     for p, sc in zip(params, scatter_context):
-        if isinstance(p, str) and not any(_compare_type(t, p) for t in new_type):
-            cur_type = p
-        elif hasattr(p, "type_") and not any(
-            _compare_type(t, p.type_) for t in new_type
-        ):
+        if isinstance(p, str) and not any(_compare_type(t, p) for t in new_types):
+            cur_type: cwl_utils.parser.ParameterType | ArraySchema | None = p
+        elif p is not None and not any(_compare_type(t, p.type_) for t in new_types):
             cur_type = p.type_
         else:
             cur_type = None
@@ -429,14 +455,19 @@ def type_for_source(
                         cur_type = ArraySchema(items=cur_type, type_="array")
                 else:
                     cur_type = ArraySchema(items=cur_type, type_="array")
-            new_type.append(cur_type)
-    if len(new_type) == 1:
-        new_type = new_type[0]
-    if linkMerge == "merge_nested":
-        return ArraySchema(items=new_type, type_="array")
-    elif linkMerge == "merge_flattened":
-        return cwl_utils.parser.utils.merge_flatten_type(new_type)
-    elif isinstance(sourcenames, list) and len(sourcenames) > 1:
-        return ArraySchema(items=new_type, type_="array")
+            new_types.append(cur_type)
+    if len(new_types) == 1:
+        final_type: cwl_utils.parser.ParameterTypeOrArraySchema = new_types[0]
     else:
-        return new_type
+        final_type = cast(
+            cwl_utils.parser.ParameterTypeOrArraySchema,
+            flatten(new_types),
+        )
+    if linkMerge == "merge_nested":
+        return ArraySchema(items=final_type, type_="array")
+    elif linkMerge == "merge_flattened":
+        return cwl_utils.parser.utils.merge_flatten_type(final_type)
+    elif isinstance(sourcenames, list) and len(sourcenames) > 1:
+        return ArraySchema(items=final_type, type_="array")
+    else:
+        return final_type

--- a/src/cwl_utils/parser/cwl_v1_2.py
+++ b/src/cwl_utils/parser/cwl_v1_2.py
@@ -27,12 +27,15 @@ else:
 import schema_salad.metaschema
 
 import copy
-from collections.abc import MutableSequence, Sequence, MutableMapping
+from collections.abc import Mapping, Sequence, MutableSequence, MutableMapping
 from io import StringIO
 from itertools import chain
-from typing import Any, Final, cast, Generic
+from typing import Any, Final, cast
+from typing import Literal, TypeAlias  # pylint: disable=unused-import # noqa: F401
 from urllib.parse import urldefrag, urlsplit, urlunsplit
 
+from mypy_extensions import i32, i64, trait  # pylint: disable=unused-import # noqa: F401
+from mypy_extensions import mypyc_attr
 from ruamel.yaml.comments import CommentedMap
 
 from schema_salad.exceptions import ValidationException, SchemaSaladException
@@ -42,16 +45,19 @@ from schema_salad.runtime import (
     extract_type,
     SaveableType,
     Loader,
+    FieldType,
+    EnumFieldType,
 )
 from schema_salad.sourceline import SourceLine, add_lc_filename
 from schema_salad.utils import yaml_no_ts  # requires schema-salad v8.2+
 
-_loaders: Final[dict[str, Loader | None]] = {}
+_loaders: Final[dict[str, Loader[Any] | None]] = {}
 _vocab: Final[dict[str, str]] = {}
 _rvocab: Final[dict[str, str]] = {}
 
 
-class _AnyLoader(Loader):
+@mypyc_attr(native_class=True)
+class _AnyLoader(Loader[Any]):
     def load(
         self,
         doc: Any,
@@ -65,8 +71,9 @@ class _AnyLoader(Loader):
         raise ValidationException("Expected non-null")
 
 
-class _PrimitiveLoader(Loader):
-    def __init__(self, tp: type | tuple[type[str], type[str]]) -> None:
+@mypyc_attr(native_class=True)
+class _PrimitiveLoader(Loader[FieldType]):
+    def __init__(self, tp: type[FieldType]) -> None:
         self.tp: Final = tp
 
     def load(
@@ -76,7 +83,7 @@ class _PrimitiveLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if not isinstance(doc, self.tp):
             raise ValidationException(f"Expected a {self.tp} but got {doc.__class__.__name__}")
         return doc
@@ -85,8 +92,9 @@ class _PrimitiveLoader(Loader):
         return str(self.tp)
 
 
-class _ArrayLoader(Loader):
-    def __init__(self, items: Loader) -> None:
+@mypyc_attr(native_class=True)
+class _ArrayLoader(Loader[Sequence[FieldType]]):
+    def __init__(self, items: Loader[FieldType]) -> None:
         self.items: Final = items
 
     def load(
@@ -96,9 +104,9 @@ class _ArrayLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> list[Any]:
+    ) -> list[FieldType]:
         if not isinstance(doc, MutableSequence):
-            raise ValidationException(
+            raise SourceLine(doc, None, ValidationException).makeError(
                 f"Value is a {convert_typing(extract_type(type(doc)))}, "
                 f"but valid type for this field is an array."
             )
@@ -142,10 +150,11 @@ class _ArrayLoader(Loader):
         return f"array<{self.items}>"
 
 
-class _MapLoader(Loader):
+@mypyc_attr(native_class=True)
+class _MapLoader(Loader[Mapping[str, FieldType]]):
     def __init__(
         self,
-        values: Loader,
+        values: Loader[FieldType],
         name: str | None = None,
         container: str | None = None,
         no_link_check: bool | None = None,
@@ -162,7 +171,7 @@ class _MapLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> dict[str, Any]:
+    ) -> dict[str, FieldType]:
         if not isinstance(doc, MutableMapping):
             raise ValidationException(f"Expected a map, was {type(doc)}")
         if self.container is not None or self.no_link_check is not None:
@@ -185,8 +194,9 @@ class _MapLoader(Loader):
         return self.name if self.name is not None else f"map<string, {self.values}>"
 
 
-class _EnumLoader(Loader):
-    def __init__(self, symbols: Sequence[str], name: str) -> None:
+@mypyc_attr(native_class=True)
+class _EnumLoader(Loader[EnumFieldType]):
+    def __init__(self, symbols: tuple[EnumFieldType, ...], name: str) -> None:
         self.symbols: Final = symbols
         self.name: Final = name
 
@@ -197,17 +207,18 @@ class _EnumLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> str:
+    ) -> EnumFieldType:
         if doc in self.symbols:
-            return cast(str, doc)
+            return cast(EnumFieldType, doc)
         raise ValidationException(f"Expected one of {self.symbols}")
 
     def __repr__(self) -> str:
         return self.name
 
 
-class _SecondaryDSLLoader(Loader):
-    def __init__(self, inner: Loader) -> None:
+@mypyc_attr(native_class=True)
+class _SecondaryDSLLoader(Loader[FieldType]):
+    def __init__(self, inner: Loader[FieldType]) -> None:
         self.inner: Final = inner
 
     def load(
@@ -217,7 +228,7 @@ class _SecondaryDSLLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         r: Final[list[dict[str, Any]]] = []
         match doc:
             case MutableSequence() as dlist:
@@ -279,7 +290,8 @@ class _SecondaryDSLLoader(Loader):
         return self.inner.load(r, baseuri, loadingOptions, docRoot, lc=lc)
 
 
-class _RecordLoader(Loader, Generic[SaveableType]):
+@mypyc_attr(native_class=True)
+class _RecordLoader(Loader[SaveableType]):
     def __init__(
         self,
         classtype: type[SaveableType],
@@ -299,7 +311,7 @@ class _RecordLoader(Loader, Generic[SaveableType]):
         lc: Any | None = None,
     ) -> SaveableType:
         if not isinstance(doc, MutableMapping):
-            raise ValidationException(
+            raise SourceLine(doc, None, ValidationException).makeError(
                 f"Value is a {convert_typing(extract_type(type(doc)))}, "
                 f"but valid type for this field is an object."
             )
@@ -313,7 +325,8 @@ class _RecordLoader(Loader, Generic[SaveableType]):
         return str(self.classtype.__name__)
 
 
-class _ExpressionLoader(Loader):
+@mypyc_attr(native_class=True)
+class _ExpressionLoader(Loader[str]):
     def __init__(self, items: type[str]) -> None:
         self.items: Final = items
 
@@ -326,7 +339,7 @@ class _ExpressionLoader(Loader):
         lc: Any | None = None,
     ) -> str:
         if not isinstance(doc, str):
-            raise ValidationException(
+            raise SourceLine(doc, None, ValidationException).makeError(
                 f"Value is a {convert_typing(extract_type(type(doc)))}, "
                 f"but valid type for this field is a str."
             )
@@ -334,12 +347,13 @@ class _ExpressionLoader(Loader):
             return doc
 
 
-class _UnionLoader(Loader):
-    def __init__(self, alternates: Sequence[Loader], name: str | None = None) -> None:
+@mypyc_attr(native_class=True)
+class _UnionLoader(Loader[FieldType]):
+    def __init__(self, alternates: Sequence[Loader[FieldType]], name: str | None = None) -> None:
         self.alternates = alternates
         self.name: Final = name
 
-    def add_loaders(self, loaders: Sequence[Loader]) -> None:
+    def add_loaders(self, loaders: Sequence[Loader[FieldType]]) -> None:
         self.alternates = tuple(loader for loader in chain(self.alternates, loaders))
 
     def load(
@@ -349,7 +363,7 @@ class _UnionLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         errors: Final = []
 
         if lc is None:
@@ -424,10 +438,11 @@ class _UnionLoader(Loader):
         return self.name if self.name is not None else " | ".join(str(a) for a in self.alternates)
 
 
-class _URILoader(Loader):
+@mypyc_attr(native_class=True)
+class _URILoader(Loader[FieldType]):
     def __init__(
         self,
-        inner: Loader,
+        inner: Loader[FieldType],
         scoped_id: bool,
         vocab_term: bool,
         scoped_ref: int | None,
@@ -446,7 +461,7 @@ class _URILoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if self.no_link_check is not None:
             loadingOptions = LoadingOptions(
                 copyfrom=loadingOptions, no_link_check=self.no_link_check
@@ -493,10 +508,11 @@ class _URILoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
-class _TypeDSLLoader(Loader):
+@mypyc_attr(native_class=True)
+class _TypeDSLLoader(Loader[FieldType]):
     def __init__(
         self,
-        inner: Loader,
+        inner: Loader[FieldType],
         refScope: int | None,
         salad_version: str,
     ) -> None:
@@ -567,7 +583,7 @@ class _TypeDSLLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if isinstance(doc, MutableSequence):
             r: Final[list[Any]] = []
             for d in doc:
@@ -589,8 +605,9 @@ class _TypeDSLLoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
-class _IdMapLoader(Loader):
-    def __init__(self, inner: Loader, mapSubject: str, mapPredicate: str | None) -> None:
+@mypyc_attr(native_class=True)
+class _IdMapLoader(Loader[FieldType]):
+    def __init__(self, inner: Loader[FieldType], mapSubject: str, mapPredicate: str | None) -> None:
         self.inner: Final = inner
         self.mapSubject: Final = mapSubject
         self.mapPredicate: Final = mapPredicate
@@ -602,7 +619,7 @@ class _IdMapLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any:
+    ) -> FieldType:
         if isinstance(doc, MutableMapping):
             r: Final[list[Any]] = []
             for k in doc.keys():
@@ -628,7 +645,8 @@ class _IdMapLoader(Loader):
         return self.inner.load(doc, baseuri, loadingOptions, lc=lc)
 
 
-class _ProxyLoader(Loader):
+@mypyc_attr(native_class=True)
+class _ProxyLoader(Loader[FieldType]):
     def __init__(self, name: str) -> None:
         self.name: Final = name
 
@@ -639,25 +657,25 @@ class _ProxyLoader(Loader):
         loadingOptions: LoadingOptions,
         docRoot: str | None = None,
         lc: Any | None = None,
-    ) -> Any | None:
+    ) -> FieldType:
         if (
             self.name in loadingOptions.loaders
             and (loader := loadingOptions.loaders.get(self.name)) is not None
         ):
-            return loader.load(doc, baseuri, loadingOptions, lc=lc)
+            return cast(Loader[FieldType], loader).load(doc, baseuri, loadingOptions, lc=lc)
         elif self.name in _loaders and (loader := _loaders.get(self.name)) is not None:
-            return loader.load(doc, baseuri, loadingOptions, lc=lc)
+            return cast(Loader[FieldType], loader).load(doc, baseuri, loadingOptions, lc=lc)
         else:
             raise ValidationException(f"No Loader instance available for {self.name}")
 
 
 def _document_load(
-    loader: Loader,
+    loader: Loader[FieldType],
     doc: str | MutableMapping[str, Any] | MutableSequence[Any],
     baseuri: str,
     loadingOptions: LoadingOptions,
     addl_metadata_fields: MutableSequence[str] | None = None,
-) -> tuple[Any, LoadingOptions]:
+) -> tuple[FieldType, LoadingOptions]:
     if isinstance(doc, str):
         return _document_load_by_url(
             loader,
@@ -723,11 +741,11 @@ def _document_load(
 
 
 def _document_load_by_url(
-    loader: Loader,
+    loader: Loader[FieldType],
     url: str,
     loadingOptions: LoadingOptions,
     addl_metadata_fields: MutableSequence[str] | None = None,
-) -> tuple[Any, LoadingOptions]:
+) -> tuple[FieldType, LoadingOptions]:
     if url in loadingOptions.idx:
         return loadingOptions.idx[url]
 
@@ -823,11 +841,11 @@ def _expand_url(
 
 def _load_field(
     val: Any | None,
-    fieldtype: Loader,
+    fieldtype: Loader[FieldType],
     baseuri: str,
     loadingOptions: LoadingOptions,
     lc: Any | None = None,
-) -> Any:
+) -> FieldType:
     """Load field."""
     if isinstance(val, MutableMapping):
         if "$import" in val:
@@ -854,25 +872,8 @@ def parser_info() -> str:
     return "org.w3id.cwl.v1_2"
 
 
+@mypyc_attr(native_class=True)
 class CWLArraySchema(schema_salad.metaschema.ArraySchema):
-    def __init__(
-        self,
-        items: Any,
-        type_: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.items = items
-        self.type_ = type_
-
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CWLArraySchema):
             return bool(self.items == other.items and self.type_ == other.type_)
@@ -1050,17 +1051,10 @@ class CWLArraySchema(schema_salad.metaschema.ArraySchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["items", "type"])
-
-
-class CWLRecordField(schema_salad.metaschema.RecordField):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
+        items: CWLArraySchema | CWLRecordSchema | PrimitiveType | Sequence[CWLArraySchema | CWLRecordSchema | PrimitiveType | schema_salad.metaschema.EnumSchema | str] | schema_salad.metaschema.EnumSchema | str,
+        type_: Array_name,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -1069,12 +1063,18 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.items = items
         self.type_ = type_
+
+    attrs: ClassVar[Collection[str]] = frozenset(["items", "type"])
+
+
+@mypyc_attr(native_class=True)
+class CWLRecordField(schema_salad.metaschema.RecordField):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CWLRecordField):
@@ -1149,15 +1149,62 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -1278,13 +1325,13 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -1299,7 +1346,10 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -1318,14 +1368,11 @@ class CWLRecordField(schema_salad.metaschema.RecordField):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["doc", "name", "type"])
-
-
-class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
     def __init__(
         self,
-        type_: Any,
-        fields: Any | None = None,
+        name: str,
+        type_: CWLArraySchema | CWLRecordSchema | PrimitiveType | Sequence[CWLArraySchema | CWLRecordSchema | PrimitiveType | schema_salad.metaschema.EnumSchema | str] | schema_salad.metaschema.EnumSchema | str,
+        doc: None | Sequence[str] | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -1334,12 +1381,18 @@ class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.fields = fields
+        self.doc = doc
+        self.name = name
         self.type_ = type_
 
+    attrs: ClassVar[Collection[str]] = frozenset(["doc", "name", "type"])
+
+
+@mypyc_attr(native_class=True)
+class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CWLRecordSchema):
             return bool(self.fields == other.fields and self.type_ == other.type_)
@@ -1517,9 +1570,28 @@ class CWLRecordSchema(schema_salad.metaschema.RecordSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        type_: Record_name,
+        fields: None | Sequence[CWLRecordField] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.fields = fields
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(["fields", "type"])
 
 
+@mypyc_attr(native_class=True)
 class File(Saveable):
     """
     Represents a file (or group of files when ``secondaryFiles`` is provided) that will be accessible by tools using standard POSIX file system call API such as open(2) and read(2).
@@ -1547,43 +1619,6 @@ class File(Saveable):
     An ExpressionTool may forward file references from input to output by using the same value for ``location``.
 
     """
-
-    def __init__(
-        self,
-        location: Any | None = None,
-        path: Any | None = None,
-        basename: Any | None = None,
-        dirname: Any | None = None,
-        nameroot: Any | None = None,
-        nameext: Any | None = None,
-        checksum: Any | None = None,
-        size: Any | None = None,
-        secondaryFiles: Any | None = None,
-        format: Any | None = None,
-        contents: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "File"
-        self.location = location
-        self.path = path
-        self.basename = basename
-        self.dirname = dirname
-        self.nameroot = nameroot
-        self.nameext = nameext
-        self.checksum = checksum
-        self.size = size
-        self.secondaryFiles = secondaryFiles
-        self.format = format
-        self.contents = contents
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, File):
@@ -1986,7 +2021,7 @@ class File(Saveable):
             try:
                 size = _load_field(
                     _doc.get("size"),
-                    union_of_None_type_or_inttype,
+                    union_of_None_type_or_inttype_or_longtype,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("size")
@@ -2284,6 +2319,43 @@ class File(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        location: None | str = None,
+        path: None | str = None,
+        basename: None | str = None,
+        dirname: None | str = None,
+        nameroot: None | str = None,
+        nameext: None | str = None,
+        checksum: None | str = None,
+        size: None | i32 | i64 = None,
+        secondaryFiles: None | Sequence[Directory | File] = None,
+        format: None | str = None,
+        contents: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "File"
+        self.location = location
+        self.path = path
+        self.basename = basename
+        self.dirname = dirname
+        self.nameroot = nameroot
+        self.nameext = nameext
+        self.checksum = checksum
+        self.size = size
+        self.secondaryFiles = secondaryFiles
+        self.format = format
+        self.contents = contents
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -2302,6 +2374,7 @@ class File(Saveable):
     )
 
 
+@mypyc_attr(native_class=True)
 class Directory(Saveable):
     """
     Represents a directory to present to a command line tool.
@@ -2325,29 +2398,6 @@ class Directory(Saveable):
     Name conflicts (the same ``basename`` appearing multiple times in ``listing`` or in any entry in ``secondaryFiles`` in the listing) is a fatal error.
 
     """
-
-    def __init__(
-        self,
-        location: Any | None = None,
-        path: Any | None = None,
-        basename: Any | None = None,
-        listing: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "Directory"
-        self.location = location
-        self.path = path
-        self.basename = basename
-        self.listing = listing
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Directory):
@@ -2662,39 +2712,78 @@ class Directory(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        location: None | str = None,
+        path: None | str = None,
+        basename: None | str = None,
+        listing: None | Sequence[Directory | File] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "Directory"
+        self.location = location
+        self.path = path
+        self.basename = basename
+        self.listing = listing
+
     attrs: ClassVar[Collection[str]] = frozenset(
         ["class", "location", "path", "basename", "listing"]
     )
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Labeled(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Identified(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class IdentifierRequired(Identified):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class LoadContents(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class FieldBase(Labeled):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class InputFormat(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class OutputFormat(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Parameter(FieldBase, schema_salad.metaschema.Documented, IdentifierRequired):
     """
     Define an input or output parameter to a process.
@@ -2704,23 +2793,8 @@ class Parameter(FieldBase, schema_salad.metaschema.Documented, IdentifierRequire
     pass
 
 
+@mypyc_attr(native_class=True)
 class InputBinding(Saveable):
-    def __init__(
-        self,
-        loadContents: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.loadContents = loadContents
-
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputBinding):
             return bool(self.loadContents == other.loadContents)
@@ -2848,35 +2922,9 @@ class InputBinding(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["loadContents"])
-
-
-class IOSchema(Labeled, schema_salad.metaschema.Documented):
-    pass
-
-
-class InputSchema(IOSchema):
-    pass
-
-
-class OutputSchema(IOSchema):
-    pass
-
-
-class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        format: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
+        loadContents: None | bool = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -2885,18 +2933,35 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.type_ = type_
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.format = format
         self.loadContents = loadContents
-        self.loadListing = loadListing
+
+    attrs: ClassVar[Collection[str]] = frozenset(["loadContents"])
+
+
+@mypyc_attr(native_class=True)
+@trait
+class IOSchema(Labeled, schema_salad.metaschema.Documented):
+    pass
+
+
+@mypyc_attr(native_class=True)
+@trait
+class InputSchema(IOSchema):
+    pass
+
+
+@mypyc_attr(native_class=True)
+@trait
+class OutputSchema(IOSchema):
+    pass
+
+
+@mypyc_attr(native_class=True)
+class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputRecordField):
@@ -2989,15 +3054,62 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -3400,8 +3512,8 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             label=label,
             secondaryFiles=secondaryFiles,
@@ -3412,7 +3524,7 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -3427,7 +3539,10 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -3481,6 +3596,38 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        name: str,
+        type_: CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        format: None | Sequence[str] | str = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.doc = doc
+        self.name = name
+        self.type_ = type_
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.format = format
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "doc",
@@ -3496,32 +3643,9 @@ class InputRecordField(CWLRecordField, FieldBase, InputFormat, LoadContents):
     )
 
 
+@mypyc_attr(native_class=True)
 class InputRecordSchema(CWLRecordSchema, InputSchema):
     name: str
-
-    def __init__(
-        self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.fields = fields
-        self.type_ = type_
-        self.label = label
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputRecordSchema):
@@ -3598,15 +3722,61 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -3821,15 +3991,15 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -3844,7 +4014,10 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -3871,21 +4044,13 @@ class InputRecordSchema(CWLRecordSchema, InputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["fields", "type", "label", "doc", "name"]
-    )
-
-
-class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[InputRecordField] = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -3894,14 +4059,23 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
         self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["fields", "type", "label", "doc", "name"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputEnumSchema):
@@ -3978,15 +4152,61 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -4210,7 +4430,7 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -4225,7 +4445,10 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -4251,21 +4474,13 @@ class InputEnumSchema(schema_salad.metaschema.EnumSchema, InputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "doc"]
-    )
-
-
-class InputArraySchema(CWLArraySchema, InputSchema):
-    name: str
-
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -4274,14 +4489,23 @@ class InputArraySchema(CWLArraySchema, InputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "doc"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class InputArraySchema(CWLArraySchema, InputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InputArraySchema):
@@ -4358,15 +4582,61 @@ class InputArraySchema(CWLArraySchema, InputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("items") is None:
                 raise ValidationException("missing required field `items`", None, [])
@@ -4582,15 +4852,15 @@ class InputArraySchema(CWLArraySchema, InputSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             items=items,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -4605,7 +4875,10 @@ class InputArraySchema(CWLArraySchema, InputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.items is not None:
             u = save_relative_uri(self.items, self.name, False, 2, relative_uris)
@@ -4631,23 +4904,13 @@ class InputArraySchema(CWLArraySchema, InputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["items", "type", "label", "doc", "name"]
-    )
-
-
-class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        format: Any | None = None,
+        items: CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -4656,16 +4919,23 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.items = items
         self.type_ = type_
         self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.format = format
+        self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["items", "type", "label", "doc", "name"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputRecordField):
@@ -4754,15 +5024,62 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -5071,8 +5388,8 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             label=label,
             secondaryFiles=secondaryFiles,
@@ -5081,7 +5398,7 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -5096,7 +5413,10 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -5136,21 +5456,15 @@ class OutputRecordField(CWLRecordField, FieldBase, OutputFormat):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["doc", "name", "type", "label", "secondaryFiles", "streamable", "format"]
-    )
-
-
-class OutputRecordSchema(CWLRecordSchema, OutputSchema):
-    name: str
-
     def __init__(
         self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
+        name: str,
+        type_: CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | Sequence[CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        format: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -5159,14 +5473,25 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.fields = fields
+        self.doc = doc
+        self.name = name
         self.type_ = type_
         self.label = label
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.format = format
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["doc", "name", "type", "label", "secondaryFiles", "streamable", "format"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputRecordSchema(CWLRecordSchema, OutputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputRecordSchema):
@@ -5243,15 +5568,61 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -5466,15 +5837,15 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -5489,7 +5860,10 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -5516,21 +5890,13 @@ class OutputRecordSchema(CWLRecordSchema, OutputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["fields", "type", "label", "doc", "name"]
-    )
-
-
-class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[OutputRecordField] = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -5539,14 +5905,23 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
         self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["fields", "type", "label", "doc", "name"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputEnumSchema):
@@ -5623,15 +5998,61 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -5855,7 +6276,7 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -5870,7 +6291,10 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -5896,21 +6320,13 @@ class OutputEnumSchema(schema_salad.metaschema.EnumSchema, OutputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "doc"]
-    )
-
-
-class OutputArraySchema(CWLArraySchema, OutputSchema):
-    name: str
-
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -5919,14 +6335,23 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "doc"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class OutputArraySchema(CWLArraySchema, OutputSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OutputArraySchema):
@@ -6003,15 +6428,61 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("items") is None:
                 raise ValidationException("missing required field `items`", None, [])
@@ -6227,15 +6698,15 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             items=items,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -6250,7 +6721,10 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.items is not None:
             u = save_relative_uri(self.items, self.name, False, 2, relative_uris)
@@ -6276,19 +6750,49 @@ class OutputArraySchema(CWLArraySchema, OutputSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        items: CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | Sequence[CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.items = items
+        self.type_ = type_
+        self.label = label
+        self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
     attrs: ClassVar[Collection[str]] = frozenset(
         ["items", "type", "label", "doc", "name"]
     )
 
 
+@mypyc_attr(native_class=True)
+@trait
 class InputParameter(Parameter, InputFormat, LoadContents):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class OutputParameter(Parameter, OutputFormat):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class ProcessRequirement(Saveable):
     """
     A process requirement declares a prerequisite that may or must be fulfilled before executing a process.  See ```Process.hints`` <#process>`__ and ```Process.requirements`` <#process>`__.
@@ -6300,6 +6804,8 @@ class ProcessRequirement(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Process(Identified, Labeled, schema_salad.metaschema.Documented):
     """
     The base executable type in CWL is the ``Process`` object defined by the document.  Note that the ``Process`` object is abstract and cannot be directly executed.
@@ -6309,28 +6815,12 @@ class Process(Identified, Labeled, schema_salad.metaschema.Documented):
     pass
 
 
+@mypyc_attr(native_class=True)
 class InlineJavascriptRequirement(ProcessRequirement):
     """
     Indicates that the workflow platform must support inline Javascript expressions. If this requirement is not present, the workflow platform must not perform expression interpolation.
 
     """
-
-    def __init__(
-        self,
-        expressionLib: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "InlineJavascriptRequirement"
-        self.expressionLib = expressionLib
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InlineJavascriptRequirement):
@@ -6489,13 +6979,33 @@ class InlineJavascriptRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        expressionLib: None | Sequence[str] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "InlineJavascriptRequirement"
+        self.expressionLib = expressionLib
+
     attrs: ClassVar[Collection[str]] = frozenset(["class", "expressionLib"])
 
 
+@mypyc_attr(native_class=True)
+@trait
 class CommandInputSchema(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
 class SchemaDefRequirement(ProcessRequirement):
     """
     This field consists of an array of type definitions which must be used when interpreting the ``inputs`` and ``outputs`` fields.  When a ``type`` field contains a IRI, the implementation must check if the type is defined in ``schemaDefs`` and use that definition.  If the type is not found in ``schemaDefs``, it is an error.  The entries in ``schemaDefs`` must be processed in the order listed such that later schema definitions may refer to earlier schema definitions.
@@ -6505,23 +7015,6 @@ class SchemaDefRequirement(ProcessRequirement):
     - A file can contain a list of type definitions
 
     """
-
-    def __init__(
-        self,
-        types: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "SchemaDefRequirement"
-        self.types = types
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SchemaDefRequirement):
@@ -6568,7 +7061,7 @@ class SchemaDefRequirement(ProcessRequirement):
 
             types = _load_field(
                 _doc.get("types"),
-                array_of_CommandInputSchema,
+                array_of_CommandInputSchemaProxyLoader,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("types")
@@ -6675,9 +7168,27 @@ class SchemaDefRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        types: Sequence[CommandInputSchema],
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "SchemaDefRequirement"
+        self.types = types
+
     attrs: ClassVar[Collection[str]] = frozenset(["class", "types"])
 
 
+@mypyc_attr(native_class=True)
 class SecondaryFileSchema(Saveable):
     """
     Secondary files are specified using the following micro-DSL for secondary files:
@@ -6690,24 +7201,6 @@ class SecondaryFileSchema(Saveable):
     For implementation details and examples, please see `this section <SchemaSalad.html#Domain_Specific_Language_for_secondary_files>`__ in the Schema Salad specification.
 
     """
-
-    def __init__(
-        self,
-        pattern: Any,
-        required: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.pattern = pattern
-        self.required = required
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SecondaryFileSchema):
@@ -6888,18 +7381,10 @@ class SecondaryFileSchema(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["pattern", "required"])
-
-
-class LoadListingRequirement(ProcessRequirement):
-    """
-    Specify the desired behavior for loading the ``listing`` field of a Directory object for use by expressions.
-
-    """
-
     def __init__(
         self,
-        loadListing: Any | None = None,
+        pattern: str,
+        required: None | bool | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -6908,11 +7393,21 @@ class LoadListingRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "LoadListingRequirement"
-        self.loadListing = loadListing
+        self.pattern = pattern
+        self.required = required
+
+    attrs: ClassVar[Collection[str]] = frozenset(["pattern", "required"])
+
+
+@mypyc_attr(native_class=True)
+class LoadListingRequirement(ProcessRequirement):
+    """
+    Specify the desired behavior for loading the ``listing`` field of a Directory object for use by expressions.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, LoadListingRequirement):
@@ -7070,19 +7565,9 @@ class LoadListingRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "loadListing"])
-
-
-class EnvironmentDef(Saveable):
-    """
-    Define an environment variable that will be set in the runtime environment by the workflow platform when executing the command line tool.  May be the result of executing an expression, such as getting a parameter from input.
-
-    """
-
     def __init__(
         self,
-        envName: Any,
-        envValue: Any,
+        loadListing: LoadListingEnum | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -7091,11 +7576,21 @@ class EnvironmentDef(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.envName = envName
-        self.envValue = envValue
+        self.class_: Final[str] = "LoadListingRequirement"
+        self.loadListing = loadListing
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "loadListing"])
+
+
+@mypyc_attr(native_class=True)
+class EnvironmentDef(Saveable):
+    """
+    Define an environment variable that will be set in the runtime environment by the workflow platform when executing the command line tool.  May be the result of executing an expression, such as getting a parameter from input.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, EnvironmentDef):
@@ -7277,9 +7772,28 @@ class EnvironmentDef(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        envName: str,
+        envValue: str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.envName = envName
+        self.envValue = envValue
+
     attrs: ClassVar[Collection[str]] = frozenset(["envName", "envValue"])
 
 
+@mypyc_attr(native_class=True)
 class CommandLineBinding(InputBinding):
     """
     When listed under ``inputBinding`` in the input schema, the term "value" refers to the corresponding value in the input object.  For binding objects listed in ``CommandLineTool.arguments``, the term "value" refers to the effective value after evaluating ``valueFrom``.
@@ -7303,34 +7817,6 @@ class CommandLineBinding(InputBinding):
     - **null**: Add nothing.
 
     """
-
-    def __init__(
-        self,
-        loadContents: Any | None = None,
-        position: Any | None = None,
-        prefix: Any | None = None,
-        separate: Any | None = None,
-        itemSeparator: Any | None = None,
-        valueFrom: Any | None = None,
-        shellQuote: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.loadContents = loadContents
-        self.position = position
-        self.prefix = prefix
-        self.separate = separate
-        self.itemSeparator = itemSeparator
-        self.valueFrom = valueFrom
-        self.shellQuote = shellQuote
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandLineBinding):
@@ -7798,6 +8284,34 @@ class CommandLineBinding(InputBinding):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        loadContents: None | bool = None,
+        position: None | i32 | str = None,
+        prefix: None | str = None,
+        separate: None | bool = None,
+        itemSeparator: None | str = None,
+        valueFrom: None | str = None,
+        shellQuote: None | bool = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.loadContents = loadContents
+        self.position = position
+        self.prefix = prefix
+        self.separate = separate
+        self.itemSeparator = itemSeparator
+        self.valueFrom = valueFrom
+        self.shellQuote = shellQuote
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "loadContents",
@@ -7811,6 +8325,7 @@ class CommandLineBinding(InputBinding):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandOutputBinding(LoadContents):
     """
     Describes how to generate an output parameter based on the files produced by a CommandLineTool.
@@ -7823,28 +8338,6 @@ class CommandOutputBinding(LoadContents):
     - secondaryFiles
 
     """
-
-    def __init__(
-        self,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        glob: Any | None = None,
-        outputEval: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.loadContents = loadContents
-        self.loadListing = loadListing
-        self.glob = glob
-        self.outputEval = outputEval
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputBinding):
@@ -8140,30 +8633,12 @@ class CommandOutputBinding(LoadContents):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["loadContents", "loadListing", "glob", "outputEval"]
-    )
-
-
-class CommandLineBindable(Saveable):
-    pass
-
-
-class CommandInputRecordField(InputRecordField, CommandLineBindable):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        format: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        inputBinding: Any | None = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        glob: None | Sequence[str] | str = None,
+        outputEval: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -8172,19 +8647,28 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.type_ = type_
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.format = format
         self.loadContents = loadContents
         self.loadListing = loadListing
-        self.inputBinding = inputBinding
+        self.glob = glob
+        self.outputEval = outputEval
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["loadContents", "loadListing", "glob", "outputEval"]
+    )
+
+
+@mypyc_attr(native_class=True)
+@trait
+class CommandLineBindable(Saveable):
+    pass
+
+
+@mypyc_attr(native_class=True)
+class CommandInputRecordField(InputRecordField, CommandLineBindable):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputRecordField):
@@ -8279,15 +8763,62 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -8737,8 +9268,8 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             label=label,
             secondaryFiles=secondaryFiles,
@@ -8750,7 +9281,7 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -8765,7 +9296,10 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -8826,6 +9360,40 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        name: str,
+        type_: CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | Sequence[CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        format: None | Sequence[str] | str = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        inputBinding: CommandLineBinding | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.doc = doc
+        self.name = name
+        self.type_ = type_
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.format = format
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+        self.inputBinding = inputBinding
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "doc",
@@ -8842,36 +9410,11 @@ class CommandInputRecordField(InputRecordField, CommandLineBindable):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandInputRecordSchema(
     InputRecordSchema, CommandInputSchema, CommandLineBindable
 ):
     name: str
-
-    def __init__(
-        self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
-        inputBinding: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.fields = fields
-        self.type_ = type_
-        self.label = label
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.inputBinding = inputBinding
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputRecordSchema):
@@ -8958,15 +9501,61 @@ class CommandInputRecordSchema(
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -9228,16 +9817,16 @@ class CommandInputRecordSchema(
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             inputBinding=inputBinding,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -9252,7 +9841,10 @@ class CommandInputRecordSchema(
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -9286,22 +9878,14 @@ class CommandInputRecordSchema(
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["fields", "type", "label", "doc", "name", "inputBinding"]
-    )
-
-
-class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBindable):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        inputBinding: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[CommandInputRecordField] = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
+        inputBinding: CommandLineBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -9310,15 +9894,24 @@ class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBin
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
         self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
         self.inputBinding = inputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["fields", "type", "label", "doc", "name", "inputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBindable):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputEnumSchema):
@@ -9405,15 +9998,61 @@ class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBin
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -9685,7 +10324,7 @@ class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBin
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -9700,7 +10339,10 @@ class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBin
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -9733,24 +10375,14 @@ class CommandInputEnumSchema(InputEnumSchema, CommandInputSchema, CommandLineBin
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "doc", "inputBinding"]
-    )
-
-
-class CommandInputArraySchema(
-    InputArraySchema, CommandInputSchema, CommandLineBindable
-):
-    name: str
-
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
-        inputBinding: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        inputBinding: CommandLineBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -9759,15 +10391,26 @@ class CommandInputArraySchema(
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
         self.inputBinding = inputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "doc", "inputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandInputArraySchema(
+    InputArraySchema, CommandInputSchema, CommandLineBindable
+):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputArraySchema):
@@ -9847,15 +10490,61 @@ class CommandInputArraySchema(
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("items") is None:
                 raise ValidationException("missing required field `items`", None, [])
@@ -10118,16 +10807,16 @@ class CommandInputArraySchema(
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             items=items,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             inputBinding=inputBinding,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -10142,7 +10831,10 @@ class CommandInputArraySchema(
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.items is not None:
             u = save_relative_uri(self.items, self.name, False, 2, relative_uris)
@@ -10175,24 +10867,14 @@ class CommandInputArraySchema(
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["items", "type", "label", "doc", "name", "inputBinding"]
-    )
-
-
-class CommandOutputRecordField(OutputRecordField):
-    name: str
-
     def __init__(
         self,
-        name: Any,
-        type_: Any,
-        doc: Any | None = None,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        format: Any | None = None,
-        outputBinding: Any | None = None,
+        items: CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | Sequence[CWLType | CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
+        inputBinding: CommandLineBinding | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -10201,17 +10883,24 @@ class CommandOutputRecordField(OutputRecordField):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.items = items
         self.type_ = type_
         self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.format = format
-        self.outputBinding = outputBinding
+        self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.inputBinding = inputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["items", "type", "label", "doc", "name", "inputBinding"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandOutputRecordField(OutputRecordField):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputRecordField):
@@ -10302,15 +10991,62 @@ class CommandOutputRecordField(OutputRecordField):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
+                name = ""
                 _errors__.append(ValidationException("missing name"))
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         doc = None
         if "doc" in _doc:
             try:
@@ -10666,8 +11402,8 @@ class CommandOutputRecordField(OutputRecordField):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            doc=doc,
             name=name,
+            doc=doc,
             type_=type_,
             label=label,
             secondaryFiles=secondaryFiles,
@@ -10677,7 +11413,7 @@ class CommandOutputRecordField(OutputRecordField):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -10692,7 +11428,10 @@ class CommandOutputRecordField(OutputRecordField):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.doc is not None:
             r["doc"] = save(
@@ -10739,6 +11478,36 @@ class CommandOutputRecordField(OutputRecordField):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        name: str,
+        type_: CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | Sequence[CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | str] | str,
+        doc: None | Sequence[str] | str = None,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        format: None | str = None,
+        outputBinding: CommandOutputBinding | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.doc = doc
+        self.name = name
+        self.type_ = type_
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.format = format
+        self.outputBinding = outputBinding
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "doc",
@@ -10753,32 +11522,9 @@ class CommandOutputRecordField(OutputRecordField):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandOutputRecordSchema(OutputRecordSchema):
     name: str
-
-    def __init__(
-        self,
-        type_: Any,
-        fields: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.fields = fields
-        self.type_ = type_
-        self.label = label
-        self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputRecordSchema):
@@ -10855,15 +11601,61 @@ class CommandOutputRecordSchema(OutputRecordSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         fields = None
         if "fields" in _doc:
             try:
@@ -11078,15 +11870,15 @@ class CommandOutputRecordSchema(OutputRecordSchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             fields=fields,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -11101,7 +11893,10 @@ class CommandOutputRecordSchema(OutputRecordSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.fields is not None:
             r["fields"] = save(
@@ -11128,21 +11923,13 @@ class CommandOutputRecordSchema(OutputRecordSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["fields", "type", "label", "doc", "name"]
-    )
-
-
-class CommandOutputEnumSchema(OutputEnumSchema):
-    name: str
-
     def __init__(
         self,
-        symbols: Any,
-        type_: Any,
-        name: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
+        type_: Record_name,
+        fields: None | Sequence[CommandOutputRecordField] = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -11151,14 +11938,23 @@ class CommandOutputEnumSchema(OutputEnumSchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
-        self.symbols = symbols
+        self.fields = fields
         self.type_ = type_
         self.label = label
         self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["fields", "type", "label", "doc", "name"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandOutputEnumSchema(OutputEnumSchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputEnumSchema):
@@ -11235,15 +12031,61 @@ class CommandOutputEnumSchema(OutputEnumSchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("symbols") is None:
                 raise ValidationException("missing required field `symbols`", None, [])
@@ -11467,7 +12309,7 @@ class CommandOutputEnumSchema(OutputEnumSchema):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -11482,7 +12324,10 @@ class CommandOutputEnumSchema(OutputEnumSchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.symbols is not None:
             u = save_relative_uri(self.symbols, self.name, True, None, relative_uris)
@@ -11508,21 +12353,13 @@ class CommandOutputEnumSchema(OutputEnumSchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["name", "symbols", "type", "label", "doc"]
-    )
-
-
-class CommandOutputArraySchema(OutputArraySchema):
-    name: str
-
     def __init__(
         self,
-        items: Any,
-        type_: Any,
-        label: Any | None = None,
-        doc: Any | None = None,
-        name: Any | None = None,
+        symbols: Sequence[str],
+        type_: Enum_name,
+        name: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -11531,14 +12368,23 @@ class CommandOutputArraySchema(OutputArraySchema):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.items = items
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.symbols = symbols
         self.type_ = type_
         self.label = label
         self.doc = doc
-        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["name", "symbols", "type", "label", "doc"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandOutputArraySchema(OutputArraySchema):
+    name: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputArraySchema):
@@ -11615,15 +12461,61 @@ class CommandOutputArraySchema(OutputArraySchema):
                                 "is not valid because:",
                             )
                         )
+        name = None
+        if "name" in _doc:
+            try:
+                name = _load_field(
+                    _doc.get("name"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
 
-        __original_name_is_none = name is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if name is None:
             if docRoot is not None:
                 name = docRoot
             else:
                 name = "_:" + str(_uuid__.uuid4())
-        if not __original_name_is_none:
-            baseuri = cast(str, name)
+        else:
+            baseuri = name
         try:
             if _doc.get("items") is None:
                 raise ValidationException("missing required field `items`", None, [])
@@ -11839,15 +12731,15 @@ class CommandOutputArraySchema(OutputArraySchema):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            name=name,
             items=items,
             type_=type_,
             label=label,
             doc=doc,
-            name=name,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        loadingOptions.idx[name] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -11862,7 +12754,10 @@ class CommandOutputArraySchema(OutputArraySchema):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.name is not None:
-            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
+            r["name"] = u
+        if self.name is not None:
+            u = save_relative_uri(self.name, self.name, True, None, relative_uris)
             r["name"] = u
         if self.items is not None:
             u = save_relative_uri(self.items, self.name, False, 2, relative_uris)
@@ -11888,32 +12783,13 @@ class CommandOutputArraySchema(OutputArraySchema):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["items", "type", "label", "doc", "name"]
-    )
-
-
-class CommandInputParameter(InputParameter):
-    """
-    An input parameter for a CommandLineTool.
-
-    """
-
-    id: str
-
     def __init__(
         self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        default: Any | None = None,
-        inputBinding: Any | None = None,
+        items: CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | Sequence[CWLType | CommandOutputArraySchema | CommandOutputEnumSchema | CommandOutputRecordSchema | str] | str,
+        type_: Array_name,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        name: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -11922,20 +12798,28 @@ class CommandInputParameter(InputParameter):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.loadContents = loadContents
-        self.loadListing = loadListing
-        self.default = default
+        self.items = items
         self.type_ = type_
-        self.inputBinding = inputBinding
+        self.label = label
+        self.doc = doc
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["items", "type", "label", "doc", "name"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class CommandInputParameter(InputParameter):
+    """
+    An input parameter for a CommandLineTool.
+
+    """
+
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandInputParameter):
@@ -12032,15 +12916,62 @@ class CommandInputParameter(InputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -12423,7 +13354,7 @@ class CommandInputParameter(InputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_stdinLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2,
+                typedsl_CommandInputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -12537,11 +13468,11 @@ class CommandInputParameter(InputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             loadContents=loadContents,
             loadListing=loadListing,
@@ -12551,7 +13482,7 @@ class CommandInputParameter(InputParameter):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -12566,7 +13497,10 @@ class CommandInputParameter(InputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -12631,6 +13565,42 @@ class CommandInputParameter(InputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        type_: CommandInputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | Sequence[str] | str = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        default: CWLObjectType | None = None,
+        inputBinding: CommandLineBinding | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+        self.default = default
+        self.type_ = type_
+        self.inputBinding = inputBinding
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -12648,6 +13618,7 @@ class CommandInputParameter(InputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandOutputParameter(OutputParameter):
     """
     An output parameter for a CommandLineTool.
@@ -12655,36 +13626,6 @@ class CommandOutputParameter(OutputParameter):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        outputBinding: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.type_ = type_
-        self.outputBinding = outputBinding
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandOutputParameter):
@@ -12775,15 +13716,62 @@ class CommandOutputParameter(OutputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -13025,7 +14013,7 @@ class CommandOutputParameter(OutputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2,
+                typedsl_CommandOutputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -13139,18 +14127,18 @@ class CommandOutputParameter(OutputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             type_=type_,
             outputBinding=outputBinding,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -13165,7 +14153,10 @@ class CommandOutputParameter(OutputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -13212,6 +14203,36 @@ class CommandOutputParameter(OutputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        type_: CommandOutputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | str = None,
+        outputBinding: CommandOutputBinding | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.type_ = type_
+        self.outputBinding = outputBinding
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -13226,6 +14247,7 @@ class CommandOutputParameter(OutputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class CommandLineTool(Process):
     """
     This defines the schema of the CWL Command Line Tool Description document.
@@ -13233,55 +14255,6 @@ class CommandLineTool(Process):
     """
 
     id: str
-
-    def __init__(
-        self,
-        inputs: Any,
-        outputs: Any,
-        id: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        cwlVersion: Any | None = None,
-        intent: Any | None = None,
-        baseCommand: Any | None = None,
-        arguments: Any | None = None,
-        stdin: Any | None = None,
-        stderr: Any | None = None,
-        stdout: Any | None = None,
-        successCodes: Any | None = None,
-        temporaryFailCodes: Any | None = None,
-        permanentFailCodes: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.label = label
-        self.doc = doc
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.cwlVersion = cwlVersion
-        self.intent = intent
-        self.class_: Final[str] = "CommandLineTool"
-        self.baseCommand = baseCommand
-        self.arguments = arguments
-        self.stdin = stdin
-        self.stderr = stderr
-        self.stdout = stdout
-        self.successCodes = successCodes
-        self.temporaryFailCodes = temporaryFailCodes
-        self.permanentFailCodes = permanentFailCodes
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CommandLineTool):
@@ -13392,15 +14365,61 @@ class CommandLineTool(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -13613,7 +14632,7 @@ class CommandLineTool(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -13660,7 +14679,7 @@ class CommandLineTool(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -14217,7 +15236,7 @@ class CommandLineTool(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -14232,7 +15251,10 @@ class CommandLineTool(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -14330,6 +15352,55 @@ class CommandLineTool(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[CommandInputParameter],
+        outputs: Sequence[CommandOutputParameter],
+        id: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        cwlVersion: CWLVersion | None = None,
+        intent: None | Sequence[str] = None,
+        baseCommand: None | Sequence[str] | str = None,
+        arguments: None | Sequence[CommandLineBinding | str] = None,
+        stdin: None | str = None,
+        stderr: None | str = None,
+        stdout: None | str = None,
+        successCodes: None | Sequence[i32] = None,
+        temporaryFailCodes: None | Sequence[i32] = None,
+        permanentFailCodes: None | Sequence[i32] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.label = label
+        self.doc = doc
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.cwlVersion = cwlVersion
+        self.intent = intent
+        self.class_: Final[str] = "CommandLineTool"
+        self.baseCommand = baseCommand
+        self.arguments = arguments
+        self.stdin = stdin
+        self.stderr = stderr
+        self.stdout = stdout
+        self.successCodes = successCodes
+        self.temporaryFailCodes = temporaryFailCodes
+        self.permanentFailCodes = permanentFailCodes
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -14354,6 +15425,7 @@ class CommandLineTool(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class DockerRequirement(ProcessRequirement):
     """
     Indicates that a workflow component should be run in a `Docker <https://docker.com>`__ or Docker-compatible (such as `Singularity <https://www.sylabs.io/>`__ and `udocker <https://github.com/indigo-dc/udocker>`__) container environment and specifies how to fetch or build the image.
@@ -14378,33 +15450,6 @@ class DockerRequirement(ProcessRequirement):
     If `EnvVarRequirement <#EnvVarRequirement>`__ is specified alongside a DockerRequirement, the environment variables must be provided to Docker using ``--env`` or ``--env-file`` and interact with the container's preexisting environment as defined by Docker.
 
     """
-
-    def __init__(
-        self,
-        dockerPull: Any | None = None,
-        dockerLoad: Any | None = None,
-        dockerFile: Any | None = None,
-        dockerImport: Any | None = None,
-        dockerImageId: Any | None = None,
-        dockerOutputDirectory: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "DockerRequirement"
-        self.dockerPull = dockerPull
-        self.dockerLoad = dockerLoad
-        self.dockerFile = dockerFile
-        self.dockerImport = dockerImport
-        self.dockerImageId = dockerImageId
-        self.dockerOutputDirectory = dockerOutputDirectory
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, DockerRequirement):
@@ -14853,6 +15898,33 @@ class DockerRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        dockerPull: None | str = None,
+        dockerLoad: None | str = None,
+        dockerFile: None | str = None,
+        dockerImport: None | str = None,
+        dockerImageId: None | str = None,
+        dockerOutputDirectory: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "DockerRequirement"
+        self.dockerPull = dockerPull
+        self.dockerLoad = dockerLoad
+        self.dockerFile = dockerFile
+        self.dockerImport = dockerImport
+        self.dockerImageId = dockerImageId
+        self.dockerOutputDirectory = dockerOutputDirectory
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -14866,28 +15938,12 @@ class DockerRequirement(ProcessRequirement):
     )
 
 
+@mypyc_attr(native_class=True)
 class SoftwareRequirement(ProcessRequirement):
     """
     A list of software packages that should be configured in the environment of the defined process.
 
     """
-
-    def __init__(
-        self,
-        packages: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "SoftwareRequirement"
-        self.packages = packages
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SoftwareRequirement):
@@ -15041,15 +16097,9 @@ class SoftwareRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "packages"])
-
-
-class SoftwarePackage(Saveable):
     def __init__(
         self,
-        package: Any,
-        version: Any | None = None,
-        specs: Any | None = None,
+        packages: Sequence[SoftwarePackage],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -15058,13 +16108,17 @@ class SoftwarePackage(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.package = package
-        self.version = version
-        self.specs = specs
+        self.class_: Final[str] = "SoftwareRequirement"
+        self.packages = packages
 
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "packages"])
+
+
+@mypyc_attr(native_class=True)
+class SoftwarePackage(Saveable):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SoftwarePackage):
             return bool(
@@ -15297,22 +16351,11 @@ class SoftwarePackage(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["package", "version", "specs"])
-
-
-class Dirent(Saveable):
-    """
-    Define a file or subdirectory that must be staged to a particular place prior to executing the command line tool.  May be the result of executing an expression, such as building a configuration file from a template.
-
-    Usually files are staged within the `designated output directory <#Runtime_environment>`__. However, under certain circumstances, files may be staged at arbitrary locations, see discussion for ``entryname``.
-
-    """
-
     def __init__(
         self,
-        entry: Any,
-        entryname: Any | None = None,
-        writable: Any | None = None,
+        package: str,
+        version: None | Sequence[str] = None,
+        specs: None | Sequence[str] = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -15321,12 +16364,24 @@ class Dirent(Saveable):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.entryname = entryname
-        self.entry = entry
-        self.writable = writable
+        self.package = package
+        self.version = version
+        self.specs = specs
+
+    attrs: ClassVar[Collection[str]] = frozenset(["package", "version", "specs"])
+
+
+@mypyc_attr(native_class=True)
+class Dirent(Saveable):
+    """
+    Define a file or subdirectory that must be staged to a particular place prior to executing the command line tool.  May be the result of executing an expression, such as building a configuration file from a template.
+
+    Usually files are staged within the `designated output directory <#Runtime_environment>`__. However, under certain circumstances, files may be staged at arbitrary locations, see discussion for ``entryname``.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Dirent):
@@ -15564,18 +16619,11 @@ class Dirent(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["entryname", "entry", "writable"])
-
-
-class InitialWorkDirRequirement(ProcessRequirement):
-    """
-    Define a list of files and subdirectories that must be staged by the workflow platform prior to executing the command line tool. Normally files are staged within the designated output directory. However, when running inside containers, files may be staged at arbitrary locations, see discussion for ```Dirent.entryname`` <#Dirent>`__. Together with ``DockerRequirement.dockerOutputDirectory`` it is possible to control the locations of both input and output files when running in containers.
-
-    """
-
     def __init__(
         self,
-        listing: Any,
+        entry: str,
+        entryname: None | str = None,
+        writable: None | bool = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -15584,11 +16632,22 @@ class InitialWorkDirRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "InitialWorkDirRequirement"
-        self.listing = listing
+        self.entryname = entryname
+        self.entry = entry
+        self.writable = writable
+
+    attrs: ClassVar[Collection[str]] = frozenset(["entryname", "entry", "writable"])
+
+
+@mypyc_attr(native_class=True)
+class InitialWorkDirRequirement(ProcessRequirement):
+    """
+    Define a list of files and subdirectories that must be staged by the workflow platform prior to executing the command line tool. Normally files are staged within the designated output directory. However, when running inside containers, files may be staged at arbitrary locations, see discussion for ```Dirent.entryname`` <#Dirent>`__. Together with ``DockerRequirement.dockerOutputDirectory`` it is possible to control the locations of both input and output files when running in containers.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InitialWorkDirRequirement):
@@ -15742,18 +16801,9 @@ class InitialWorkDirRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "listing"])
-
-
-class EnvVarRequirement(ProcessRequirement):
-    """
-    Define a list of environment variables which will be set in the execution environment of the tool.  See ``EnvironmentDef`` for details.
-
-    """
-
     def __init__(
         self,
-        envDef: Any,
+        listing: Sequence[Directory | Dirent | File | None | Sequence[Directory | File] | str] | str,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -15762,11 +16812,21 @@ class EnvVarRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "EnvVarRequirement"
-        self.envDef = envDef
+        self.class_: Final[str] = "InitialWorkDirRequirement"
+        self.listing = listing
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "listing"])
+
+
+@mypyc_attr(native_class=True)
+class EnvVarRequirement(ProcessRequirement):
+    """
+    Define a list of environment variables which will be set in the execution environment of the tool.  See ``EnvironmentDef`` for details.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, EnvVarRequirement):
@@ -15920,17 +16980,9 @@ class EnvVarRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "envDef"])
-
-
-class ShellCommandRequirement(ProcessRequirement):
-    """
-    Modify the behavior of CommandLineTool to generate a single string containing a shell command line.  Each item in the ``arguments`` list must be joined into a string separated by single spaces and quoted to prevent interpretation by the shell, unless ``CommandLineBinding`` for that argument contains ``shellQuote: false``.  If ``shellQuote: false`` is specified, the argument is joined into the command string without quoting, which allows the use of shell metacharacters such as ``|`` for pipes.
-
-    """
-
     def __init__(
         self,
+        envDef: Sequence[EnvironmentDef],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -15939,10 +16991,21 @@ class ShellCommandRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ShellCommandRequirement"
+        self.class_: Final[str] = "EnvVarRequirement"
+        self.envDef = envDef
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "envDef"])
+
+
+@mypyc_attr(native_class=True)
+class ShellCommandRequirement(ProcessRequirement):
+    """
+    Modify the behavior of CommandLineTool to generate a single string containing a shell command line.  Each item in the ``arguments`` list must be joined into a string separated by single spaces and quoted to prevent interpretation by the shell, unless ``CommandLineBinding`` for that argument contains ``shellQuote: false``.  If ``shellQuote: false`` is specified, the argument is joined into the command string without quoting, which allows the use of shell metacharacters such as ``|`` for pipes.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ShellCommandRequirement):
@@ -16041,9 +17104,25 @@ class ShellCommandRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "ShellCommandRequirement"
+
     attrs: ClassVar[Collection[str]] = frozenset(["class"])
 
 
+@mypyc_attr(native_class=True)
 class ResourceRequirement(ProcessRequirement):
     """
     Specify basic hardware resource requirements.
@@ -16063,37 +17142,6 @@ class ResourceRequirement(ProcessRequirement):
     If neither "min" nor "max" is specified for a resource, use the default values below.
 
     """
-
-    def __init__(
-        self,
-        coresMin: Any | None = None,
-        coresMax: Any | None = None,
-        ramMin: Any | None = None,
-        ramMax: Any | None = None,
-        tmpdirMin: Any | None = None,
-        tmpdirMax: Any | None = None,
-        outdirMin: Any | None = None,
-        outdirMax: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ResourceRequirement"
-        self.coresMin = coresMin
-        self.coresMax = coresMax
-        self.ramMin = ramMin
-        self.ramMax = ramMax
-        self.tmpdirMin = tmpdirMin
-        self.tmpdirMax = tmpdirMax
-        self.outdirMin = outdirMin
-        self.outdirMax = outdirMax
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ResourceRequirement):
@@ -16161,7 +17209,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 coresMin = _load_field(
                     _doc.get("coresMin"),
-                    union_of_None_type_or_inttype_or_floattype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_floattype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("coresMin")
@@ -16208,7 +17256,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 coresMax = _load_field(
                     _doc.get("coresMax"),
-                    union_of_None_type_or_inttype_or_floattype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_floattype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("coresMax")
@@ -16255,7 +17303,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 ramMin = _load_field(
                     _doc.get("ramMin"),
-                    union_of_None_type_or_inttype_or_floattype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_floattype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("ramMin")
@@ -16302,7 +17350,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 ramMax = _load_field(
                     _doc.get("ramMax"),
-                    union_of_None_type_or_inttype_or_floattype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_floattype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("ramMax")
@@ -16349,7 +17397,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 tmpdirMin = _load_field(
                     _doc.get("tmpdirMin"),
-                    union_of_None_type_or_inttype_or_floattype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_floattype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("tmpdirMin")
@@ -16396,7 +17444,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 tmpdirMax = _load_field(
                     _doc.get("tmpdirMax"),
-                    union_of_None_type_or_inttype_or_floattype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_floattype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("tmpdirMax")
@@ -16443,7 +17491,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 outdirMin = _load_field(
                     _doc.get("outdirMin"),
-                    union_of_None_type_or_inttype_or_floattype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_floattype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outdirMin")
@@ -16490,7 +17538,7 @@ class ResourceRequirement(ProcessRequirement):
             try:
                 outdirMax = _load_field(
                     _doc.get("outdirMax"),
-                    union_of_None_type_or_inttype_or_floattype_or_ExpressionLoader,
+                    union_of_None_type_or_inttype_or_longtype_or_floattype_or_ExpressionLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("outdirMax")
@@ -16644,6 +17692,37 @@ class ResourceRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        coresMin: None | float | i32 | i64 | str = None,
+        coresMax: None | float | i32 | i64 | str = None,
+        ramMin: None | float | i32 | i64 | str = None,
+        ramMax: None | float | i32 | i64 | str = None,
+        tmpdirMin: None | float | i32 | i64 | str = None,
+        tmpdirMax: None | float | i32 | i64 | str = None,
+        outdirMin: None | float | i32 | i64 | str = None,
+        outdirMax: None | float | i32 | i64 | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "ResourceRequirement"
+        self.coresMin = coresMin
+        self.coresMax = coresMax
+        self.ramMin = ramMin
+        self.ramMax = ramMax
+        self.tmpdirMin = tmpdirMin
+        self.tmpdirMax = tmpdirMax
+        self.outdirMin = outdirMin
+        self.outdirMax = outdirMax
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -16659,6 +17738,7 @@ class ResourceRequirement(ProcessRequirement):
     )
 
 
+@mypyc_attr(native_class=True)
 class WorkReuse(ProcessRequirement):
     """
     For implementations that support reusing output from past work (on the assumption that same code and same input produce same results), control whether to enable or disable the reuse behavior for a particular tool or step (to accommodate situations where that assumption is incorrect).  A reused step is not executed but instead returns the same output as the original execution.
@@ -16666,23 +17746,6 @@ class WorkReuse(ProcessRequirement):
     If ``WorkReuse`` is not specified, correct tools should assume it is enabled by default.
 
     """
-
-    def __init__(
-        self,
-        enableReuse: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "WorkReuse"
-        self.enableReuse = enableReuse
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkReuse):
@@ -16841,9 +17904,27 @@ class WorkReuse(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        enableReuse: bool | str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "WorkReuse"
+        self.enableReuse = enableReuse
+
     attrs: ClassVar[Collection[str]] = frozenset(["class", "enableReuse"])
 
 
+@mypyc_attr(native_class=True)
 class NetworkAccess(ProcessRequirement):
     """
     Indicate whether a process requires outgoing IPv4/IPv6 network access.  Choice of IPv4 or IPv6 is implementation and site specific, correct tools must support both.
@@ -16855,23 +17936,6 @@ class NetworkAccess(ProcessRequirement):
     Enabling network access does not imply a publicly routable IP address or the ability to accept inbound connections.
 
     """
-
-    def __init__(
-        self,
-        networkAccess: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "NetworkAccess"
-        self.networkAccess = networkAccess
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, NetworkAccess):
@@ -17031,9 +18095,27 @@ class NetworkAccess(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        networkAccess: bool | str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "NetworkAccess"
+        self.networkAccess = networkAccess
+
     attrs: ClassVar[Collection[str]] = frozenset(["class", "networkAccess"])
 
 
+@mypyc_attr(native_class=True)
 class InplaceUpdateRequirement(ProcessRequirement):
     """
     If ``inplaceUpdate`` is true, then an implementation supporting this feature may permit tools to directly update files with ``writable: true`` in InitialWorkDirRequirement.  That is, as an optimization, files may be destructively modified in place as opposed to copied and updated.
@@ -17047,23 +18129,6 @@ class InplaceUpdateRequirement(ProcessRequirement):
     Users and implementers should be aware that workflows that destructively modify inputs may not be repeatable or reproducible. In particular, enabling this feature implies that WorkReuse should not be enabled.
 
     """
-
-    def __init__(
-        self,
-        inplaceUpdate: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "InplaceUpdateRequirement"
-        self.inplaceUpdate = inplaceUpdate
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, InplaceUpdateRequirement):
@@ -17223,18 +18288,9 @@ class InplaceUpdateRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "inplaceUpdate"])
-
-
-class ToolTimeLimit(ProcessRequirement):
-    """
-    Set an upper limit on the execution time of a CommandLineTool. A CommandLineTool whose execution duration exceeds the time limit may be preemptively terminated and considered failed. May also be used by batch systems to make scheduling decisions. The execution duration excludes external operations, such as staging of files, pulling a docker image etc, and only counts wall-time for the execution of the command line itself.
-
-    """
-
     def __init__(
         self,
-        timelimit: Any,
+        inplaceUpdate: bool,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -17243,11 +18299,21 @@ class ToolTimeLimit(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ToolTimeLimit"
-        self.timelimit = timelimit
+        self.class_: Final[str] = "InplaceUpdateRequirement"
+        self.inplaceUpdate = inplaceUpdate
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "inplaceUpdate"])
+
+
+@mypyc_attr(native_class=True)
+class ToolTimeLimit(ProcessRequirement):
+    """
+    Set an upper limit on the execution time of a CommandLineTool. A CommandLineTool whose execution duration exceeds the time limit may be preemptively terminated and considered failed. May also be used by batch systems to make scheduling decisions. The execution duration excludes external operations, such as staging of files, pulling a docker image etc, and only counts wall-time for the execution of the command line itself.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ToolTimeLimit):
@@ -17296,7 +18362,7 @@ class ToolTimeLimit(ProcessRequirement):
 
             timelimit = _load_field(
                 _doc.get("timelimit"),
-                union_of_inttype_or_ExpressionLoader,
+                union_of_inttype_or_longtype_or_ExpressionLoader,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("timelimit")
@@ -17406,21 +18472,9 @@ class ToolTimeLimit(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "timelimit"])
-
-
-class ExpressionToolOutputParameter(OutputParameter):
-    id: str
-
     def __init__(
         self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
+        timelimit: i32 | i64 | str,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -17429,16 +18483,18 @@ class ExpressionToolOutputParameter(OutputParameter):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.type_ = type_
+        self.class_: Final[str] = "ToolTimeLimit"
+        self.timelimit = timelimit
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "timelimit"])
+
+
+@mypyc_attr(native_class=True)
+class ExpressionToolOutputParameter(OutputParameter):
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ExpressionToolOutputParameter):
@@ -17527,15 +18583,62 @@ class ExpressionToolOutputParameter(OutputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -17777,7 +18880,7 @@ class ExpressionToolOutputParameter(OutputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2,
+                typedsl_OutputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -17844,17 +18947,17 @@ class ExpressionToolOutputParameter(OutputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             type_=type_,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -17869,7 +18972,10 @@ class ExpressionToolOutputParameter(OutputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -17909,27 +19015,15 @@ class ExpressionToolOutputParameter(OutputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["label", "secondaryFiles", "streamable", "doc", "id", "format", "type"]
-    )
-
-
-class WorkflowInputParameter(InputParameter):
-    id: str
-
     def __init__(
         self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        default: Any | None = None,
-        inputBinding: Any | None = None,
+        id: str,
+        type_: OutputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -17938,20 +19032,25 @@ class WorkflowInputParameter(InputParameter):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
         self.label = label
         self.secondaryFiles = secondaryFiles
         self.streamable = streamable
         self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.id = id
         self.format = format
-        self.loadContents = loadContents
-        self.loadListing = loadListing
-        self.default = default
         self.type_ = type_
-        self.inputBinding = inputBinding
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["label", "secondaryFiles", "streamable", "doc", "id", "format", "type"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class WorkflowInputParameter(InputParameter):
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowInputParameter):
@@ -18048,15 +19147,62 @@ class WorkflowInputParameter(InputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -18439,7 +19585,7 @@ class WorkflowInputParameter(InputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2,
+                typedsl_InputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -18553,11 +19699,11 @@ class WorkflowInputParameter(InputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             loadContents=loadContents,
             loadListing=loadListing,
@@ -18567,7 +19713,7 @@ class WorkflowInputParameter(InputParameter):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -18582,7 +19728,10 @@ class WorkflowInputParameter(InputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -18647,6 +19796,42 @@ class WorkflowInputParameter(InputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        type_: InputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | Sequence[str] | str = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        default: CWLObjectType | None = None,
+        inputBinding: InputBinding | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+        self.default = default
+        self.type_ = type_
+        self.inputBinding = inputBinding
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -18664,6 +19849,7 @@ class WorkflowInputParameter(InputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class ExpressionTool(Process):
     """
     An ExpressionTool is a type of Process object that can be run by itself or as a Workflow step. It executes a pure Javascript expression that has access to the same input parameters as a workflow. It is meant to be used sparingly as a way to isolate complex Javascript expressions that need to operate on input data and produce some result; perhaps just a rearrangement of the inputs. No Docker software container is required or allowed.
@@ -18671,41 +19857,6 @@ class ExpressionTool(Process):
     """
 
     id: str
-
-    def __init__(
-        self,
-        inputs: Any,
-        outputs: Any,
-        expression: Any,
-        id: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        cwlVersion: Any | None = None,
-        intent: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.label = label
-        self.doc = doc
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.cwlVersion = cwlVersion
-        self.intent = intent
-        self.class_: Final[str] = "ExpressionTool"
-        self.expression = expression
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ExpressionTool):
@@ -18802,15 +19953,61 @@ class ExpressionTool(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -19023,7 +20220,7 @@ class ExpressionTool(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -19070,7 +20267,7 @@ class ExpressionTool(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -19292,7 +20489,7 @@ class ExpressionTool(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -19307,7 +20504,10 @@ class ExpressionTool(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -19368,6 +20568,41 @@ class ExpressionTool(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[WorkflowInputParameter],
+        outputs: Sequence[ExpressionToolOutputParameter],
+        expression: str,
+        id: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        cwlVersion: CWLVersion | None = None,
+        intent: None | Sequence[str] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.label = label
+        self.doc = doc
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.cwlVersion = cwlVersion
+        self.intent = intent
+        self.class_: Final[str] = "ExpressionTool"
+        self.expression = expression
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -19385,6 +20620,7 @@ class ExpressionTool(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class WorkflowOutputParameter(OutputParameter):
     """
     Describe an output parameter of a workflow.  The parameter must be connected to one or more parameters defined in the workflow that will provide the value of the output parameter. It is legal to connect a WorkflowInputParameter to a WorkflowOutputParameter.
@@ -19394,40 +20630,6 @@ class WorkflowOutputParameter(OutputParameter):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        outputSource: Any | None = None,
-        linkMerge: Any | None = None,
-        pickValue: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.outputSource = outputSource
-        self.linkMerge = linkMerge
-        self.pickValue = pickValue
-        self.type_ = type_
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowOutputParameter):
@@ -19522,15 +20724,62 @@ class WorkflowOutputParameter(OutputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -19913,7 +21162,7 @@ class WorkflowOutputParameter(OutputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2,
+                typedsl_OutputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -19980,11 +21229,11 @@ class WorkflowOutputParameter(OutputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             outputSource=outputSource,
             linkMerge=linkMerge,
@@ -19993,7 +21242,7 @@ class WorkflowOutputParameter(OutputParameter):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -20008,7 +21257,10 @@ class WorkflowOutputParameter(OutputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -20059,6 +21311,40 @@ class WorkflowOutputParameter(OutputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        type_: OutputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | str = None,
+        outputSource: None | Sequence[str] | str = None,
+        linkMerge: LinkMergeMethod | None = None,
+        pickValue: None | PickValueMethod = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.outputSource = outputSource
+        self.linkMerge = linkMerge
+        self.pickValue = pickValue
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -20075,10 +21361,13 @@ class WorkflowOutputParameter(OutputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
+@trait
 class Sink(Saveable):
     pass
 
 
+@mypyc_attr(native_class=True)
 class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
     """
     The input of a workflow step connects an upstream parameter (from the workflow inputs, or the outputs of other workflows steps) with the input parameters of the process specified by the ``run`` field. Only input parameters declared by the target process will be passed through at runtime to the process though additional parameters may be specified (for use within ``valueFrom`` expressions for instance) - unconnected or unused parameters do not represent an error condition.
@@ -20156,38 +21445,6 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        source: Any | None = None,
-        linkMerge: Any | None = None,
-        pickValue: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        label: Any | None = None,
-        default: Any | None = None,
-        valueFrom: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.source = source
-        self.linkMerge = linkMerge
-        self.pickValue = pickValue
-        self.loadContents = loadContents
-        self.loadListing = loadListing
-        self.label = label
-        self.default = default
-        self.valueFrom = valueFrom
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowStepInput):
@@ -20280,15 +21537,62 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         source = None
         if "source" in _doc:
             try:
@@ -20702,7 +22006,7 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -20717,7 +22021,10 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.source is not None:
             u = save_relative_uri(self.source, self.id, False, 2, relative_uris)
@@ -20765,6 +22072,38 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        source: None | Sequence[str] | str = None,
+        linkMerge: LinkMergeMethod | None = None,
+        pickValue: None | PickValueMethod = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        label: None | str = None,
+        default: CWLObjectType | None = None,
+        valueFrom: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id
+        self.source = source
+        self.linkMerge = linkMerge
+        self.pickValue = pickValue
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+        self.label = label
+        self.default = default
+        self.valueFrom = valueFrom
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -20780,6 +22119,7 @@ class WorkflowStepInput(IdentifierRequired, Sink, LoadContents, Labeled):
     )
 
 
+@mypyc_attr(native_class=True)
 class WorkflowStepOutput(IdentifierRequired):
     """
     Associate an output parameter of the underlying process with a workflow parameter.  The workflow parameter (given in the ``id`` field) be may be used as a ``source`` to connect with input parameters of other workflow steps, or with an output parameter of the process.
@@ -20789,22 +22129,6 @@ class WorkflowStepOutput(IdentifierRequired):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowStepOutput):
@@ -20875,15 +22199,62 @@ class WorkflowStepOutput(IdentifierRequired):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         extension_fields: MutableMapping[str, Any] = {}
         for k in _doc.keys():
             if k not in cls.attrs:
@@ -20911,7 +22282,7 @@ class WorkflowStepOutput(IdentifierRequired):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -20926,7 +22297,10 @@ class WorkflowStepOutput(IdentifierRequired):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
 
         # top refers to the directory level
@@ -20937,9 +22311,26 @@ class WorkflowStepOutput(IdentifierRequired):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id
+
     attrs: ClassVar[Collection[str]] = frozenset(["id"])
 
 
+@mypyc_attr(native_class=True)
 class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Documented):
     """
     A workflow step is an executable element of a workflow.  It specifies the underlying process implementation (such as ``CommandLineTool`` or another ``Workflow``) in the ``run`` field and connects the input and output parameters of the underlying process to workflow parameters.
@@ -20986,42 +22377,6 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        in_: Any,
-        out: Any,
-        run: Any,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        when: Any | None = None,
-        scatter: Any | None = None,
-        scatterMethod: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.label = label
-        self.doc = doc
-        self.in_ = in_
-        self.out = out
-        self.requirements = requirements
-        self.hints = hints
-        self.run = run
-        self.when = when
-        self.scatter = scatter
-        self.scatterMethod = scatterMethod
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowStep):
@@ -21118,15 +22473,62 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -21322,7 +22724,7 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -21419,7 +22821,7 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
 
             run = _load_field(
                 _doc.get("run"),
-                uri_union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader_False_False_None_None,
+                uri_union_of_strtype_or_ProcessProxyLoader_False_False_None_None,
                 subscope_baseuri,
                 loadingOptions,
                 lc=_doc.get("run")
@@ -21641,7 +23043,7 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -21656,7 +23058,10 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -21708,6 +23113,42 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        in_: Sequence[WorkflowStepInput],
+        out: Sequence[WorkflowStepOutput | str],
+        run: Process | str,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any] = None,
+        when: None | str = None,
+        scatter: None | Sequence[str] | str = None,
+        scatterMethod: None | ScatterMethod = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id
+        self.label = label
+        self.doc = doc
+        self.in_ = in_
+        self.out = out
+        self.requirements = requirements
+        self.hints = hints
+        self.run = run
+        self.when = when
+        self.scatter = scatter
+        self.scatterMethod = scatterMethod
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -21725,6 +23166,7 @@ class WorkflowStep(IdentifierRequired, Labeled, schema_salad.metaschema.Document
     )
 
 
+@mypyc_attr(native_class=True)
 class Workflow(Process):
     """
     A workflow describes a set of **steps** and the **dependencies** between those steps.  When a step produces output that will be consumed by a second step, the first step is a dependency of the second step.
@@ -21756,41 +23198,6 @@ class Workflow(Process):
     """
 
     id: str
-
-    def __init__(
-        self,
-        inputs: Any,
-        outputs: Any,
-        steps: Any,
-        id: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        cwlVersion: Any | None = None,
-        intent: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.label = label
-        self.doc = doc
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.cwlVersion = cwlVersion
-        self.intent = intent
-        self.class_: Final[str] = "Workflow"
-        self.steps = steps
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Workflow):
@@ -21887,15 +23294,61 @@ class Workflow(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -22108,7 +23561,7 @@ class Workflow(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -22155,7 +23608,7 @@ class Workflow(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -22377,7 +23830,7 @@ class Workflow(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -22392,7 +23845,10 @@ class Workflow(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -22450,6 +23906,41 @@ class Workflow(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[WorkflowInputParameter],
+        outputs: Sequence[WorkflowOutputParameter],
+        steps: Sequence[WorkflowStep],
+        id: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        cwlVersion: CWLVersion | None = None,
+        intent: None | Sequence[str] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.label = label
+        self.doc = doc
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.cwlVersion = cwlVersion
+        self.intent = intent
+        self.class_: Final[str] = "Workflow"
+        self.steps = steps
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -22467,26 +23958,12 @@ class Workflow(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class SubworkflowFeatureRequirement(ProcessRequirement):
     """
     Indicates that the workflow platform must support nested workflows in the ``run`` field of `WorkflowStep <#WorkflowStep>`__.
 
     """
-
-    def __init__(
-        self,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "SubworkflowFeatureRequirement"
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, SubworkflowFeatureRequirement):
@@ -22585,15 +24062,6 @@ class SubworkflowFeatureRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class ScatterFeatureRequirement(ProcessRequirement):
-    """
-    Indicates that the workflow platform must support the ``scatter`` and ``scatterMethod`` fields of `WorkflowStep <#WorkflowStep>`__.
-
-    """
-
     def __init__(
         self,
         extension_fields: MutableMapping[str, Any] | None = None,
@@ -22604,10 +24072,20 @@ class ScatterFeatureRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ScatterFeatureRequirement"
+        self.class_: Final[str] = "SubworkflowFeatureRequirement"
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class ScatterFeatureRequirement(ProcessRequirement):
+    """
+    Indicates that the workflow platform must support the ``scatter`` and ``scatterMethod`` fields of `WorkflowStep <#WorkflowStep>`__.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ScatterFeatureRequirement):
@@ -22706,15 +24184,6 @@ class ScatterFeatureRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class MultipleInputFeatureRequirement(ProcessRequirement):
-    """
-    Indicates that the workflow platform must support multiple inbound data links listed in the ``source`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
-
-    """
-
     def __init__(
         self,
         extension_fields: MutableMapping[str, Any] | None = None,
@@ -22725,10 +24194,20 @@ class MultipleInputFeatureRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "MultipleInputFeatureRequirement"
+        self.class_: Final[str] = "ScatterFeatureRequirement"
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class MultipleInputFeatureRequirement(ProcessRequirement):
+    """
+    Indicates that the workflow platform must support multiple inbound data links listed in the ``source`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, MultipleInputFeatureRequirement):
@@ -22827,15 +24306,6 @@ class MultipleInputFeatureRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class StepInputExpressionRequirement(ProcessRequirement):
-    """
-    Indicate that the workflow platform must support the ``valueFrom`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
-
-    """
-
     def __init__(
         self,
         extension_fields: MutableMapping[str, Any] | None = None,
@@ -22846,10 +24316,20 @@ class StepInputExpressionRequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "StepInputExpressionRequirement"
+        self.class_: Final[str] = "MultipleInputFeatureRequirement"
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class StepInputExpressionRequirement(ProcessRequirement):
+    """
+    Indicate that the workflow platform must support the ``valueFrom`` field of `WorkflowStepInput <#WorkflowStepInput>`__.
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, StepInputExpressionRequirement):
@@ -22948,29 +24428,8 @@ class StepInputExpressionRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class"])
-
-
-class OperationInputParameter(InputParameter):
-    """
-    Describe an input parameter of an operation.
-
-    """
-
-    id: str
-
     def __init__(
         self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        loadContents: Any | None = None,
-        loadListing: Any | None = None,
-        default: Any | None = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -22979,19 +24438,22 @@ class OperationInputParameter(InputParameter):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.loadContents = loadContents
-        self.loadListing = loadListing
-        self.default = default
-        self.type_ = type_
+        self.class_: Final[str] = "StepInputExpressionRequirement"
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class"])
+
+
+@mypyc_attr(native_class=True)
+class OperationInputParameter(InputParameter):
+    """
+    Describe an input parameter of an operation.
+
+    """
+
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OperationInputParameter):
@@ -23086,15 +24548,62 @@ class OperationInputParameter(InputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -23477,7 +24986,7 @@ class OperationInputParameter(InputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2,
+                typedsl_InputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -23544,11 +25053,11 @@ class OperationInputParameter(InputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             loadContents=loadContents,
             loadListing=loadListing,
@@ -23557,7 +25066,7 @@ class OperationInputParameter(InputParameter):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -23572,7 +25081,10 @@ class OperationInputParameter(InputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -23630,6 +25142,40 @@ class OperationInputParameter(InputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        id: str,
+        type_: InputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | Sequence[str] | str = None,
+        loadContents: None | bool = None,
+        loadListing: LoadListingEnum | None = None,
+        default: CWLObjectType | None = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
+        self.doc = doc
+        self.id = id
+        self.format = format
+        self.loadContents = loadContents
+        self.loadListing = loadListing
+        self.default = default
+        self.type_ = type_
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "label",
@@ -23646,6 +25192,7 @@ class OperationInputParameter(InputParameter):
     )
 
 
+@mypyc_attr(native_class=True)
 class OperationOutputParameter(OutputParameter):
     """
     Describe an output parameter of an operation.
@@ -23653,34 +25200,6 @@ class OperationOutputParameter(OutputParameter):
     """
 
     id: str
-
-    def __init__(
-        self,
-        id: Any,
-        type_: Any,
-        label: Any | None = None,
-        secondaryFiles: Any | None = None,
-        streamable: Any | None = None,
-        doc: Any | None = None,
-        format: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.label = label
-        self.secondaryFiles = secondaryFiles
-        self.streamable = streamable
-        self.doc = doc
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.format = format
-        self.type_ = type_
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, OperationOutputParameter):
@@ -23769,15 +25288,62 @@ class OperationOutputParameter(OutputParameter):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
+                id = ""
                 _errors__.append(ValidationException("missing id"))
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         label = None
         if "label" in _doc:
             try:
@@ -24019,7 +25585,7 @@ class OperationOutputParameter(OutputParameter):
 
             type_ = _load_field(
                 _doc.get("type"),
-                typedsl_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2,
+                typedsl_OutputParameterTypeLoader_2,
                 baseuri,
                 loadingOptions,
                 lc=_doc.get("type")
@@ -24086,17 +25652,17 @@ class OperationOutputParameter(OutputParameter):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
+            id=id,
             label=label,
             secondaryFiles=secondaryFiles,
             streamable=streamable,
             doc=doc,
-            id=id,
             format=format,
             type_=type_,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -24111,7 +25677,10 @@ class OperationOutputParameter(OutputParameter):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.label is not None:
             r["label"] = save(
@@ -24151,30 +25720,15 @@ class OperationOutputParameter(OutputParameter):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["label", "secondaryFiles", "streamable", "doc", "id", "format", "type"]
-    )
-
-
-class Operation(Process):
-    """
-    This record describes an abstract operation.  It is a potential step of a workflow that has not yet been bound to a concrete implementation.  It specifies an input and output signature, but does not provide enough information to be executed.  An implementation (or other tooling) may provide a means of binding an Operation to a concrete process (such as Workflow, CommandLineTool, or ExpressionTool) with a compatible signature.
-
-    """
-
-    id: str
-
     def __init__(
         self,
-        inputs: Any,
-        outputs: Any,
-        id: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        cwlVersion: Any | None = None,
-        intent: Any | None = None,
+        id: str,
+        type_: OutputParameterType,
+        label: None | str = None,
+        secondaryFiles: None | SecondaryFileSchema | Sequence[SecondaryFileSchema] = None,
+        streamable: None | bool = None,
+        doc: None | Sequence[str] | str = None,
+        format: None | str = None,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -24183,19 +25737,30 @@ class Operation(Process):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
         self.label = label
+        self.secondaryFiles = secondaryFiles
+        self.streamable = streamable
         self.doc = doc
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.cwlVersion = cwlVersion
-        self.intent = intent
-        self.class_: Final[str] = "Operation"
+        self.id = id
+        self.format = format
+        self.type_ = type_
+
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["label", "secondaryFiles", "streamable", "doc", "id", "format", "type"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class Operation(Process):
+    """
+    This record describes an abstract operation.  It is a potential step of a workflow that has not yet been bound to a concrete implementation.  It specifies an input and output signature, but does not provide enough information to be executed.  An implementation (or other tooling) may provide a means of binding an Operation to a concrete process (such as Workflow, CommandLineTool, or ExpressionTool) with a compatible signature.
+
+    """
+
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Operation):
@@ -24290,15 +25855,61 @@ class Operation(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -24511,7 +26122,7 @@ class Operation(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -24558,7 +26169,7 @@ class Operation(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -24731,7 +26342,7 @@ class Operation(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -24746,7 +26357,10 @@ class Operation(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -24800,6 +26414,39 @@ class Operation(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[OperationInputParameter],
+        outputs: Sequence[OperationOutputParameter],
+        id: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        cwlVersion: CWLVersion | None = None,
+        intent: None | Sequence[str] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.label = label
+        self.doc = doc
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.cwlVersion = cwlVersion
+        self.intent = intent
+        self.class_: Final[str] = "Operation"
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -24816,24 +26463,8 @@ class Operation(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class Secrets(ProcessRequirement):
-    def __init__(
-        self,
-        secrets: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "Secrets"
-        self.secrets = secrets
-
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Secrets):
             return bool(self.class_ == other.class_ and self.secrets == other.secrets)
@@ -24985,24 +26616,9 @@ class Secrets(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "secrets"])
-
-
-class ProcessGenerator(Process):
-    id: str
-
     def __init__(
         self,
-        inputs: Any,
-        outputs: Any,
-        run: Any,
-        id: Any | None = None,
-        label: Any | None = None,
-        doc: Any | None = None,
-        requirements: Any | None = None,
-        hints: Any | None = None,
-        cwlVersion: Any | None = None,
-        intent: Any | None = None,
+        secrets: Sequence[str],
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -25011,20 +26627,18 @@ class ProcessGenerator(Process):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.label = label
-        self.doc = doc
-        self.inputs = inputs
-        self.outputs = outputs
-        self.requirements = requirements
-        self.hints = hints
-        self.cwlVersion = cwlVersion
-        self.intent = intent
-        self.class_: Final[str] = "ProcessGenerator"
-        self.run = run
+        self.class_: Final[str] = "Secrets"
+        self.secrets = secrets
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "secrets"])
+
+
+@mypyc_attr(native_class=True)
+class ProcessGenerator(Process):
+    id: str
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ProcessGenerator):
@@ -25121,15 +26735,61 @@ class ProcessGenerator(Process):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         try:
             if _doc.get("class") is None:
                 raise ValidationException("missing required field `class`", None, [])
@@ -25342,7 +27002,7 @@ class ProcessGenerator(Process):
             try:
                 requirements = _load_field(
                     _doc.get("requirements"),
-                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement,
+                    idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("requirements")
@@ -25389,7 +27049,7 @@ class ProcessGenerator(Process):
             try:
                 hints = _load_field(
                     _doc.get("hints"),
-                    idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type,
+                    idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
                     baseuri,
                     loadingOptions,
                     lc=_doc.get("hints")
@@ -25533,7 +27193,7 @@ class ProcessGenerator(Process):
 
             run = _load_field(
                 _doc.get("run"),
-                uri_union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader_False_False_None_None,
+                uri_union_of_strtype_or_ProcessProxyLoader_False_False_None_None,
                 subscope_baseuri,
                 loadingOptions,
                 lc=_doc.get("run")
@@ -25613,7 +27273,7 @@ class ProcessGenerator(Process):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -25628,7 +27288,10 @@ class ProcessGenerator(Process):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.class_ is not None:
             vocab = _vocab | self.loadingOptions.vocab
@@ -25685,6 +27348,41 @@ class ProcessGenerator(Process):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        inputs: Sequence[WorkflowInputParameter],
+        outputs: Sequence[ExpressionToolOutputParameter],
+        run: Process | str,
+        id: None | str = None,
+        label: None | str = None,
+        doc: None | Sequence[str] | str = None,
+        requirements: None | Sequence[ProcessRequirement] = None,
+        hints: None | Sequence[Any | ProcessRequirement] = None,
+        cwlVersion: CWLVersion | None = None,
+        intent: None | Sequence[str] = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.label = label
+        self.doc = doc
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.hints = hints
+        self.cwlVersion = cwlVersion
+        self.intent = intent
+        self.class_: Final[str] = "ProcessGenerator"
+        self.run = run
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "id",
@@ -25702,28 +27400,12 @@ class ProcessGenerator(Process):
     )
 
 
+@mypyc_attr(native_class=True)
 class MPIRequirement(ProcessRequirement):
     """
     Indicates that a process requires an MPI runtime.
 
     """
-
-    def __init__(
-        self,
-        processes: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "MPIRequirement"
-        self.processes = processes
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, MPIRequirement):
@@ -25882,21 +27564,9 @@ class MPIRequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(["class", "processes"])
-
-
-class CUDARequirement(ProcessRequirement):
-    """
-    Require support for NVIDA CUDA (GPU hardware acceleration).
-
-    """
-
     def __init__(
         self,
-        cudaComputeCapability: Any,
-        cudaVersionMin: Any,
-        cudaDeviceCountMax: Any | None = None,
-        cudaDeviceCountMin: Any | None = None,
+        processes: i32 | str,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -25905,14 +27575,21 @@ class CUDARequirement(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "CUDARequirement"
-        self.cudaComputeCapability = cudaComputeCapability
-        self.cudaDeviceCountMax = cudaDeviceCountMax
-        self.cudaDeviceCountMin = cudaDeviceCountMin
-        self.cudaVersionMin = cudaVersionMin
+        self.class_: Final[str] = "MPIRequirement"
+        self.processes = processes
+
+    attrs: ClassVar[Collection[str]] = frozenset(["class", "processes"])
+
+
+@mypyc_attr(native_class=True)
+class CUDARequirement(ProcessRequirement):
+    """
+    Require support for NVIDA CUDA (GPU hardware acceleration).
+
+    """
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CUDARequirement):
@@ -26249,6 +27926,29 @@ class CUDARequirement(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        cudaComputeCapability: Sequence[str] | str,
+        cudaVersionMin: str,
+        cudaDeviceCountMax: None | i32 | str = None,
+        cudaDeviceCountMin: None | i32 | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "CUDARequirement"
+        self.cudaComputeCapability = cudaComputeCapability
+        self.cudaDeviceCountMax = cudaDeviceCountMax
+        self.cudaDeviceCountMin = cudaDeviceCountMin
+        self.cudaVersionMin = cudaVersionMin
+
     attrs: ClassVar[Collection[str]] = frozenset(
         [
             "class",
@@ -26260,34 +27960,9 @@ class CUDARequirement(ProcessRequirement):
     )
 
 
+@mypyc_attr(native_class=True)
 class LoopInput(Saveable):
     id: str
-
-    def __init__(
-        self,
-        default: Any | None = None,
-        id: Any | None = None,
-        linkMerge: Any | None = None,
-        loopSource: Any | None = None,
-        pickValue: Any | None = None,
-        valueFrom: Any | None = None,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.default = default
-        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
-        self.linkMerge = linkMerge
-        self.loopSource = loopSource
-        self.pickValue = pickValue
-        self.valueFrom = valueFrom
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, LoopInput):
@@ -26374,15 +28049,61 @@ class LoopInput(Saveable):
                                 "is not valid because:",
                             )
                         )
+        id = None
+        if "id" in _doc:
+            try:
+                id = _load_field(
+                    _doc.get("id"),
+                    uri_union_of_None_type_or_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("id")
+                )
 
-        __original_id_is_none = id is None
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `id`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("id")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `id` field is not valid because:",
+                                SourceLine(_doc, "id", str),
+                                [e],
+                                detailed_message=f"the `id` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
         if id is None:
             if docRoot is not None:
                 id = docRoot
             else:
                 id = "_:" + str(_uuid__.uuid4())
-        if not __original_id_is_none:
-            baseuri = cast(str, id)
+        else:
+            baseuri = id
         default = None
         if "default" in _doc:
             try:
@@ -26643,8 +28364,8 @@ class LoopInput(Saveable):
         if _errors__:
             raise ValidationException("", None, _errors__, "*")
         _constructed = cls(
-            default=default,
             id=id,
+            default=default,
             linkMerge=linkMerge,
             loopSource=loopSource,
             pickValue=pickValue,
@@ -26652,7 +28373,7 @@ class LoopInput(Saveable):
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
-        loadingOptions.idx[cast(str, id)] = (_constructed, loadingOptions)
+        loadingOptions.idx[id] = (_constructed, loadingOptions)
         return _constructed
 
     def save(
@@ -26667,7 +28388,10 @@ class LoopInput(Saveable):
             for ef in self.extension_fields:
                 r[ef] = self.extension_fields[ef]
         if self.id is not None:
-            u = save_relative_uri(self.id, base_url, True, None, relative_uris)
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
+            r["id"] = u
+        if self.id is not None:
+            u = save_relative_uri(self.id, self.id, True, None, relative_uris)
             r["id"] = u
         if self.default is not None:
             r["default"] = save(
@@ -26697,11 +28421,38 @@ class LoopInput(Saveable):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        default: Any | None = None,
+        id: None | str = None,
+        linkMerge: LinkMergeMethod | None = None,
+        loopSource: None | Sequence[str] | str = None,
+        pickValue: None | PickValueMethod = None,
+        valueFrom: None | str = None,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.default = default
+        self.id = id if id is not None else "_:" + str(_uuid__.uuid4())
+        self.linkMerge = linkMerge
+        self.loopSource = loopSource
+        self.pickValue = pickValue
+        self.valueFrom = valueFrom
+
     attrs: ClassVar[Collection[str]] = frozenset(
         ["default", "id", "linkMerge", "loopSource", "pickValue", "valueFrom"]
     )
 
 
+@mypyc_attr(native_class=True)
 class Loop(ProcessRequirement):
     """
     Prototype to enable workflow-level looping of a step.
@@ -26715,27 +28466,6 @@ class Loop(ProcessRequirement):
     ``loopWhen`` is not compatible with ``scatter`` at this time and combining the two in the same step will produce an error.
 
     """
-
-    def __init__(
-        self,
-        loop: Any,
-        loopWhen: Any,
-        outputMethod: Any,
-        extension_fields: MutableMapping[str, Any] | None = None,
-        loadingOptions: LoadingOptions | None = None,
-    ) -> None:
-        if extension_fields:
-            self.extension_fields = extension_fields
-        else:
-            self.extension_fields = CommentedMap()
-        if loadingOptions:
-            self.loadingOptions = loadingOptions
-        else:
-            self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "Loop"
-        self.loop = loop
-        self.loopWhen = loopWhen
-        self.outputMethod = outputMethod
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Loop):
@@ -27003,15 +28733,11 @@ class Loop(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
-    attrs: ClassVar[Collection[str]] = frozenset(
-        ["class", "loop", "loopWhen", "outputMethod"]
-    )
-
-
-class ShmSize(ProcessRequirement):
     def __init__(
         self,
-        shmSize: Any,
+        loop: Sequence[LoopInput],
+        loopWhen: str,
+        outputMethod: LoopOutputModes,
         extension_fields: MutableMapping[str, Any] | None = None,
         loadingOptions: LoadingOptions | None = None,
     ) -> None:
@@ -27020,12 +28746,21 @@ class ShmSize(ProcessRequirement):
         else:
             self.extension_fields = CommentedMap()
         if loadingOptions:
-            self.loadingOptions = loadingOptions
+            self.loadingOptions: LoadingOptions = loadingOptions
         else:
             self.loadingOptions = LoadingOptions()
-        self.class_: Final[str] = "ShmSize"
-        self.shmSize = shmSize
+        self.class_: Final[str] = "Loop"
+        self.loop = loop
+        self.loopWhen = loopWhen
+        self.outputMethod = outputMethod
 
+    attrs: ClassVar[Collection[str]] = frozenset(
+        ["class", "loop", "loopWhen", "outputMethod"]
+    )
+
+
+@mypyc_attr(native_class=True)
+class ShmSize(ProcessRequirement):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ShmSize):
             return bool(self.class_ == other.class_ and self.shmSize == other.shmSize)
@@ -27178,6 +28913,23 @@ class ShmSize(ProcessRequirement):
                 r["$schemas"] = self.loadingOptions.schemas
         return r
 
+    def __init__(
+        self,
+        shmSize: str,
+        extension_fields: MutableMapping[str, Any] | None = None,
+        loadingOptions: LoadingOptions | None = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions: LoadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.class_: Final[str] = "ShmSize"
+        self.shmSize = shmSize
+
     attrs: ClassVar[Collection[str]] = frozenset(["class", "shmSize"])
 
 
@@ -27195,6 +28947,7 @@ _vocab.update({
     "CommandInputArraySchema": "https://w3id.org/cwl/cwl#CommandInputArraySchema",
     "CommandInputEnumSchema": "https://w3id.org/cwl/cwl#CommandInputEnumSchema",
     "CommandInputParameter": "https://w3id.org/cwl/cwl#CommandInputParameter",
+    "CommandInputParameterType": "https://w3id.org/cwl/cwl#CommandInputParameterType",
     "CommandInputRecordField": "https://w3id.org/cwl/cwl#CommandInputRecordField",
     "CommandInputRecordSchema": "https://w3id.org/cwl/cwl#CommandInputRecordSchema",
     "CommandInputSchema": "https://w3id.org/cwl/cwl#CommandInputSchema",
@@ -27205,6 +28958,7 @@ _vocab.update({
     "CommandOutputBinding": "https://w3id.org/cwl/cwl#CommandOutputBinding",
     "CommandOutputEnumSchema": "https://w3id.org/cwl/cwl#CommandOutputEnumSchema",
     "CommandOutputParameter": "https://w3id.org/cwl/cwl#CommandOutputParameter",
+    "CommandOutputParameterType": "https://w3id.org/cwl/cwl#CommandOutputParameterType",
     "CommandOutputRecordField": "https://w3id.org/cwl/cwl#CommandOutputRecordField",
     "CommandOutputRecordSchema": "https://w3id.org/cwl/cwl#CommandOutputRecordSchema",
     "Directory": "https://w3id.org/cwl/cwl#Directory",
@@ -27231,6 +28985,7 @@ _vocab.update({
     "InputEnumSchema": "https://w3id.org/cwl/cwl#InputEnumSchema",
     "InputFormat": "https://w3id.org/cwl/cwl#InputFormat",
     "InputParameter": "https://w3id.org/cwl/cwl#InputParameter",
+    "InputParameterType": "https://w3id.org/cwl/cwl#InputParameterType",
     "InputRecordField": "https://w3id.org/cwl/cwl#InputRecordField",
     "InputRecordSchema": "https://w3id.org/cwl/cwl#InputRecordSchema",
     "InputSchema": "https://w3id.org/cwl/cwl#InputSchema",
@@ -27252,6 +29007,7 @@ _vocab.update({
     "OutputEnumSchema": "https://w3id.org/cwl/cwl#OutputEnumSchema",
     "OutputFormat": "https://w3id.org/cwl/cwl#OutputFormat",
     "OutputParameter": "https://w3id.org/cwl/cwl#OutputParameter",
+    "OutputParameterType": "https://w3id.org/cwl/cwl#OutputParameterType",
     "OutputRecordField": "https://w3id.org/cwl/cwl#OutputRecordField",
     "OutputRecordSchema": "https://w3id.org/cwl/cwl#OutputRecordSchema",
     "OutputSchema": "https://w3id.org/cwl/cwl#OutputSchema",
@@ -27329,6 +29085,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#CommandInputArraySchema": "CommandInputArraySchema",
     "https://w3id.org/cwl/cwl#CommandInputEnumSchema": "CommandInputEnumSchema",
     "https://w3id.org/cwl/cwl#CommandInputParameter": "CommandInputParameter",
+    "https://w3id.org/cwl/cwl#CommandInputParameterType": "CommandInputParameterType",
     "https://w3id.org/cwl/cwl#CommandInputRecordField": "CommandInputRecordField",
     "https://w3id.org/cwl/cwl#CommandInputRecordSchema": "CommandInputRecordSchema",
     "https://w3id.org/cwl/cwl#CommandInputSchema": "CommandInputSchema",
@@ -27339,6 +29096,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#CommandOutputBinding": "CommandOutputBinding",
     "https://w3id.org/cwl/cwl#CommandOutputEnumSchema": "CommandOutputEnumSchema",
     "https://w3id.org/cwl/cwl#CommandOutputParameter": "CommandOutputParameter",
+    "https://w3id.org/cwl/cwl#CommandOutputParameterType": "CommandOutputParameterType",
     "https://w3id.org/cwl/cwl#CommandOutputRecordField": "CommandOutputRecordField",
     "https://w3id.org/cwl/cwl#CommandOutputRecordSchema": "CommandOutputRecordSchema",
     "https://w3id.org/cwl/cwl#Directory": "Directory",
@@ -27365,6 +29123,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#InputEnumSchema": "InputEnumSchema",
     "https://w3id.org/cwl/cwl#InputFormat": "InputFormat",
     "https://w3id.org/cwl/cwl#InputParameter": "InputParameter",
+    "https://w3id.org/cwl/cwl#InputParameterType": "InputParameterType",
     "https://w3id.org/cwl/cwl#InputRecordField": "InputRecordField",
     "https://w3id.org/cwl/cwl#InputRecordSchema": "InputRecordSchema",
     "https://w3id.org/cwl/cwl#InputSchema": "InputSchema",
@@ -27386,6 +29145,7 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#OutputEnumSchema": "OutputEnumSchema",
     "https://w3id.org/cwl/cwl#OutputFormat": "OutputFormat",
     "https://w3id.org/cwl/cwl#OutputParameter": "OutputParameter",
+    "https://w3id.org/cwl/cwl#OutputParameterType": "OutputParameterType",
     "https://w3id.org/cwl/cwl#OutputRecordField": "OutputRecordField",
     "https://w3id.org/cwl/cwl#OutputRecordSchema": "OutputRecordSchema",
     "https://w3id.org/cwl/cwl#OutputSchema": "OutputSchema",
@@ -27450,14 +29210,20 @@ _rvocab.update({
     "https://w3id.org/cwl/cwl#v1.2": "v1.2",
 })
 
-strtype: Final = _PrimitiveLoader(str)
-inttype: Final = _PrimitiveLoader(int)
-floattype: Final = _PrimitiveLoader(float)
-booltype: Final = _PrimitiveLoader(bool)
-None_type: Final = _PrimitiveLoader(type(None))
-Any_type: Final = _AnyLoader()
-DocumentedProxyLoader: Final = _ProxyLoader("DocumentedLoader")
-PrimitiveTypeLoader: Final = _EnumLoader(
+strtype: Final[Loader[str]] = _PrimitiveLoader(str)
+inttype: Final[Loader[i32]] = _PrimitiveLoader(i32)
+longtype: Final[Loader[i64]] = _PrimitiveLoader(i64)
+floattype: Final[Loader[float]] = _PrimitiveLoader(float)
+booltype: Final[Loader[bool]] = _PrimitiveLoader(bool)
+None_type: Final[Loader[None]] = _PrimitiveLoader(type(None))
+Any_type: Final[Loader[Any]] = _AnyLoader()
+DocumentedProxyLoader: Final[Loader[schema_salad.metaschema.Documented]] = _ProxyLoader(
+    "DocumentedLoader"
+)
+PrimitiveType: TypeAlias = Literal[
+    "null", "boolean", "int", "long", "float", "double", "string"
+]
+PrimitiveTypeLoader: Final[Loader[PrimitiveType]] = _EnumLoader[PrimitiveType](
     (
         "null",
         "boolean",
@@ -27488,25 +29254,33 @@ double: double precision (64-bit) IEEE 754 floating-point number
 
 string: Unicode character sequence
 """
-AnyLoader: Final = _EnumLoader(("Any",), "Any")
+Any_: TypeAlias = Literal["Any"]
+Any_Loader: Final[Loader[Any_]] = _EnumLoader[Any_](("Any",), "Any_")
 """
 The **Any** type validates for any non-null value.
 """
-RecordFieldLoader: Final = _RecordLoader(
+RecordFieldLoader: Final[Loader[schema_salad.metaschema.RecordField]] = _RecordLoader(
     schema_salad.metaschema.RecordField, None, None
 )
-RecordSchemaLoader: Final = _RecordLoader(
+RecordSchemaLoader: Final[Loader[schema_salad.metaschema.RecordSchema]] = _RecordLoader(
     schema_salad.metaschema.RecordSchema, None, None
 )
-EnumSchemaLoader: Final = _RecordLoader(schema_salad.metaschema.EnumSchema, None, None)
-ArraySchemaLoader: Final = _RecordLoader(
+EnumSchemaLoader: Final[Loader[schema_salad.metaschema.EnumSchema]] = _RecordLoader(
+    schema_salad.metaschema.EnumSchema, None, None
+)
+ArraySchemaLoader: Final[Loader[schema_salad.metaschema.ArraySchema]] = _RecordLoader(
     schema_salad.metaschema.ArraySchema, None, None
 )
-MapSchemaLoader: Final = _RecordLoader(schema_salad.metaschema.MapSchema, None, None)
-UnionSchemaLoader: Final = _RecordLoader(
+MapSchemaLoader: Final[Loader[schema_salad.metaschema.MapSchema]] = _RecordLoader(
+    schema_salad.metaschema.MapSchema, None, None
+)
+UnionSchemaLoader: Final[Loader[schema_salad.metaschema.UnionSchema]] = _RecordLoader(
     schema_salad.metaschema.UnionSchema, None, None
 )
-CWLTypeLoader: Final = _EnumLoader(
+CWLType: TypeAlias = Literal[
+    "null", "boolean", "int", "long", "float", "double", "string", "File", "Directory"
+]
+CWLTypeLoader: Final[Loader[CWLType]] = _EnumLoader[CWLType](
     (
         "null",
         "boolean",
@@ -27527,120 +29301,51 @@ File: A File object
 
 Directory: A Directory object
 """
-CWLArraySchemaLoader: Final = _RecordLoader(CWLArraySchema, None, None)
-CWLRecordFieldLoader: Final = _RecordLoader(CWLRecordField, None, None)
-CWLRecordSchemaLoader: Final = _RecordLoader(CWLRecordSchema, None, None)
-FileLoader: Final = _RecordLoader(File, None, None)
-DirectoryLoader: Final = _RecordLoader(Directory, None, None)
-CWLObjectTypeLoader: Final = _UnionLoader((), "CWLObjectTypeLoader")
-union_of_None_type_or_CWLObjectTypeLoader: Final = _UnionLoader(
-    (
-        None_type,
-        CWLObjectTypeLoader,
-    )
+CWLArraySchemaLoader: Final[Loader[CWLArraySchema]] = _RecordLoader(
+    CWLArraySchema, None, None
 )
-array_of_union_of_None_type_or_CWLObjectTypeLoader: Final = _ArrayLoader(
-    union_of_None_type_or_CWLObjectTypeLoader
+CWLRecordFieldLoader: Final[Loader[CWLRecordField]] = _RecordLoader(
+    CWLRecordField, None, None
 )
-map_of_union_of_None_type_or_CWLObjectTypeLoader: Final = _MapLoader(
-    union_of_None_type_or_CWLObjectTypeLoader, "None", None, None
+CWLRecordSchemaLoader: Final[Loader[CWLRecordSchema]] = _RecordLoader(
+    CWLRecordSchema, None, None
 )
-InlineJavascriptRequirementLoader: Final = _RecordLoader(
-    InlineJavascriptRequirement, None, None
+FileLoader: Final[Loader[File]] = _RecordLoader(File, None, None)
+DirectoryLoader: Final[Loader[Directory]] = _RecordLoader(Directory, None, None)
+CWLObjectTypeLoader: Final[Loader[CWLObjectType]] = _UnionLoader(
+    (), "CWLObjectTypeLoader"
 )
-SchemaDefRequirementLoader: Final = _RecordLoader(SchemaDefRequirement, None, None)
-LoadListingRequirementLoader: Final = _RecordLoader(LoadListingRequirement, None, None)
-DockerRequirementLoader: Final = _RecordLoader(DockerRequirement, None, None)
-SoftwareRequirementLoader: Final = _RecordLoader(SoftwareRequirement, None, None)
-InitialWorkDirRequirementLoader: Final = _RecordLoader(
-    InitialWorkDirRequirement, None, None
-)
-EnvVarRequirementLoader: Final = _RecordLoader(EnvVarRequirement, None, None)
-ShellCommandRequirementLoader: Final = _RecordLoader(
-    ShellCommandRequirement, None, None
-)
-ResourceRequirementLoader: Final = _RecordLoader(ResourceRequirement, None, None)
-WorkReuseLoader: Final = _RecordLoader(WorkReuse, None, None)
-NetworkAccessLoader: Final = _RecordLoader(NetworkAccess, None, None)
-InplaceUpdateRequirementLoader: Final = _RecordLoader(
-    InplaceUpdateRequirement, None, None
-)
-ToolTimeLimitLoader: Final = _RecordLoader(ToolTimeLimit, None, None)
-SubworkflowFeatureRequirementLoader: Final = _RecordLoader(
-    SubworkflowFeatureRequirement, None, None
-)
-ScatterFeatureRequirementLoader: Final = _RecordLoader(
-    ScatterFeatureRequirement, None, None
-)
-MultipleInputFeatureRequirementLoader: Final = _RecordLoader(
-    MultipleInputFeatureRequirement, None, None
-)
-StepInputExpressionRequirementLoader: Final = _RecordLoader(
-    StepInputExpressionRequirement, None, None
-)
-SecretsLoader: Final = _RecordLoader(Secrets, None, None)
-MPIRequirementLoader: Final = _RecordLoader(MPIRequirement, None, None)
-CUDARequirementLoader: Final = _RecordLoader(CUDARequirement, None, None)
-LoopLoader: Final = _RecordLoader(Loop, None, None)
-ShmSizeLoader: Final = _RecordLoader(ShmSize, None, None)
-union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader: (
-    Final
-) = _UnionLoader(
-    (
-        InlineJavascriptRequirementLoader,
-        SchemaDefRequirementLoader,
-        LoadListingRequirementLoader,
-        DockerRequirementLoader,
-        SoftwareRequirementLoader,
-        InitialWorkDirRequirementLoader,
-        EnvVarRequirementLoader,
-        ShellCommandRequirementLoader,
-        ResourceRequirementLoader,
-        WorkReuseLoader,
-        NetworkAccessLoader,
-        InplaceUpdateRequirementLoader,
-        ToolTimeLimitLoader,
-        SubworkflowFeatureRequirementLoader,
-        ScatterFeatureRequirementLoader,
-        MultipleInputFeatureRequirementLoader,
-        StepInputExpressionRequirementLoader,
-        SecretsLoader,
-        MPIRequirementLoader,
-        CUDARequirementLoader,
-        LoopLoader,
-        ShmSizeLoader,
-    )
-)
-ProcessRequirementProxyLoader: Final = _ProxyLoader("ProcessRequirementLoader")
-array_of_ProcessRequirement: Final = _ArrayLoader(ProcessRequirementProxyLoader)
-union_of_None_type_or_array_of_ProcessRequirement_or_CWLObjectTypeLoader: Final = (
+union_of_None_type_or_CWLObjectTypeLoader: Final[Loader[CWLObjectType | None]] = (
     _UnionLoader(
         (
             None_type,
-            array_of_ProcessRequirement,
             CWLObjectTypeLoader,
         )
     )
 )
-map_of_union_of_None_type_or_array_of_ProcessRequirement_or_CWLObjectTypeLoader: (
-    Final
-) = _MapLoader(
-    union_of_None_type_or_array_of_ProcessRequirement_or_CWLObjectTypeLoader,
-    "CWLInputFile",
-    "@list",
-    True,
+array_of_union_of_None_type_or_CWLObjectTypeLoader: Final[
+    Loader[Sequence[CWLObjectType | None]]
+] = _ArrayLoader(union_of_None_type_or_CWLObjectTypeLoader)
+map_of_union_of_None_type_or_CWLObjectTypeLoader: Final[
+    Loader[Mapping[str, CWLObjectType | None]]
+] = _MapLoader(union_of_None_type_or_CWLObjectTypeLoader, "None", None, None)
+CWLObjectType: TypeAlias = (
+    "Directory | File | Mapping[str, CWLObjectType | None] | Sequence[CWLObjectType | None] | bool | float | i32 | str"
 )
-CWLInputFileLoader: Final = (
-    map_of_union_of_None_type_or_array_of_ProcessRequirement_or_CWLObjectTypeLoader
+CWLVersion: TypeAlias = Literal["v1.2"]
+CWLVersionLoader: Final[Loader[CWLVersion]] = _EnumLoader[CWLVersion](
+    ("v1.2",), "CWLVersion"
 )
-CWLVersionLoader: Final = _EnumLoader(("v1.2",), "CWLVersion")
 """
 Current version symbol for CWL documents.
 """
-LabeledProxyLoader: Final = _ProxyLoader("LabeledLoader")
-IdentifiedProxyLoader: Final = _ProxyLoader("IdentifiedLoader")
-IdentifierRequiredProxyLoader: Final = _ProxyLoader("IdentifierRequiredLoader")
-LoadListingEnumLoader: Final = _EnumLoader(
+LabeledProxyLoader: Final[Loader[Labeled]] = _ProxyLoader("LabeledLoader")
+IdentifiedProxyLoader: Final[Loader[Identified]] = _ProxyLoader("IdentifiedLoader")
+IdentifierRequiredProxyLoader: Final[Loader[IdentifierRequired]] = _ProxyLoader(
+    "IdentifierRequiredLoader"
+)
+LoadListingEnum: TypeAlias = Literal["no_listing", "shallow_listing", "deep_listing"]
+LoadListingEnumLoader: Final[Loader[LoadListingEnum]] = _EnumLoader[LoadListingEnum](
     (
         "no_listing",
         "shallow_listing",
@@ -27657,58 +29362,174 @@ shallow_listing: Only load the top level listing, do not recurse into subdirecto
 
 deep_listing: Load the directory listing and recursively load all subdirectories as well.
 """
-LoadContentsProxyLoader: Final = _ProxyLoader("LoadContentsLoader")
-FieldBaseProxyLoader: Final = _ProxyLoader("FieldBaseLoader")
-InputFormatProxyLoader: Final = _ProxyLoader("InputFormatLoader")
-OutputFormatProxyLoader: Final = _ProxyLoader("OutputFormatLoader")
-ParameterProxyLoader: Final = _ProxyLoader("ParameterLoader")
-ExpressionLoader: Final = _ExpressionLoader(str)
-InputBindingLoader: Final = _RecordLoader(InputBinding, None, None)
-IOSchemaProxyLoader: Final = _ProxyLoader("IOSchemaLoader")
-InputSchemaProxyLoader: Final = _ProxyLoader("InputSchemaLoader")
-OutputSchemaProxyLoader: Final = _ProxyLoader("OutputSchemaLoader")
-InputRecordFieldLoader: Final = _RecordLoader(InputRecordField, None, None)
-InputRecordSchemaLoader: Final = _RecordLoader(InputRecordSchema, None, None)
-InputEnumSchemaLoader: Final = _RecordLoader(InputEnumSchema, None, None)
-InputArraySchemaLoader: Final = _RecordLoader(InputArraySchema, None, None)
-OutputRecordFieldLoader: Final = _RecordLoader(OutputRecordField, None, None)
-OutputRecordSchemaLoader: Final = _RecordLoader(OutputRecordSchema, None, None)
-OutputEnumSchemaLoader: Final = _RecordLoader(OutputEnumSchema, None, None)
-OutputArraySchemaLoader: Final = _RecordLoader(OutputArraySchema, None, None)
-InputParameterProxyLoader: Final = _ProxyLoader("InputParameterLoader")
-OutputParameterProxyLoader: Final = _ProxyLoader("OutputParameterLoader")
-ProcessProxyLoader: Final = _ProxyLoader("ProcessLoader")
-CommandInputSchemaProxyLoader: Final = _ProxyLoader("CommandInputSchemaLoader")
-SecondaryFileSchemaLoader: Final = _RecordLoader(SecondaryFileSchema, None, None)
-EnvironmentDefLoader: Final = _RecordLoader(EnvironmentDef, None, None)
-CommandLineBindingLoader: Final = _RecordLoader(CommandLineBinding, None, None)
-CommandOutputBindingLoader: Final = _RecordLoader(CommandOutputBinding, None, None)
-CommandLineBindableProxyLoader: Final = _ProxyLoader("CommandLineBindableLoader")
-CommandInputRecordFieldLoader: Final = _RecordLoader(
+LoadContentsProxyLoader: Final[Loader[LoadContents]] = _ProxyLoader(
+    "LoadContentsLoader"
+)
+FieldBaseProxyLoader: Final[Loader[FieldBase]] = _ProxyLoader("FieldBaseLoader")
+InputFormatProxyLoader: Final[Loader[InputFormat]] = _ProxyLoader("InputFormatLoader")
+OutputFormatProxyLoader: Final[Loader[OutputFormat]] = _ProxyLoader(
+    "OutputFormatLoader"
+)
+ParameterProxyLoader: Final[Loader[Parameter]] = _ProxyLoader("ParameterLoader")
+Expression: TypeAlias = Literal["ExpressionPlaceholder"]
+ExpressionLoader: Final[Loader[str]] = _ExpressionLoader(str)
+InputBindingLoader: Final[Loader[InputBinding]] = _RecordLoader(
+    InputBinding, None, None
+)
+IOSchemaProxyLoader: Final[Loader[IOSchema]] = _ProxyLoader("IOSchemaLoader")
+InputSchemaProxyLoader: Final[Loader[InputSchema]] = _ProxyLoader("InputSchemaLoader")
+OutputSchemaProxyLoader: Final[Loader[OutputSchema]] = _ProxyLoader(
+    "OutputSchemaLoader"
+)
+InputRecordFieldLoader: Final[Loader[InputRecordField]] = _RecordLoader(
+    InputRecordField, None, None
+)
+InputRecordSchemaLoader: Final[Loader[InputRecordSchema]] = _RecordLoader(
+    InputRecordSchema, None, None
+)
+InputEnumSchemaLoader: Final[Loader[InputEnumSchema]] = _RecordLoader(
+    InputEnumSchema, None, None
+)
+InputArraySchemaLoader: Final[Loader[InputArraySchema]] = _RecordLoader(
+    InputArraySchema, None, None
+)
+InputParameterTypeLoader: Final[Loader[InputParameterType]] = _UnionLoader(
+    (), "InputParameterTypeLoader"
+)
+union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: Final[
+    Loader[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        InputRecordSchemaLoader,
+        InputEnumSchemaLoader,
+        InputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype
+)
+InputParameterType: TypeAlias = (
+    CWLType
+    | InputArraySchema
+    | InputEnumSchema
+    | InputRecordSchema
+    | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+    | str
+)
+OutputRecordFieldLoader: Final[Loader[OutputRecordField]] = _RecordLoader(
+    OutputRecordField, None, None
+)
+OutputRecordSchemaLoader: Final[Loader[OutputRecordSchema]] = _RecordLoader(
+    OutputRecordSchema, None, None
+)
+OutputEnumSchemaLoader: Final[Loader[OutputEnumSchema]] = _RecordLoader(
+    OutputEnumSchema, None, None
+)
+OutputArraySchemaLoader: Final[Loader[OutputArraySchema]] = _RecordLoader(
+    OutputArraySchema, None, None
+)
+OutputParameterTypeLoader: Final[Loader[OutputParameterType]] = _UnionLoader(
+    (), "OutputParameterTypeLoader"
+)
+union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: Final[
+    Loader[CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        OutputRecordSchemaLoader,
+        OutputEnumSchemaLoader,
+        OutputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype
+)
+OutputParameterType: TypeAlias = (
+    CWLType
+    | OutputArraySchema
+    | OutputEnumSchema
+    | OutputRecordSchema
+    | Sequence[
+        CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+    ]
+    | str
+)
+InputParameterProxyLoader: Final[Loader[InputParameter]] = _ProxyLoader(
+    "InputParameterLoader"
+)
+OutputParameterProxyLoader: Final[Loader[OutputParameter]] = _ProxyLoader(
+    "OutputParameterLoader"
+)
+ProcessRequirementProxyLoader: Final[Loader[ProcessRequirement]] = _ProxyLoader(
+    "ProcessRequirementLoader"
+)
+ProcessProxyLoader: Final[Loader[Process]] = _ProxyLoader("ProcessLoader")
+InlineJavascriptRequirementLoader: Final[Loader[InlineJavascriptRequirement]] = (
+    _RecordLoader(InlineJavascriptRequirement, None, None)
+)
+CommandInputSchemaProxyLoader: Final[Loader[CommandInputSchema]] = _ProxyLoader(
+    "CommandInputSchemaLoader"
+)
+SchemaDefRequirementLoader: Final[Loader[SchemaDefRequirement]] = _RecordLoader(
+    SchemaDefRequirement, None, None
+)
+SecondaryFileSchemaLoader: Final[Loader[SecondaryFileSchema]] = _RecordLoader(
+    SecondaryFileSchema, None, None
+)
+LoadListingRequirementLoader: Final[Loader[LoadListingRequirement]] = _RecordLoader(
+    LoadListingRequirement, None, None
+)
+EnvironmentDefLoader: Final[Loader[EnvironmentDef]] = _RecordLoader(
+    EnvironmentDef, None, None
+)
+CommandLineBindingLoader: Final[Loader[CommandLineBinding]] = _RecordLoader(
+    CommandLineBinding, None, None
+)
+CommandOutputBindingLoader: Final[Loader[CommandOutputBinding]] = _RecordLoader(
+    CommandOutputBinding, None, None
+)
+CommandLineBindableProxyLoader: Final[Loader[CommandLineBindable]] = _ProxyLoader(
+    "CommandLineBindableLoader"
+)
+CommandInputRecordFieldLoader: Final[Loader[CommandInputRecordField]] = _RecordLoader(
     CommandInputRecordField, None, None
 )
-CommandInputRecordSchemaLoader: Final = _RecordLoader(
+CommandInputRecordSchemaLoader: Final[Loader[CommandInputRecordSchema]] = _RecordLoader(
     CommandInputRecordSchema, None, None
 )
-CommandInputEnumSchemaLoader: Final = _RecordLoader(CommandInputEnumSchema, None, None)
-CommandInputArraySchemaLoader: Final = _RecordLoader(
+CommandInputEnumSchemaLoader: Final[Loader[CommandInputEnumSchema]] = _RecordLoader(
+    CommandInputEnumSchema, None, None
+)
+CommandInputArraySchemaLoader: Final[Loader[CommandInputArraySchema]] = _RecordLoader(
     CommandInputArraySchema, None, None
 )
-CommandOutputRecordFieldLoader: Final = _RecordLoader(
+CommandOutputRecordFieldLoader: Final[Loader[CommandOutputRecordField]] = _RecordLoader(
     CommandOutputRecordField, None, None
 )
-CommandOutputRecordSchemaLoader: Final = _RecordLoader(
-    CommandOutputRecordSchema, None, None
+CommandOutputRecordSchemaLoader: Final[Loader[CommandOutputRecordSchema]] = (
+    _RecordLoader(CommandOutputRecordSchema, None, None)
 )
-CommandOutputEnumSchemaLoader: Final = _RecordLoader(
+CommandOutputEnumSchemaLoader: Final[Loader[CommandOutputEnumSchema]] = _RecordLoader(
     CommandOutputEnumSchema, None, None
 )
-CommandOutputArraySchemaLoader: Final = _RecordLoader(
+CommandOutputArraySchemaLoader: Final[Loader[CommandOutputArraySchema]] = _RecordLoader(
     CommandOutputArraySchema, None, None
 )
-CommandInputParameterLoader: Final = _RecordLoader(CommandInputParameter, None, None)
-CommandOutputParameterLoader: Final = _RecordLoader(CommandOutputParameter, None, None)
-stdinLoader: Final = _EnumLoader(("stdin",), "stdin")
+stdin: TypeAlias = Literal["stdin"]
+stdinLoader: Final[Loader[stdin]] = _EnumLoader[stdin](("stdin",), "stdin")
 """
 Only valid as a ``type`` for a ``CommandLineTool`` input with no ``inputBinding`` set. ``stdin`` must not be specified at the ``CommandLineTool`` level.
 
@@ -27732,7 +29553,8 @@ is equivalent to
 
    stdin: $(inputs.an_input_name.path)
 """
-stdoutLoader: Final = _EnumLoader(("stdout",), "stdout")
+stdout: TypeAlias = Literal["stdout"]
+stdoutLoader: Final[Loader[stdout]] = _EnumLoader[stdout](("stdout",), "stdout")
 """
 Only valid as a ``type`` for a ``CommandLineTool`` output with no ``outputBinding`` set.
 
@@ -27786,7 +29608,8 @@ is equivalent to
 
 If the ``CommandLineTool`` contains logically chained commands (e.g. ``echo a && echo b``) ``stdout`` must include the output of every command.
 """
-stderrLoader: Final = _EnumLoader(("stderr",), "stderr")
+stderr: TypeAlias = Literal["stderr"]
+stderrLoader: Final[Loader[stderr]] = _EnumLoader[stderr](("stderr",), "stderr")
 """
 Only valid as a ``type`` for a ``CommandLineTool`` output with no ``outputBinding`` set.
 
@@ -27837,15 +29660,155 @@ is equivalent to
 
    stderr: random_stderr_filenameABCDEFG
 """
-CommandLineToolLoader: Final = _RecordLoader(CommandLineTool, None, None)
-SoftwarePackageLoader: Final = _RecordLoader(SoftwarePackage, None, None)
-DirentLoader: Final = _RecordLoader(Dirent, None, None)
-ExpressionToolOutputParameterLoader: Final = _RecordLoader(
-    ExpressionToolOutputParameter, None, None
+CommandInputParameterTypeLoader: Final[Loader[CommandInputParameterType]] = (
+    _UnionLoader((), "CommandInputParameterTypeLoader")
 )
-WorkflowInputParameterLoader: Final = _RecordLoader(WorkflowInputParameter, None, None)
-ExpressionToolLoader: Final = _RecordLoader(ExpressionTool, None, None)
-LinkMergeMethodLoader: Final = _EnumLoader(
+union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | str
+    ]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        CommandInputRecordSchemaLoader,
+        CommandInputEnumSchemaLoader,
+        CommandInputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype
+)
+CommandInputParameterType: TypeAlias = (
+    CWLType
+    | CommandInputArraySchema
+    | CommandInputEnumSchema
+    | CommandInputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | str
+    ]
+    | stdin
+    | str
+)
+CommandInputParameterLoader: Final[Loader[CommandInputParameter]] = _RecordLoader(
+    CommandInputParameter, None, None
+)
+CommandOutputParameterTypeLoader: Final[Loader[CommandOutputParameterType]] = (
+    _UnionLoader((), "CommandOutputParameterTypeLoader")
+)
+union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | str
+    ]
+] = _UnionLoader(
+    (
+        CWLTypeLoader,
+        CommandOutputRecordSchemaLoader,
+        CommandOutputEnumSchemaLoader,
+        CommandOutputArraySchemaLoader,
+        strtype,
+    )
+)
+array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
+    union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype
+)
+CommandOutputParameterType: TypeAlias = (
+    CWLType
+    | CommandOutputArraySchema
+    | CommandOutputEnumSchema
+    | CommandOutputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | str
+    ]
+    | stderr
+    | stdout
+    | str
+)
+CommandOutputParameterLoader: Final[Loader[CommandOutputParameter]] = _RecordLoader(
+    CommandOutputParameter, None, None
+)
+CommandLineToolLoader: Final[Loader[CommandLineTool]] = _RecordLoader(
+    CommandLineTool, None, None
+)
+DockerRequirementLoader: Final[Loader[DockerRequirement]] = _RecordLoader(
+    DockerRequirement, None, None
+)
+SoftwareRequirementLoader: Final[Loader[SoftwareRequirement]] = _RecordLoader(
+    SoftwareRequirement, None, None
+)
+SoftwarePackageLoader: Final[Loader[SoftwarePackage]] = _RecordLoader(
+    SoftwarePackage, None, None
+)
+DirentLoader: Final[Loader[Dirent]] = _RecordLoader(Dirent, None, None)
+InitialWorkDirRequirementLoader: Final[Loader[InitialWorkDirRequirement]] = (
+    _RecordLoader(InitialWorkDirRequirement, None, None)
+)
+EnvVarRequirementLoader: Final[Loader[EnvVarRequirement]] = _RecordLoader(
+    EnvVarRequirement, None, None
+)
+ShellCommandRequirementLoader: Final[Loader[ShellCommandRequirement]] = _RecordLoader(
+    ShellCommandRequirement, None, None
+)
+ResourceRequirementLoader: Final[Loader[ResourceRequirement]] = _RecordLoader(
+    ResourceRequirement, None, None
+)
+WorkReuseLoader: Final[Loader[WorkReuse]] = _RecordLoader(WorkReuse, None, None)
+NetworkAccessLoader: Final[Loader[NetworkAccess]] = _RecordLoader(
+    NetworkAccess, None, None
+)
+InplaceUpdateRequirementLoader: Final[Loader[InplaceUpdateRequirement]] = _RecordLoader(
+    InplaceUpdateRequirement, None, None
+)
+ToolTimeLimitLoader: Final[Loader[ToolTimeLimit]] = _RecordLoader(
+    ToolTimeLimit, None, None
+)
+ExpressionToolOutputParameterLoader: Final[Loader[ExpressionToolOutputParameter]] = (
+    _RecordLoader(ExpressionToolOutputParameter, None, None)
+)
+WorkflowInputParameterLoader: Final[Loader[WorkflowInputParameter]] = _RecordLoader(
+    WorkflowInputParameter, None, None
+)
+ExpressionToolLoader: Final[Loader[ExpressionTool]] = _RecordLoader(
+    ExpressionTool, None, None
+)
+LinkMergeMethod: TypeAlias = Literal["merge_nested", "merge_flattened"]
+LinkMergeMethodLoader: Final[Loader[LinkMergeMethod]] = _EnumLoader[LinkMergeMethod](
     (
         "merge_nested",
         "merge_flattened",
@@ -27855,7 +29818,10 @@ LinkMergeMethodLoader: Final = _EnumLoader(
 """
 The input link merge method, described in `WorkflowStepInput <#WorkflowStepInput>`__.
 """
-PickValueMethodLoader: Final = _EnumLoader(
+PickValueMethod: TypeAlias = Literal[
+    "first_non_null", "the_only_non_null", "all_non_null"
+]
+PickValueMethodLoader: Final[Loader[PickValueMethod]] = _EnumLoader[PickValueMethod](
     (
         "first_non_null",
         "the_only_non_null",
@@ -27866,13 +29832,20 @@ PickValueMethodLoader: Final = _EnumLoader(
 """
 Picking non-null values among inbound data links, described in `WorkflowStepInput <#WorkflowStepInput>`__.
 """
-WorkflowOutputParameterLoader: Final = _RecordLoader(
+WorkflowOutputParameterLoader: Final[Loader[WorkflowOutputParameter]] = _RecordLoader(
     WorkflowOutputParameter, None, None
 )
-SinkProxyLoader: Final = _ProxyLoader("SinkLoader")
-WorkflowStepInputLoader: Final = _RecordLoader(WorkflowStepInput, None, None)
-WorkflowStepOutputLoader: Final = _RecordLoader(WorkflowStepOutput, None, None)
-ScatterMethodLoader: Final = _EnumLoader(
+SinkProxyLoader: Final[Loader[Sink]] = _ProxyLoader("SinkLoader")
+WorkflowStepInputLoader: Final[Loader[WorkflowStepInput]] = _RecordLoader(
+    WorkflowStepInput, None, None
+)
+WorkflowStepOutputLoader: Final[Loader[WorkflowStepOutput]] = _RecordLoader(
+    WorkflowStepOutput, None, None
+)
+ScatterMethod: TypeAlias = Literal[
+    "dotproduct", "nested_crossproduct", "flat_crossproduct"
+]
+ScatterMethodLoader: Final[Loader[ScatterMethod]] = _EnumLoader[ScatterMethod](
     (
         "dotproduct",
         "nested_crossproduct",
@@ -27883,29 +29856,130 @@ ScatterMethodLoader: Final = _EnumLoader(
 """
 The scatter method, as described in `workflow step scatter <#WorkflowStep>`__.
 """
-WorkflowStepLoader: Final = _RecordLoader(WorkflowStep, None, None)
-WorkflowLoader: Final = _RecordLoader(Workflow, None, None)
-OperationInputParameterLoader: Final = _RecordLoader(
+WorkflowStepLoader: Final[Loader[WorkflowStep]] = _RecordLoader(
+    WorkflowStep, None, None
+)
+WorkflowLoader: Final[Loader[Workflow]] = _RecordLoader(Workflow, None, None)
+SubworkflowFeatureRequirementLoader: Final[Loader[SubworkflowFeatureRequirement]] = (
+    _RecordLoader(SubworkflowFeatureRequirement, None, None)
+)
+ScatterFeatureRequirementLoader: Final[Loader[ScatterFeatureRequirement]] = (
+    _RecordLoader(ScatterFeatureRequirement, None, None)
+)
+MultipleInputFeatureRequirementLoader: Final[
+    Loader[MultipleInputFeatureRequirement]
+] = _RecordLoader(MultipleInputFeatureRequirement, None, None)
+StepInputExpressionRequirementLoader: Final[Loader[StepInputExpressionRequirement]] = (
+    _RecordLoader(StepInputExpressionRequirement, None, None)
+)
+OperationInputParameterLoader: Final[Loader[OperationInputParameter]] = _RecordLoader(
     OperationInputParameter, None, None
 )
-OperationOutputParameterLoader: Final = _RecordLoader(
+OperationOutputParameterLoader: Final[Loader[OperationOutputParameter]] = _RecordLoader(
     OperationOutputParameter, None, None
 )
-OperationLoader: Final = _RecordLoader(Operation, None, None)
-ProcessGeneratorLoader: Final = _RecordLoader(ProcessGenerator, None, None)
-LoopInputLoader: Final = _RecordLoader(LoopInput, None, None)
-array_of_strtype: Final = _ArrayLoader(strtype)
-union_of_None_type_or_strtype_or_array_of_strtype: Final = _UnionLoader(
+OperationLoader: Final[Loader[Operation]] = _RecordLoader(Operation, None, None)
+union_of_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_ToolTimeLimitLoader_or_SoftwareRequirementLoader_or_InplaceUpdateRequirementLoader_or_ResourceRequirementLoader_or_InlineJavascriptRequirementLoader_or_LoadListingRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InitialWorkDirRequirementLoader_or_DockerRequirementLoader_or_SchemaDefRequirementLoader_or_ShellCommandRequirementLoader_or_SubworkflowFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_EnvVarRequirementLoader: Final[
+    Loader[
+        DockerRequirement
+        | EnvVarRequirement
+        | InitialWorkDirRequirement
+        | InlineJavascriptRequirement
+        | InplaceUpdateRequirement
+        | LoadListingRequirement
+        | MultipleInputFeatureRequirement
+        | NetworkAccess
+        | ResourceRequirement
+        | ScatterFeatureRequirement
+        | SchemaDefRequirement
+        | ShellCommandRequirement
+        | SoftwareRequirement
+        | StepInputExpressionRequirement
+        | SubworkflowFeatureRequirement
+        | ToolTimeLimit
+        | WorkReuse
+    ]
+] = _UnionLoader(
+    (
+        ScatterFeatureRequirementLoader,
+        MultipleInputFeatureRequirementLoader,
+        ToolTimeLimitLoader,
+        SoftwareRequirementLoader,
+        InplaceUpdateRequirementLoader,
+        ResourceRequirementLoader,
+        InlineJavascriptRequirementLoader,
+        LoadListingRequirementLoader,
+        WorkReuseLoader,
+        NetworkAccessLoader,
+        InitialWorkDirRequirementLoader,
+        DockerRequirementLoader,
+        SchemaDefRequirementLoader,
+        ShellCommandRequirementLoader,
+        SubworkflowFeatureRequirementLoader,
+        StepInputExpressionRequirementLoader,
+        EnvVarRequirementLoader,
+    )
+)
+array_of_ProcessRequirementProxyLoader: Final[Loader[Sequence[ProcessRequirement]]] = (
+    _ArrayLoader(ProcessRequirementProxyLoader)
+)
+union_of_None_type_or_array_of_ProcessRequirementProxyLoader_or_CWLObjectTypeLoader: (
+    Final[Loader[CWLObjectType | None | Sequence[ProcessRequirement]]]
+) = _UnionLoader(
+    (
+        None_type,
+        array_of_ProcessRequirementProxyLoader,
+        CWLObjectTypeLoader,
+    )
+)
+map_of_union_of_None_type_or_array_of_ProcessRequirementProxyLoader_or_CWLObjectTypeLoader: Final[
+    Loader[Mapping[str, CWLObjectType | None | Sequence[ProcessRequirement]]]
+] = _MapLoader(
+    union_of_None_type_or_array_of_ProcessRequirementProxyLoader_or_CWLObjectTypeLoader,
+    "CWLInputFile",
+    "@list",
+    True,
+)
+CWLInputFileLoader: Final[
+    Loader[Mapping[str, CWLObjectType | None | Sequence[ProcessRequirement]]]
+] = map_of_union_of_None_type_or_array_of_ProcessRequirementProxyLoader_or_CWLObjectTypeLoader
+SecretsLoader: Final[Loader[Secrets]] = _RecordLoader(Secrets, None, None)
+ProcessGeneratorLoader: Final[Loader[ProcessGenerator]] = _RecordLoader(
+    ProcessGenerator, None, None
+)
+MPIRequirementLoader: Final[Loader[MPIRequirement]] = _RecordLoader(
+    MPIRequirement, None, None
+)
+CUDARequirementLoader: Final[Loader[CUDARequirement]] = _RecordLoader(
+    CUDARequirement, None, None
+)
+LoopInputLoader: Final[Loader[LoopInput]] = _RecordLoader(LoopInput, None, None)
+LoopLoader: Final[Loader[Loop]] = _RecordLoader(Loop, None, None)
+ShmSizeLoader: Final[Loader[ShmSize]] = _RecordLoader(ShmSize, None, None)
+array_of_strtype: Final[Loader[Sequence[str]]] = _ArrayLoader(strtype)
+union_of_None_type_or_strtype_or_array_of_strtype: Final[
+    Loader[None | Sequence[str] | str]
+] = _UnionLoader(
     (
         None_type,
         strtype,
         array_of_strtype,
     )
 )
-uri_strtype_True_False_None_None: Final = _URILoader(strtype, True, False, None, None)
-union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+uri_strtype_True_False_None_None: Final[Loader[str]] = _URILoader(
+    strtype, True, False, None, None
+)
+union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: Final[
+    Loader[
+        PrimitiveType
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         RecordSchemaLoader,
@@ -27916,14 +29990,41 @@ union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArrayS
         strtype,
     )
 )
-array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
     union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype
 )
-union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype: Final[
+    Loader[
+        PrimitiveType
+        | Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         RecordSchemaLoader,
@@ -27935,57 +30036,141 @@ union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArrayS
         array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_2: Final[
+    Loader[
+        PrimitiveType
+        | Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _TypeDSLLoader[
+    PrimitiveType
+    | Sequence[
+        PrimitiveType
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+    | schema_salad.metaschema.ArraySchema
+    | schema_salad.metaschema.EnumSchema
+    | schema_salad.metaschema.MapSchema
+    | schema_salad.metaschema.RecordSchema
+    | schema_salad.metaschema.UnionSchema
+    | str
+](
     union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_RecordFieldLoader: Final = _ArrayLoader(RecordFieldLoader)
-union_of_None_type_or_array_of_RecordFieldLoader: Final = _UnionLoader(
+array_of_RecordFieldLoader: Final[
+    Loader[Sequence[schema_salad.metaschema.RecordField]]
+] = _ArrayLoader(RecordFieldLoader)
+union_of_None_type_or_array_of_RecordFieldLoader: Final[
+    Loader[None | Sequence[schema_salad.metaschema.RecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_RecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader: Final = _IdMapLoader(
-    union_of_None_type_or_array_of_RecordFieldLoader, "name", "type"
+idmap_fields_union_of_None_type_or_array_of_RecordFieldLoader: Final[
+    Loader[None | Sequence[schema_salad.metaschema.RecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_RecordFieldLoader, "name", "type")
+Record_name: TypeAlias = Literal["record"]
+Record_nameLoader: Final[Loader[Record_name]] = _EnumLoader[Record_name](
+    ("record",), "Record_name"
 )
-Record_nameLoader: Final = _EnumLoader(("record",), "Record_name")
-typedsl_Record_nameLoader_2: Final = _TypeDSLLoader(Record_nameLoader, 2, "v1.1")
-union_of_None_type_or_strtype: Final = _UnionLoader(
+typedsl_Record_nameLoader_2: Final[Loader[Record_name]] = _TypeDSLLoader[Record_name](
+    Record_nameLoader, 2, "v1.1"
+)
+union_of_None_type_or_strtype: Final[Loader[None | str]] = _UnionLoader(
     (
         None_type,
         strtype,
     )
 )
-uri_union_of_None_type_or_strtype_True_False_None_None: Final = _URILoader(
-    union_of_None_type_or_strtype, True, False, None, None
+uri_union_of_None_type_or_strtype_True_False_None_None: Final[Loader[None | str]] = (
+    _URILoader(union_of_None_type_or_strtype, True, False, None, None)
 )
-uri_array_of_strtype_True_False_None_None: Final = _URILoader(
+uri_array_of_strtype_True_False_None_None: Final[Loader[Sequence[str]]] = _URILoader(
     array_of_strtype, True, False, None, None
 )
-Enum_nameLoader: Final = _EnumLoader(("enum",), "Enum_name")
-typedsl_Enum_nameLoader_2: Final = _TypeDSLLoader(Enum_nameLoader, 2, "v1.1")
-uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+Enum_name: TypeAlias = Literal["enum"]
+Enum_nameLoader: Final[Loader[Enum_name]] = _EnumLoader[Enum_name](
+    ("enum",), "Enum_name"
+)
+typedsl_Enum_nameLoader_2: Final[Loader[Enum_name]] = _TypeDSLLoader[Enum_name](
+    Enum_nameLoader, 2, "v1.1"
+)
+uri_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        PrimitiveType
+        | Sequence[
+            PrimitiveType
+            | schema_salad.metaschema.ArraySchema
+            | schema_salad.metaschema.EnumSchema
+            | schema_salad.metaschema.MapSchema
+            | schema_salad.metaschema.RecordSchema
+            | schema_salad.metaschema.UnionSchema
+            | str
+        ]
+        | schema_salad.metaschema.ArraySchema
+        | schema_salad.metaschema.EnumSchema
+        | schema_salad.metaschema.MapSchema
+        | schema_salad.metaschema.RecordSchema
+        | schema_salad.metaschema.UnionSchema
+        | str
+    ]
+] = _URILoader(
     union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_RecordSchemaLoader_or_EnumSchemaLoader_or_ArraySchemaLoader_or_MapSchemaLoader_or_UnionSchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-Array_nameLoader: Final = _EnumLoader(("array",), "Array_name")
-typedsl_Array_nameLoader_2: Final = _TypeDSLLoader(Array_nameLoader, 2, "v1.1")
-Map_nameLoader: Final = _EnumLoader(("map",), "Map_name")
-typedsl_Map_nameLoader_2: Final = _TypeDSLLoader(Map_nameLoader, 2, "v1.1")
-Union_nameLoader: Final = _EnumLoader(("union",), "Union_name")
-typedsl_Union_nameLoader_2: Final = _TypeDSLLoader(Union_nameLoader, 2, "v1.1")
-union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+Array_name: TypeAlias = Literal["array"]
+Array_nameLoader: Final[Loader[Array_name]] = _EnumLoader[Array_name](
+    ("array",), "Array_name"
+)
+typedsl_Array_nameLoader_2: Final[Loader[Array_name]] = _TypeDSLLoader[Array_name](
+    Array_nameLoader, 2, "v1.1"
+)
+Map_name: TypeAlias = Literal["map"]
+Map_nameLoader: Final[Loader[Map_name]] = _EnumLoader[Map_name](("map",), "Map_name")
+typedsl_Map_nameLoader_2: Final[Loader[Map_name]] = _TypeDSLLoader[Map_name](
+    Map_nameLoader, 2, "v1.1"
+)
+Union_name: TypeAlias = Literal["union"]
+Union_nameLoader: Final[Loader[Union_name]] = _EnumLoader[Union_name](
+    ("union",), "Union_name"
+)
+typedsl_Union_nameLoader_2: Final[Loader[Union_name]] = _TypeDSLLoader[Union_name](
+    Union_nameLoader, 2, "v1.1"
+)
+union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         CWLRecordSchemaLoader,
@@ -27994,14 +30179,35 @@ union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWL
         strtype,
     )
 )
-array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: Final[
+    Loader[
+        Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+    ]
+] = _ArrayLoader(
     union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype
 )
-union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _UnionLoader(
     (
         PrimitiveTypeLoader,
         CWLRecordSchemaLoader,
@@ -28011,65 +30217,114 @@ union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWL
         array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype,
     )
 )
-uri_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+uri_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _URILoader(
     union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-typedsl_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | Sequence[
+            CWLArraySchema
+            | CWLRecordSchema
+            | PrimitiveType
+            | schema_salad.metaschema.EnumSchema
+            | str
+        ]
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLArraySchema
+    | CWLRecordSchema
+    | PrimitiveType
+    | Sequence[
+        CWLArraySchema
+        | CWLRecordSchema
+        | PrimitiveType
+        | schema_salad.metaschema.EnumSchema
+        | str
+    ]
+    | schema_salad.metaschema.EnumSchema
+    | str
+](
     union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype_or_array_of_union_of_PrimitiveTypeLoader_or_CWLRecordSchemaLoader_or_EnumSchemaLoader_or_CWLArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_CWLRecordFieldLoader: Final = _ArrayLoader(CWLRecordFieldLoader)
-union_of_None_type_or_array_of_CWLRecordFieldLoader: Final = _UnionLoader(
+array_of_CWLRecordFieldLoader: Final[Loader[Sequence[CWLRecordField]]] = _ArrayLoader(
+    CWLRecordFieldLoader
+)
+union_of_None_type_or_array_of_CWLRecordFieldLoader: Final[
+    Loader[None | Sequence[CWLRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_CWLRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_CWLRecordFieldLoader: Final = _IdMapLoader(
-    union_of_None_type_or_array_of_CWLRecordFieldLoader, "name", "type"
+idmap_fields_union_of_None_type_or_array_of_CWLRecordFieldLoader: Final[
+    Loader[None | Sequence[CWLRecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_CWLRecordFieldLoader, "name", "type")
+File_class: TypeAlias = Literal["File"]
+File_classLoader: Final[Loader[File_class]] = _EnumLoader[File_class](
+    ("File",), "File_class"
 )
-File_classLoader: Final = _EnumLoader(("File",), "File_class")
-uri_File_classLoader_False_True_None_None: Final = _URILoader(
+uri_File_classLoader_False_True_None_None: Final[Loader[File_class]] = _URILoader(
     File_classLoader, False, True, None, None
 )
-uri_union_of_None_type_or_strtype_False_False_None_None: Final = _URILoader(
-    union_of_None_type_or_strtype, False, False, None, None
+uri_union_of_None_type_or_strtype_False_False_None_None: Final[Loader[None | str]] = (
+    _URILoader(union_of_None_type_or_strtype, False, False, None, None)
 )
-union_of_None_type_or_inttype: Final = _UnionLoader(
-    (
-        None_type,
-        inttype,
+union_of_None_type_or_inttype_or_longtype: Final[Loader[None | i32 | i64]] = (
+    _UnionLoader(
+        (
+            None_type,
+            inttype,
+            longtype,
+        )
     )
 )
-union_of_FileLoader_or_DirectoryLoader: Final = _UnionLoader(
+union_of_FileLoader_or_DirectoryLoader: Final[Loader[Directory | File]] = _UnionLoader(
     (
         FileLoader,
         DirectoryLoader,
     )
 )
-array_of_union_of_FileLoader_or_DirectoryLoader: Final = _ArrayLoader(
-    union_of_FileLoader_or_DirectoryLoader
-)
-union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final = (
-    _UnionLoader(
-        (
-            None_type,
-            array_of_union_of_FileLoader_or_DirectoryLoader,
-        )
+array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[Sequence[Directory | File]]
+] = _ArrayLoader(union_of_FileLoader_or_DirectoryLoader)
+union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[None | Sequence[Directory | File]]
+] = _UnionLoader(
+    (
+        None_type,
+        array_of_union_of_FileLoader_or_DirectoryLoader,
     )
 )
-secondaryfilesdsl_union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader: (
-    Final
-) = _UnionLoader(
+secondaryfilesdsl_union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[None | Sequence[Directory | File]]
+] = _UnionLoader(
     (
         _SecondaryDSLLoader(
             union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader
@@ -28077,28 +30332,35 @@ secondaryfilesdsl_union_of_None_type_or_array_of_union_of_FileLoader_or_Director
         union_of_None_type_or_array_of_union_of_FileLoader_or_DirectoryLoader,
     )
 )
-uri_union_of_None_type_or_strtype_True_False_None_True: Final = _URILoader(
-    union_of_None_type_or_strtype, True, False, None, True
+uri_union_of_None_type_or_strtype_True_False_None_True: Final[Loader[None | str]] = (
+    _URILoader(union_of_None_type_or_strtype, True, False, None, True)
 )
-Directory_classLoader: Final = _EnumLoader(("Directory",), "Directory_class")
-uri_Directory_classLoader_False_True_None_None: Final = _URILoader(
-    Directory_classLoader, False, True, None, None
+Directory_class: TypeAlias = Literal["Directory"]
+Directory_classLoader: Final[Loader[Directory_class]] = _EnumLoader[Directory_class](
+    ("Directory",), "Directory_class"
 )
-union_of_None_type_or_booltype: Final = _UnionLoader(
+uri_Directory_classLoader_False_True_None_None: Final[Loader[Directory_class]] = (
+    _URILoader(Directory_classLoader, False, True, None, None)
+)
+union_of_None_type_or_booltype: Final[Loader[None | bool]] = _UnionLoader(
     (
         None_type,
         booltype,
     )
 )
-union_of_None_type_or_LoadListingEnumLoader: Final = _UnionLoader(
-    (
-        None_type,
-        LoadListingEnumLoader,
+union_of_None_type_or_LoadListingEnumLoader: Final[Loader[LoadListingEnum | None]] = (
+    _UnionLoader(
+        (
+            None_type,
+            LoadListingEnumLoader,
+        )
     )
 )
-array_of_SecondaryFileSchemaLoader: Final = _ArrayLoader(SecondaryFileSchemaLoader)
+array_of_SecondaryFileSchemaLoader: Final[Loader[Sequence[SecondaryFileSchema]]] = (
+    _ArrayLoader(SecondaryFileSchemaLoader)
+)
 union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaLoader: (
-    Final
+    Final[Loader[None | SecondaryFileSchema | Sequence[SecondaryFileSchema]]]
 ) = _UnionLoader(
     (
         None_type,
@@ -28106,9 +30368,9 @@ union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaL
         array_of_SecondaryFileSchemaLoader,
     )
 )
-secondaryfilesdsl_union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaLoader: (
-    Final
-) = _UnionLoader(
+secondaryfilesdsl_union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaLoader: Final[
+    Loader[None | SecondaryFileSchema | Sequence[SecondaryFileSchema]]
+] = _UnionLoader(
     (
         _SecondaryDSLLoader(
             union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaLoader
@@ -28116,56 +30378,51 @@ secondaryfilesdsl_union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_Se
         union_of_None_type_or_SecondaryFileSchemaLoader_or_array_of_SecondaryFileSchemaLoader,
     )
 )
-union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader: Final = (
-    _UnionLoader(
-        (
-            None_type,
-            strtype,
-            array_of_strtype,
-            ExpressionLoader,
-        )
+union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader: Final[
+    Loader[None | Sequence[str] | str]
+] = _UnionLoader(
+    (
+        None_type,
+        strtype,
+        array_of_strtype,
+        ExpressionLoader,
     )
 )
-uri_union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader_True_False_None_True: (
-    Final
-) = _URILoader(
+uri_union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader_True_False_None_True: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(
     union_of_None_type_or_strtype_or_array_of_strtype_or_ExpressionLoader,
     True,
     False,
     None,
     True,
 )
-union_of_None_type_or_strtype_or_ExpressionLoader: Final = _UnionLoader(
-    (
-        None_type,
-        strtype,
-        ExpressionLoader,
+union_of_None_type_or_strtype_or_ExpressionLoader: Final[Loader[None | str]] = (
+    _UnionLoader(
+        (
+            None_type,
+            strtype,
+            ExpressionLoader,
+        )
     )
 )
-uri_union_of_None_type_or_strtype_or_ExpressionLoader_True_False_None_True: Final = (
-    _URILoader(
-        union_of_None_type_or_strtype_or_ExpressionLoader, True, False, None, True
-    )
+uri_union_of_None_type_or_strtype_or_ExpressionLoader_True_False_None_True: Final[
+    Loader[None | str]
+] = _URILoader(
+    union_of_None_type_or_strtype_or_ExpressionLoader, True, False, None, True
 )
-union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        InputRecordSchemaLoader,
-        InputEnumSchemaLoader,
-        InputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | InputArraySchema
+        | InputEnumSchema
+        | InputRecordSchema
+        | Sequence[
+            CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         InputRecordSchemaLoader,
@@ -28175,51 +30432,73 @@ union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_In
         array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | InputArraySchema
+        | InputEnumSchema
+        | InputRecordSchema
+        | Sequence[
+            CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | InputArraySchema
+    | InputEnumSchema
+    | InputRecordSchema
+    | Sequence[CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str]
+    | str
+](
     union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_InputRecordFieldLoader: Final = _ArrayLoader(InputRecordFieldLoader)
-union_of_None_type_or_array_of_InputRecordFieldLoader: Final = _UnionLoader(
+array_of_InputRecordFieldLoader: Final[Loader[Sequence[InputRecordField]]] = (
+    _ArrayLoader(InputRecordFieldLoader)
+)
+union_of_None_type_or_array_of_InputRecordFieldLoader: Final[
+    Loader[None | Sequence[InputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_InputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_InputRecordFieldLoader: Final = (
-    _IdMapLoader(union_of_None_type_or_array_of_InputRecordFieldLoader, "name", "type")
-)
-uri_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+idmap_fields_union_of_None_type_or_array_of_InputRecordFieldLoader: Final[
+    Loader[None | Sequence[InputRecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_InputRecordFieldLoader, "name", "type")
+uri_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | InputArraySchema
+        | InputEnumSchema
+        | InputRecordSchema
+        | Sequence[
+            CWLType | InputArraySchema | InputEnumSchema | InputRecordSchema | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        OutputRecordSchemaLoader,
-        OutputEnumSchemaLoader,
-        OutputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | OutputArraySchema
+        | OutputEnumSchema
+        | OutputRecordSchema
+        | Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         OutputRecordSchemaLoader,
@@ -28229,224 +30508,312 @@ union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_
         array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | OutputArraySchema
+        | OutputEnumSchema
+        | OutputRecordSchema
+        | Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | OutputArraySchema
+    | OutputEnumSchema
+    | OutputRecordSchema
+    | Sequence[
+        CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+    ]
+    | str
+](
     union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_OutputRecordFieldLoader: Final = _ArrayLoader(OutputRecordFieldLoader)
-union_of_None_type_or_array_of_OutputRecordFieldLoader: Final = _UnionLoader(
+array_of_OutputRecordFieldLoader: Final[Loader[Sequence[OutputRecordField]]] = (
+    _ArrayLoader(OutputRecordFieldLoader)
+)
+union_of_None_type_or_array_of_OutputRecordFieldLoader: Final[
+    Loader[None | Sequence[OutputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_OutputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_OutputRecordFieldLoader: Final = (
-    _IdMapLoader(union_of_None_type_or_array_of_OutputRecordFieldLoader, "name", "type")
-)
-uri_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+idmap_fields_union_of_None_type_or_array_of_OutputRecordFieldLoader: Final[
+    Loader[None | Sequence[OutputRecordField]]
+] = _IdMapLoader(union_of_None_type_or_array_of_OutputRecordFieldLoader, "name", "type")
+uri_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | OutputArraySchema
+        | OutputEnumSchema
+        | OutputRecordSchema
+        | Sequence[
+            CWLType | OutputArraySchema | OutputEnumSchema | OutputRecordSchema | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_CommandInputParameterLoader_or_WorkflowInputParameterLoader_or_OperationInputParameterLoader: (
-    Final
-) = _UnionLoader(
+union_of_CommandInputParameterLoader_or_WorkflowInputParameterLoader_or_OperationInputParameterLoader: Final[
+    Loader[CommandInputParameter | OperationInputParameter | WorkflowInputParameter]
+] = _UnionLoader(
     (
         CommandInputParameterLoader,
         WorkflowInputParameterLoader,
         OperationInputParameterLoader,
     )
 )
-array_of_InputParameter: Final = _ArrayLoader(InputParameterProxyLoader)
-idmap_inputs_array_of_InputParameter: Final = _IdMapLoader(
-    array_of_InputParameter, "id", "type"
+array_of_InputParameterProxyLoader: Final[Loader[Sequence[InputParameter]]] = (
+    _ArrayLoader(InputParameterProxyLoader)
 )
-union_of_CommandOutputParameterLoader_or_ExpressionToolOutputParameterLoader_or_WorkflowOutputParameterLoader_or_OperationOutputParameterLoader: (
-    Final
-) = _UnionLoader(
+idmap_inputs_array_of_InputParameterProxyLoader: Final[
+    Loader[Sequence[InputParameter]]
+] = _IdMapLoader(array_of_InputParameterProxyLoader, "id", "type")
+union_of_CommandOutputParameterLoader_or_ExpressionToolOutputParameterLoader_or_OperationOutputParameterLoader_or_WorkflowOutputParameterLoader: Final[
+    Loader[
+        CommandOutputParameter
+        | ExpressionToolOutputParameter
+        | OperationOutputParameter
+        | WorkflowOutputParameter
+    ]
+] = _UnionLoader(
     (
         CommandOutputParameterLoader,
         ExpressionToolOutputParameterLoader,
-        WorkflowOutputParameterLoader,
         OperationOutputParameterLoader,
+        WorkflowOutputParameterLoader,
     )
 )
-array_of_OutputParameter: Final = _ArrayLoader(OutputParameterProxyLoader)
-idmap_outputs_array_of_OutputParameter: Final = _IdMapLoader(
-    array_of_OutputParameter, "id", "type"
+array_of_OutputParameterProxyLoader: Final[Loader[Sequence[OutputParameter]]] = (
+    _ArrayLoader(OutputParameterProxyLoader)
 )
-union_of_None_type_or_array_of_ProcessRequirement: Final = _UnionLoader(
+idmap_outputs_array_of_OutputParameterProxyLoader: Final[
+    Loader[Sequence[OutputParameter]]
+] = _IdMapLoader(array_of_OutputParameterProxyLoader, "id", "type")
+union_of_MultipleInputFeatureRequirementLoader_or_ToolTimeLimitLoader_or_MPIRequirementLoader_or_LoadListingRequirementLoader_or_WorkReuseLoader_or_LoopLoader_or_ShellCommandRequirementLoader_or_CUDARequirementLoader_or_InplaceUpdateRequirementLoader_or_InlineJavascriptRequirementLoader_or_NetworkAccessLoader_or_DockerRequirementLoader_or_ShmSizeLoader_or_StepInputExpressionRequirementLoader_or_SoftwareRequirementLoader_or_ResourceRequirementLoader_or_InitialWorkDirRequirementLoader_or_SchemaDefRequirementLoader_or_ScatterFeatureRequirementLoader_or_SecretsLoader_or_SubworkflowFeatureRequirementLoader_or_EnvVarRequirementLoader: Final[
+    Loader[
+        CUDARequirement
+        | DockerRequirement
+        | EnvVarRequirement
+        | InitialWorkDirRequirement
+        | InlineJavascriptRequirement
+        | InplaceUpdateRequirement
+        | LoadListingRequirement
+        | Loop
+        | MPIRequirement
+        | MultipleInputFeatureRequirement
+        | NetworkAccess
+        | ResourceRequirement
+        | ScatterFeatureRequirement
+        | SchemaDefRequirement
+        | Secrets
+        | ShellCommandRequirement
+        | ShmSize
+        | SoftwareRequirement
+        | StepInputExpressionRequirement
+        | SubworkflowFeatureRequirement
+        | ToolTimeLimit
+        | WorkReuse
+    ]
+] = _UnionLoader(
+    (
+        MultipleInputFeatureRequirementLoader,
+        ToolTimeLimitLoader,
+        MPIRequirementLoader,
+        LoadListingRequirementLoader,
+        WorkReuseLoader,
+        LoopLoader,
+        ShellCommandRequirementLoader,
+        CUDARequirementLoader,
+        InplaceUpdateRequirementLoader,
+        InlineJavascriptRequirementLoader,
+        NetworkAccessLoader,
+        DockerRequirementLoader,
+        ShmSizeLoader,
+        StepInputExpressionRequirementLoader,
+        SoftwareRequirementLoader,
+        ResourceRequirementLoader,
+        InitialWorkDirRequirementLoader,
+        SchemaDefRequirementLoader,
+        ScatterFeatureRequirementLoader,
+        SecretsLoader,
+        SubworkflowFeatureRequirementLoader,
+        EnvVarRequirementLoader,
+    )
+)
+union_of_None_type_or_array_of_ProcessRequirementProxyLoader: Final[
+    Loader[None | Sequence[ProcessRequirement]]
+] = _UnionLoader(
     (
         None_type,
-        array_of_ProcessRequirement,
+        array_of_ProcessRequirementProxyLoader,
     )
 )
-idmap_requirements_union_of_None_type_or_array_of_ProcessRequirement: Final = (
-    _IdMapLoader(union_of_None_type_or_array_of_ProcessRequirement, "class", "None")
+idmap_requirements_union_of_None_type_or_array_of_ProcessRequirementProxyLoader: Final[
+    Loader[None | Sequence[ProcessRequirement]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_ProcessRequirementProxyLoader, "class", "None"
 )
-union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
-) = _UnionLoader(
+union_of_ProcessRequirementProxyLoader_or_Any_type: Final[
+    Loader[Any | ProcessRequirement]
+] = _UnionLoader(
     (
-        InlineJavascriptRequirementLoader,
-        SchemaDefRequirementLoader,
-        LoadListingRequirementLoader,
-        DockerRequirementLoader,
-        SoftwareRequirementLoader,
-        InitialWorkDirRequirementLoader,
-        EnvVarRequirementLoader,
-        ShellCommandRequirementLoader,
-        ResourceRequirementLoader,
-        WorkReuseLoader,
-        NetworkAccessLoader,
-        InplaceUpdateRequirementLoader,
-        ToolTimeLimitLoader,
-        SubworkflowFeatureRequirementLoader,
-        ScatterFeatureRequirementLoader,
-        MultipleInputFeatureRequirementLoader,
-        StepInputExpressionRequirementLoader,
-        SecretsLoader,
-        MPIRequirementLoader,
-        CUDARequirementLoader,
-        LoopLoader,
-        ShmSizeLoader,
+        ProcessRequirementProxyLoader,
         Any_type,
     )
 )
-array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
-) = _ArrayLoader(
-    union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type
-)
-union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
+array_of_union_of_ProcessRequirementProxyLoader_or_Any_type: Final[
+    Loader[Sequence[Any | ProcessRequirement]]
+] = _ArrayLoader(union_of_ProcessRequirementProxyLoader_or_Any_type)
+union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type: (
+    Final[Loader[None | Sequence[Any | ProcessRequirement]]]
 ) = _UnionLoader(
     (
         None_type,
-        array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type,
+        array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
     )
 )
-idmap_hints_union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type: (
-    Final
-) = _IdMapLoader(
-    union_of_None_type_or_array_of_union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader_or_Any_type,
+idmap_hints_union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type: Final[
+    Loader[None | Sequence[Any | ProcessRequirement]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_union_of_ProcessRequirementProxyLoader_or_Any_type,
     "class",
     "None",
 )
-union_of_None_type_or_CWLVersionLoader: Final = _UnionLoader(
+union_of_None_type_or_CWLVersionLoader: Final[Loader[CWLVersion | None]] = _UnionLoader(
     (
         None_type,
         CWLVersionLoader,
     )
 )
-uri_union_of_None_type_or_CWLVersionLoader_False_True_None_None: Final = _URILoader(
-    union_of_None_type_or_CWLVersionLoader, False, True, None, None
-)
-union_of_None_type_or_array_of_strtype: Final = _UnionLoader(
-    (
-        None_type,
-        array_of_strtype,
+uri_union_of_None_type_or_CWLVersionLoader_False_True_None_None: Final[
+    Loader[CWLVersion | None]
+] = _URILoader(union_of_None_type_or_CWLVersionLoader, False, True, None, None)
+union_of_None_type_or_array_of_strtype: Final[Loader[None | Sequence[str]]] = (
+    _UnionLoader(
+        (
+            None_type,
+            array_of_strtype,
+        )
     )
 )
-uri_union_of_None_type_or_array_of_strtype_True_False_None_None: Final = _URILoader(
-    union_of_None_type_or_array_of_strtype, True, False, None, None
-)
-InlineJavascriptRequirement_classLoader: Final = _EnumLoader(
+uri_union_of_None_type_or_array_of_strtype_True_False_None_None: Final[
+    Loader[None | Sequence[str]]
+] = _URILoader(union_of_None_type_or_array_of_strtype, True, False, None, None)
+InlineJavascriptRequirement_class: TypeAlias = Literal["InlineJavascriptRequirement"]
+InlineJavascriptRequirement_classLoader: Final[
+    Loader[InlineJavascriptRequirement_class]
+] = _EnumLoader[InlineJavascriptRequirement_class](
     ("InlineJavascriptRequirement",), "InlineJavascriptRequirement_class"
 )
-uri_InlineJavascriptRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    InlineJavascriptRequirement_classLoader, False, True, None, None
+uri_InlineJavascriptRequirement_classLoader_False_True_None_None: Final[
+    Loader[InlineJavascriptRequirement_class]
+] = _URILoader(InlineJavascriptRequirement_classLoader, False, True, None, None)
+SchemaDefRequirement_class: TypeAlias = Literal["SchemaDefRequirement"]
+SchemaDefRequirement_classLoader: Final[Loader[SchemaDefRequirement_class]] = (
+    _EnumLoader[SchemaDefRequirement_class](
+        ("SchemaDefRequirement",), "SchemaDefRequirement_class"
+    )
 )
-SchemaDefRequirement_classLoader: Final = _EnumLoader(
-    ("SchemaDefRequirement",), "SchemaDefRequirement_class"
-)
-uri_SchemaDefRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    SchemaDefRequirement_classLoader, False, True, None, None
-)
-union_of_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader: (
-    Final
-) = _UnionLoader(
+uri_SchemaDefRequirement_classLoader_False_True_None_None: Final[
+    Loader[SchemaDefRequirement_class]
+] = _URILoader(SchemaDefRequirement_classLoader, False, True, None, None)
+union_of_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader: Final[
+    Loader[CommandInputArraySchema | CommandInputEnumSchema | CommandInputRecordSchema]
+] = _UnionLoader(
     (
         CommandInputRecordSchemaLoader,
         CommandInputEnumSchemaLoader,
         CommandInputArraySchemaLoader,
     )
 )
-array_of_CommandInputSchema: Final = _ArrayLoader(CommandInputSchemaProxyLoader)
-union_of_strtype_or_ExpressionLoader: Final = _UnionLoader(
+array_of_CommandInputSchemaProxyLoader: Final[Loader[Sequence[CommandInputSchema]]] = (
+    _ArrayLoader(CommandInputSchemaProxyLoader)
+)
+union_of_strtype_or_ExpressionLoader: Final[Loader[str]] = _UnionLoader(
     (
         strtype,
         ExpressionLoader,
     )
 )
-union_of_None_type_or_booltype_or_ExpressionLoader: Final = _UnionLoader(
-    (
-        None_type,
-        booltype,
-        ExpressionLoader,
-    )
-)
-LoadListingRequirement_classLoader: Final = _EnumLoader(
-    ("LoadListingRequirement",), "LoadListingRequirement_class"
-)
-uri_LoadListingRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    LoadListingRequirement_classLoader, False, True, None, None
-)
-union_of_None_type_or_inttype_or_ExpressionLoader: Final = _UnionLoader(
-    (
-        None_type,
-        inttype,
-        ExpressionLoader,
-    )
-)
-union_of_None_type_or_strtype_or_ExpressionLoader_or_array_of_strtype: Final = (
+union_of_None_type_or_booltype_or_ExpressionLoader: Final[Loader[None | bool | str]] = (
     _UnionLoader(
         (
             None_type,
-            strtype,
+            booltype,
             ExpressionLoader,
-            array_of_strtype,
         )
     )
 )
-union_of_None_type_or_ExpressionLoader: Final = _UnionLoader(
+LoadListingRequirement_class: TypeAlias = Literal["LoadListingRequirement"]
+LoadListingRequirement_classLoader: Final[Loader[LoadListingRequirement_class]] = (
+    _EnumLoader[LoadListingRequirement_class](
+        ("LoadListingRequirement",), "LoadListingRequirement_class"
+    )
+)
+uri_LoadListingRequirement_classLoader_False_True_None_None: Final[
+    Loader[LoadListingRequirement_class]
+] = _URILoader(LoadListingRequirement_classLoader, False, True, None, None)
+union_of_None_type_or_inttype_or_ExpressionLoader: Final[Loader[None | i32 | str]] = (
+    _UnionLoader(
+        (
+            None_type,
+            inttype,
+            ExpressionLoader,
+        )
+    )
+)
+union_of_None_type_or_strtype_or_ExpressionLoader_or_array_of_strtype: Final[
+    Loader[None | Sequence[str] | str]
+] = _UnionLoader(
+    (
+        None_type,
+        strtype,
+        ExpressionLoader,
+        array_of_strtype,
+    )
+)
+union_of_None_type_or_ExpressionLoader: Final[Loader[None | str]] = _UnionLoader(
     (
         None_type,
         ExpressionLoader,
     )
 )
-union_of_None_type_or_CommandLineBindingLoader: Final = _UnionLoader(
+union_of_None_type_or_CommandLineBindingLoader: Final[
+    Loader[CommandLineBinding | None]
+] = _UnionLoader(
     (
         None_type,
         CommandLineBindingLoader,
     )
 )
-union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        CommandInputRecordSchemaLoader,
-        CommandInputEnumSchemaLoader,
-        CommandInputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         CommandInputRecordSchemaLoader,
@@ -28456,55 +30823,93 @@ union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSche
         array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | CommandInputArraySchema
+    | CommandInputEnumSchema
+    | CommandInputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | str
+    ]
+    | str
+](
     union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-array_of_CommandInputRecordFieldLoader: Final = _ArrayLoader(
-    CommandInputRecordFieldLoader
-)
-union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final = _UnionLoader(
+array_of_CommandInputRecordFieldLoader: Final[
+    Loader[Sequence[CommandInputRecordField]]
+] = _ArrayLoader(CommandInputRecordFieldLoader)
+union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandInputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_CommandInputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final = (
-    _IdMapLoader(
-        union_of_None_type_or_array_of_CommandInputRecordFieldLoader, "name", "type"
-    )
+idmap_fields_union_of_None_type_or_array_of_CommandInputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandInputRecordField]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_CommandInputRecordFieldLoader, "name", "type"
 )
-uri_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+uri_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | CommandInputArraySchema
+        | CommandInputEnumSchema
+        | CommandInputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandInputArraySchema
+            | CommandInputEnumSchema
+            | CommandInputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        CommandOutputRecordSchemaLoader,
-        CommandOutputEnumSchemaLoader,
-        CommandOutputArraySchemaLoader,
-        strtype,
-    )
-)
-array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _ArrayLoader(
-    union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype
-)
-union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
+union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _UnionLoader(
     (
         CWLTypeLoader,
         CommandOutputRecordSchemaLoader,
@@ -28514,152 +30919,178 @@ union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSc
         array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     )
 )
-typedsl_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
+typedsl_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _TypeDSLLoader[
+    CWLType
+    | CommandOutputArraySchema
+    | CommandOutputEnumSchema
+    | CommandOutputRecordSchema
+    | Sequence[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | str
+    ]
+    | str
+](
     union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     2,
     "v1.1",
 )
-union_of_None_type_or_CommandOutputBindingLoader: Final = _UnionLoader(
+union_of_None_type_or_CommandOutputBindingLoader: Final[
+    Loader[CommandOutputBinding | None]
+] = _UnionLoader(
     (
         None_type,
         CommandOutputBindingLoader,
     )
 )
-array_of_CommandOutputRecordFieldLoader: Final = _ArrayLoader(
-    CommandOutputRecordFieldLoader
-)
-union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final = _UnionLoader(
+array_of_CommandOutputRecordFieldLoader: Final[
+    Loader[Sequence[CommandOutputRecordField]]
+] = _ArrayLoader(CommandOutputRecordFieldLoader)
+union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandOutputRecordField]]
+] = _UnionLoader(
     (
         None_type,
         array_of_CommandOutputRecordFieldLoader,
     )
 )
-idmap_fields_union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final = (
-    _IdMapLoader(
-        union_of_None_type_or_array_of_CommandOutputRecordFieldLoader, "name", "type"
-    )
+idmap_fields_union_of_None_type_or_array_of_CommandOutputRecordFieldLoader: Final[
+    Loader[None | Sequence[CommandOutputRecordField]]
+] = _IdMapLoader(
+    union_of_None_type_or_array_of_CommandOutputRecordFieldLoader, "name", "type"
 )
-uri_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_False_True_2_None: (
-    Final
-) = _URILoader(
+uri_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_False_True_2_None: Final[
+    Loader[
+        CWLType
+        | CommandOutputArraySchema
+        | CommandOutputEnumSchema
+        | CommandOutputRecordSchema
+        | Sequence[
+            CWLType
+            | CommandOutputArraySchema
+            | CommandOutputEnumSchema
+            | CommandOutputRecordSchema
+            | str
+        ]
+        | str
+    ]
+] = _URILoader(
     union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     False,
     True,
     2,
     None,
 )
-union_of_CWLTypeLoader_or_stdinLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        stdinLoader,
-        CommandInputRecordSchemaLoader,
-        CommandInputEnumSchemaLoader,
-        CommandInputArraySchemaLoader,
-        strtype,
-        array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
+typedsl_CommandInputParameterTypeLoader_2: Final[Loader[CommandInputParameterType]] = (
+    _TypeDSLLoader[CommandInputParameterType](
+        CommandInputParameterTypeLoader, 2, "v1.1"
     )
 )
-typedsl_union_of_CWLTypeLoader_or_stdinLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
-    union_of_CWLTypeLoader_or_stdinLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
-    2,
-    "v1.1",
+typedsl_CommandOutputParameterTypeLoader_2: Final[
+    Loader[CommandOutputParameterType]
+] = _TypeDSLLoader[CommandOutputParameterType](
+    CommandOutputParameterTypeLoader, 2, "v1.1"
 )
-union_of_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype: (
-    Final
-) = _UnionLoader(
-    (
-        CWLTypeLoader,
-        stdoutLoader,
-        stderrLoader,
-        CommandOutputRecordSchemaLoader,
-        CommandOutputEnumSchemaLoader,
-        CommandOutputArraySchemaLoader,
-        strtype,
-        array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
-    )
+CommandLineTool_class: TypeAlias = Literal["CommandLineTool"]
+CommandLineTool_classLoader: Final[Loader[CommandLineTool_class]] = _EnumLoader[
+    CommandLineTool_class
+](("CommandLineTool",), "CommandLineTool_class")
+uri_CommandLineTool_classLoader_False_True_None_None: Final[
+    Loader[CommandLineTool_class]
+] = _URILoader(CommandLineTool_classLoader, False, True, None, None)
+array_of_CommandInputParameterLoader: Final[Loader[Sequence[CommandInputParameter]]] = (
+    _ArrayLoader(CommandInputParameterLoader)
 )
-typedsl_union_of_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_2: (
-    Final
-) = _TypeDSLLoader(
-    union_of_CWLTypeLoader_or_stdoutLoader_or_stderrLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype_or_array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
-    2,
-    "v1.1",
-)
-CommandLineTool_classLoader: Final = _EnumLoader(
-    ("CommandLineTool",), "CommandLineTool_class"
-)
-uri_CommandLineTool_classLoader_False_True_None_None: Final = _URILoader(
-    CommandLineTool_classLoader, False, True, None, None
-)
-array_of_CommandInputParameterLoader: Final = _ArrayLoader(CommandInputParameterLoader)
-idmap_inputs_array_of_CommandInputParameterLoader: Final = _IdMapLoader(
-    array_of_CommandInputParameterLoader, "id", "type"
-)
-array_of_CommandOutputParameterLoader: Final = _ArrayLoader(
-    CommandOutputParameterLoader
-)
-idmap_outputs_array_of_CommandOutputParameterLoader: Final = _IdMapLoader(
-    array_of_CommandOutputParameterLoader, "id", "type"
-)
-union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final = _UnionLoader(
+idmap_inputs_array_of_CommandInputParameterLoader: Final[
+    Loader[Sequence[CommandInputParameter]]
+] = _IdMapLoader(array_of_CommandInputParameterLoader, "id", "type")
+array_of_CommandOutputParameterLoader: Final[
+    Loader[Sequence[CommandOutputParameter]]
+] = _ArrayLoader(CommandOutputParameterLoader)
+idmap_outputs_array_of_CommandOutputParameterLoader: Final[
+    Loader[Sequence[CommandOutputParameter]]
+] = _IdMapLoader(array_of_CommandOutputParameterLoader, "id", "type")
+union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final[
+    Loader[CommandLineBinding | str]
+] = _UnionLoader(
     (
         strtype,
         ExpressionLoader,
         CommandLineBindingLoader,
     )
 )
-array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final = (
-    _ArrayLoader(union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader)
-)
-union_of_None_type_or_array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: (
-    Final
-) = _UnionLoader(
+array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final[
+    Loader[Sequence[CommandLineBinding | str]]
+] = _ArrayLoader(union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader)
+union_of_None_type_or_array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader: Final[
+    Loader[None | Sequence[CommandLineBinding | str]]
+] = _UnionLoader(
     (
         None_type,
         array_of_union_of_strtype_or_ExpressionLoader_or_CommandLineBindingLoader,
     )
 )
-array_of_inttype: Final = _ArrayLoader(inttype)
-union_of_None_type_or_array_of_inttype: Final = _UnionLoader(
-    (
-        None_type,
-        array_of_inttype,
+array_of_inttype: Final[Loader[Sequence[i32]]] = _ArrayLoader(inttype)
+union_of_None_type_or_array_of_inttype: Final[Loader[None | Sequence[i32]]] = (
+    _UnionLoader(
+        (
+            None_type,
+            array_of_inttype,
+        )
     )
 )
-DockerRequirement_classLoader: Final = _EnumLoader(
-    ("DockerRequirement",), "DockerRequirement_class"
+DockerRequirement_class: TypeAlias = Literal["DockerRequirement"]
+DockerRequirement_classLoader: Final[Loader[DockerRequirement_class]] = _EnumLoader[
+    DockerRequirement_class
+](("DockerRequirement",), "DockerRequirement_class")
+uri_DockerRequirement_classLoader_False_True_None_None: Final[
+    Loader[DockerRequirement_class]
+] = _URILoader(DockerRequirement_classLoader, False, True, None, None)
+SoftwareRequirement_class: TypeAlias = Literal["SoftwareRequirement"]
+SoftwareRequirement_classLoader: Final[Loader[SoftwareRequirement_class]] = _EnumLoader[
+    SoftwareRequirement_class
+](("SoftwareRequirement",), "SoftwareRequirement_class")
+uri_SoftwareRequirement_classLoader_False_True_None_None: Final[
+    Loader[SoftwareRequirement_class]
+] = _URILoader(SoftwareRequirement_classLoader, False, True, None, None)
+array_of_SoftwarePackageLoader: Final[Loader[Sequence[SoftwarePackage]]] = _ArrayLoader(
+    SoftwarePackageLoader
 )
-uri_DockerRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    DockerRequirement_classLoader, False, True, None, None
-)
-SoftwareRequirement_classLoader: Final = _EnumLoader(
-    ("SoftwareRequirement",), "SoftwareRequirement_class"
-)
-uri_SoftwareRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    SoftwareRequirement_classLoader, False, True, None, None
-)
-array_of_SoftwarePackageLoader: Final = _ArrayLoader(SoftwarePackageLoader)
-idmap_packages_array_of_SoftwarePackageLoader: Final = _IdMapLoader(
-    array_of_SoftwarePackageLoader, "package", "specs"
-)
-uri_union_of_None_type_or_array_of_strtype_False_False_None_True: Final = _URILoader(
-    union_of_None_type_or_array_of_strtype, False, False, None, True
-)
-InitialWorkDirRequirement_classLoader: Final = _EnumLoader(
+idmap_packages_array_of_SoftwarePackageLoader: Final[
+    Loader[Sequence[SoftwarePackage]]
+] = _IdMapLoader(array_of_SoftwarePackageLoader, "package", "specs")
+uri_union_of_None_type_or_array_of_strtype_False_False_None_True: Final[
+    Loader[None | Sequence[str]]
+] = _URILoader(union_of_None_type_or_array_of_strtype, False, False, None, True)
+InitialWorkDirRequirement_class: TypeAlias = Literal["InitialWorkDirRequirement"]
+InitialWorkDirRequirement_classLoader: Final[
+    Loader[InitialWorkDirRequirement_class]
+] = _EnumLoader[InitialWorkDirRequirement_class](
     ("InitialWorkDirRequirement",), "InitialWorkDirRequirement_class"
 )
-uri_InitialWorkDirRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    InitialWorkDirRequirement_classLoader, False, True, None, None
-)
-union_of_None_type_or_DirentLoader_or_ExpressionLoader_or_FileLoader_or_DirectoryLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader: (
-    Final
-) = _UnionLoader(
+uri_InitialWorkDirRequirement_classLoader_False_True_None_None: Final[
+    Loader[InitialWorkDirRequirement_class]
+] = _URILoader(InitialWorkDirRequirement_classLoader, False, True, None, None)
+union_of_None_type_or_DirentLoader_or_ExpressionLoader_or_FileLoader_or_DirectoryLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[Directory | Dirent | File | None | Sequence[Directory | File] | str]
+] = _UnionLoader(
     (
         None_type,
         DirentLoader,
@@ -28669,280 +31100,363 @@ union_of_None_type_or_DirentLoader_or_ExpressionLoader_or_FileLoader_or_Director
         array_of_union_of_FileLoader_or_DirectoryLoader,
     )
 )
-array_of_union_of_None_type_or_DirentLoader_or_ExpressionLoader_or_FileLoader_or_DirectoryLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_None_type_or_DirentLoader_or_ExpressionLoader_or_FileLoader_or_DirectoryLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[
+        Sequence[Directory | Dirent | File | None | Sequence[Directory | File] | str]
+    ]
+] = _ArrayLoader(
     union_of_None_type_or_DirentLoader_or_ExpressionLoader_or_FileLoader_or_DirectoryLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader
 )
-union_of_ExpressionLoader_or_array_of_union_of_None_type_or_DirentLoader_or_ExpressionLoader_or_FileLoader_or_DirectoryLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader: (
-    Final
-) = _UnionLoader(
+union_of_ExpressionLoader_or_array_of_union_of_None_type_or_DirentLoader_or_ExpressionLoader_or_FileLoader_or_DirectoryLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader: Final[
+    Loader[
+        Sequence[Directory | Dirent | File | None | Sequence[Directory | File] | str]
+        | str
+    ]
+] = _UnionLoader(
     (
         ExpressionLoader,
         array_of_union_of_None_type_or_DirentLoader_or_ExpressionLoader_or_FileLoader_or_DirectoryLoader_or_array_of_union_of_FileLoader_or_DirectoryLoader,
     )
 )
-EnvVarRequirement_classLoader: Final = _EnumLoader(
-    ("EnvVarRequirement",), "EnvVarRequirement_class"
+EnvVarRequirement_class: TypeAlias = Literal["EnvVarRequirement"]
+EnvVarRequirement_classLoader: Final[Loader[EnvVarRequirement_class]] = _EnumLoader[
+    EnvVarRequirement_class
+](("EnvVarRequirement",), "EnvVarRequirement_class")
+uri_EnvVarRequirement_classLoader_False_True_None_None: Final[
+    Loader[EnvVarRequirement_class]
+] = _URILoader(EnvVarRequirement_classLoader, False, True, None, None)
+array_of_EnvironmentDefLoader: Final[Loader[Sequence[EnvironmentDef]]] = _ArrayLoader(
+    EnvironmentDefLoader
 )
-uri_EnvVarRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    EnvVarRequirement_classLoader, False, True, None, None
+idmap_envDef_array_of_EnvironmentDefLoader: Final[Loader[Sequence[EnvironmentDef]]] = (
+    _IdMapLoader(array_of_EnvironmentDefLoader, "envName", "envValue")
 )
-array_of_EnvironmentDefLoader: Final = _ArrayLoader(EnvironmentDefLoader)
-idmap_envDef_array_of_EnvironmentDefLoader: Final = _IdMapLoader(
-    array_of_EnvironmentDefLoader, "envName", "envValue"
+ShellCommandRequirement_class: TypeAlias = Literal["ShellCommandRequirement"]
+ShellCommandRequirement_classLoader: Final[Loader[ShellCommandRequirement_class]] = (
+    _EnumLoader[ShellCommandRequirement_class](
+        ("ShellCommandRequirement",), "ShellCommandRequirement_class"
+    )
 )
-ShellCommandRequirement_classLoader: Final = _EnumLoader(
-    ("ShellCommandRequirement",), "ShellCommandRequirement_class"
-)
-uri_ShellCommandRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    ShellCommandRequirement_classLoader, False, True, None, None
-)
-ResourceRequirement_classLoader: Final = _EnumLoader(
-    ("ResourceRequirement",), "ResourceRequirement_class"
-)
-uri_ResourceRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    ResourceRequirement_classLoader, False, True, None, None
-)
-union_of_None_type_or_inttype_or_floattype_or_ExpressionLoader: Final = _UnionLoader(
+uri_ShellCommandRequirement_classLoader_False_True_None_None: Final[
+    Loader[ShellCommandRequirement_class]
+] = _URILoader(ShellCommandRequirement_classLoader, False, True, None, None)
+ResourceRequirement_class: TypeAlias = Literal["ResourceRequirement"]
+ResourceRequirement_classLoader: Final[Loader[ResourceRequirement_class]] = _EnumLoader[
+    ResourceRequirement_class
+](("ResourceRequirement",), "ResourceRequirement_class")
+uri_ResourceRequirement_classLoader_False_True_None_None: Final[
+    Loader[ResourceRequirement_class]
+] = _URILoader(ResourceRequirement_classLoader, False, True, None, None)
+union_of_None_type_or_inttype_or_longtype_or_floattype_or_ExpressionLoader: Final[
+    Loader[None | float | i32 | i64 | str]
+] = _UnionLoader(
     (
         None_type,
         inttype,
+        longtype,
         floattype,
         ExpressionLoader,
     )
 )
-WorkReuse_classLoader: Final = _EnumLoader(("WorkReuse",), "WorkReuse_class")
-uri_WorkReuse_classLoader_False_True_None_None: Final = _URILoader(
-    WorkReuse_classLoader, False, True, None, None
+WorkReuse_class: TypeAlias = Literal["WorkReuse"]
+WorkReuse_classLoader: Final[Loader[WorkReuse_class]] = _EnumLoader[WorkReuse_class](
+    ("WorkReuse",), "WorkReuse_class"
 )
-union_of_booltype_or_ExpressionLoader: Final = _UnionLoader(
+uri_WorkReuse_classLoader_False_True_None_None: Final[Loader[WorkReuse_class]] = (
+    _URILoader(WorkReuse_classLoader, False, True, None, None)
+)
+union_of_booltype_or_ExpressionLoader: Final[Loader[bool | str]] = _UnionLoader(
     (
         booltype,
         ExpressionLoader,
     )
 )
-NetworkAccess_classLoader: Final = _EnumLoader(
-    ("NetworkAccess",), "NetworkAccess_class"
-)
-uri_NetworkAccess_classLoader_False_True_None_None: Final = _URILoader(
-    NetworkAccess_classLoader, False, True, None, None
-)
-InplaceUpdateRequirement_classLoader: Final = _EnumLoader(
-    ("InplaceUpdateRequirement",), "InplaceUpdateRequirement_class"
-)
-uri_InplaceUpdateRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    InplaceUpdateRequirement_classLoader, False, True, None, None
-)
-ToolTimeLimit_classLoader: Final = _EnumLoader(
-    ("ToolTimeLimit",), "ToolTimeLimit_class"
-)
-uri_ToolTimeLimit_classLoader_False_True_None_None: Final = _URILoader(
-    ToolTimeLimit_classLoader, False, True, None, None
-)
-union_of_inttype_or_ExpressionLoader: Final = _UnionLoader(
-    (
-        inttype,
-        ExpressionLoader,
+NetworkAccess_class: TypeAlias = Literal["NetworkAccess"]
+NetworkAccess_classLoader: Final[Loader[NetworkAccess_class]] = _EnumLoader[
+    NetworkAccess_class
+](("NetworkAccess",), "NetworkAccess_class")
+uri_NetworkAccess_classLoader_False_True_None_None: Final[
+    Loader[NetworkAccess_class]
+] = _URILoader(NetworkAccess_classLoader, False, True, None, None)
+InplaceUpdateRequirement_class: TypeAlias = Literal["InplaceUpdateRequirement"]
+InplaceUpdateRequirement_classLoader: Final[Loader[InplaceUpdateRequirement_class]] = (
+    _EnumLoader[InplaceUpdateRequirement_class](
+        ("InplaceUpdateRequirement",), "InplaceUpdateRequirement_class"
     )
 )
-union_of_None_type_or_InputBindingLoader: Final = _UnionLoader(
-    (
-        None_type,
-        InputBindingLoader,
+uri_InplaceUpdateRequirement_classLoader_False_True_None_None: Final[
+    Loader[InplaceUpdateRequirement_class]
+] = _URILoader(InplaceUpdateRequirement_classLoader, False, True, None, None)
+ToolTimeLimit_class: TypeAlias = Literal["ToolTimeLimit"]
+ToolTimeLimit_classLoader: Final[Loader[ToolTimeLimit_class]] = _EnumLoader[
+    ToolTimeLimit_class
+](("ToolTimeLimit",), "ToolTimeLimit_class")
+uri_ToolTimeLimit_classLoader_False_True_None_None: Final[
+    Loader[ToolTimeLimit_class]
+] = _URILoader(ToolTimeLimit_classLoader, False, True, None, None)
+union_of_inttype_or_longtype_or_ExpressionLoader: Final[Loader[i32 | i64 | str]] = (
+    _UnionLoader(
+        (
+            inttype,
+            longtype,
+            ExpressionLoader,
+        )
     )
 )
-ExpressionTool_classLoader: Final = _EnumLoader(
-    ("ExpressionTool",), "ExpressionTool_class"
+typedsl_OutputParameterTypeLoader_2: Final[Loader[OutputParameterType]] = (
+    _TypeDSLLoader[OutputParameterType](OutputParameterTypeLoader, 2, "v1.1")
 )
-uri_ExpressionTool_classLoader_False_True_None_None: Final = _URILoader(
-    ExpressionTool_classLoader, False, True, None, None
-)
-array_of_WorkflowInputParameterLoader: Final = _ArrayLoader(
-    WorkflowInputParameterLoader
-)
-idmap_inputs_array_of_WorkflowInputParameterLoader: Final = _IdMapLoader(
-    array_of_WorkflowInputParameterLoader, "id", "type"
-)
-array_of_ExpressionToolOutputParameterLoader: Final = _ArrayLoader(
-    ExpressionToolOutputParameterLoader
-)
-idmap_outputs_array_of_ExpressionToolOutputParameterLoader: Final = _IdMapLoader(
-    array_of_ExpressionToolOutputParameterLoader, "id", "type"
-)
-uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None: Final = (
-    _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 1, None)
-)
-union_of_None_type_or_LinkMergeMethodLoader: Final = _UnionLoader(
-    (
-        None_type,
-        LinkMergeMethodLoader,
+typedsl_InputParameterTypeLoader_2: Final[Loader[InputParameterType]] = _TypeDSLLoader[
+    InputParameterType
+](InputParameterTypeLoader, 2, "v1.1")
+union_of_None_type_or_InputBindingLoader: Final[Loader[InputBinding | None]] = (
+    _UnionLoader(
+        (
+            None_type,
+            InputBindingLoader,
+        )
     )
 )
-union_of_None_type_or_PickValueMethodLoader: Final = _UnionLoader(
-    (
-        None_type,
-        PickValueMethodLoader,
+ExpressionTool_class: TypeAlias = Literal["ExpressionTool"]
+ExpressionTool_classLoader: Final[Loader[ExpressionTool_class]] = _EnumLoader[
+    ExpressionTool_class
+](("ExpressionTool",), "ExpressionTool_class")
+uri_ExpressionTool_classLoader_False_True_None_None: Final[
+    Loader[ExpressionTool_class]
+] = _URILoader(ExpressionTool_classLoader, False, True, None, None)
+array_of_WorkflowInputParameterLoader: Final[
+    Loader[Sequence[WorkflowInputParameter]]
+] = _ArrayLoader(WorkflowInputParameterLoader)
+idmap_inputs_array_of_WorkflowInputParameterLoader: Final[
+    Loader[Sequence[WorkflowInputParameter]]
+] = _IdMapLoader(array_of_WorkflowInputParameterLoader, "id", "type")
+array_of_ExpressionToolOutputParameterLoader: Final[
+    Loader[Sequence[ExpressionToolOutputParameter]]
+] = _ArrayLoader(ExpressionToolOutputParameterLoader)
+idmap_outputs_array_of_ExpressionToolOutputParameterLoader: Final[
+    Loader[Sequence[ExpressionToolOutputParameter]]
+] = _IdMapLoader(array_of_ExpressionToolOutputParameterLoader, "id", "type")
+uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_1_None: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 1, None)
+union_of_None_type_or_LinkMergeMethodLoader: Final[Loader[LinkMergeMethod | None]] = (
+    _UnionLoader(
+        (
+            None_type,
+            LinkMergeMethodLoader,
+        )
     )
 )
-uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_2_None: Final = (
-    _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 2, None)
+union_of_None_type_or_PickValueMethodLoader: Final[Loader[None | PickValueMethod]] = (
+    _UnionLoader(
+        (
+            None_type,
+            PickValueMethodLoader,
+        )
+    )
 )
-array_of_WorkflowStepInputLoader: Final = _ArrayLoader(WorkflowStepInputLoader)
-idmap_in__array_of_WorkflowStepInputLoader: Final = _IdMapLoader(
-    array_of_WorkflowStepInputLoader, "id", "source"
+uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_2_None: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 2, None)
+array_of_WorkflowStepInputLoader: Final[Loader[Sequence[WorkflowStepInput]]] = (
+    _ArrayLoader(WorkflowStepInputLoader)
 )
-union_of_strtype_or_WorkflowStepOutputLoader: Final = _UnionLoader(
+idmap_in__array_of_WorkflowStepInputLoader: Final[
+    Loader[Sequence[WorkflowStepInput]]
+] = _IdMapLoader(array_of_WorkflowStepInputLoader, "id", "source")
+union_of_strtype_or_WorkflowStepOutputLoader: Final[
+    Loader[WorkflowStepOutput | str]
+] = _UnionLoader(
     (
         strtype,
         WorkflowStepOutputLoader,
     )
 )
-array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final = _ArrayLoader(
-    union_of_strtype_or_WorkflowStepOutputLoader
-)
-union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final = _UnionLoader(
-    (array_of_union_of_strtype_or_WorkflowStepOutputLoader,)
-)
-uri_union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader_True_False_None_None: (
-    Final
-) = _URILoader(
+array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final[
+    Loader[Sequence[WorkflowStepOutput | str]]
+] = _ArrayLoader(union_of_strtype_or_WorkflowStepOutputLoader)
+union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader: Final[
+    Loader[Sequence[WorkflowStepOutput | str]]
+] = _UnionLoader((array_of_union_of_strtype_or_WorkflowStepOutputLoader,))
+uri_union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader_True_False_None_None: Final[
+    Loader[Sequence[WorkflowStepOutput | str]]
+] = _URILoader(
     union_of_array_of_union_of_strtype_or_WorkflowStepOutputLoader,
     True,
     False,
     None,
     None,
 )
-array_of_Any_type: Final = _ArrayLoader(Any_type)
-union_of_None_type_or_array_of_Any_type: Final = _UnionLoader(
-    (
-        None_type,
-        array_of_Any_type,
+array_of_Any_type: Final[Loader[Sequence[Any]]] = _ArrayLoader(Any_type)
+union_of_None_type_or_array_of_Any_type: Final[Loader[None | Sequence[Any]]] = (
+    _UnionLoader(
+        (
+            None_type,
+            array_of_Any_type,
+        )
     )
 )
-idmap_hints_union_of_None_type_or_array_of_Any_type: Final = _IdMapLoader(
-    union_of_None_type_or_array_of_Any_type, "class", "None"
-)
-union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _UnionLoader(
+idmap_hints_union_of_None_type_or_array_of_Any_type: Final[
+    Loader[None | Sequence[Any]]
+] = _IdMapLoader(union_of_None_type_or_array_of_Any_type, "class", "None")
+union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_ProcessGeneratorLoader_or_WorkflowLoader_or_OperationLoader: Final[
+    Loader[CommandLineTool | ExpressionTool | Operation | ProcessGenerator | Workflow]
+] = _UnionLoader(
     (
-        strtype,
         CommandLineToolLoader,
         ExpressionToolLoader,
+        ProcessGeneratorLoader,
         WorkflowLoader,
         OperationLoader,
-        ProcessGeneratorLoader,
     )
 )
-uri_union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader_False_False_None_None: (
-    Final
-) = _URILoader(
-    union_of_strtype_or_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader,
-    False,
-    False,
-    None,
-    None,
-)
-uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_0_None: Final = (
-    _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 0, None)
-)
-union_of_None_type_or_ScatterMethodLoader: Final = _UnionLoader(
+union_of_strtype_or_ProcessProxyLoader: Final[Loader[Process | str]] = _UnionLoader(
     (
-        None_type,
-        ScatterMethodLoader,
+        strtype,
+        ProcessProxyLoader,
     )
 )
-uri_union_of_None_type_or_ScatterMethodLoader_False_True_None_None: Final = _URILoader(
-    union_of_None_type_or_ScatterMethodLoader, False, True, None, None
+uri_union_of_strtype_or_ProcessProxyLoader_False_False_None_None: Final[
+    Loader[Process | str]
+] = _URILoader(union_of_strtype_or_ProcessProxyLoader, False, False, None, None)
+uri_union_of_None_type_or_strtype_or_array_of_strtype_False_False_0_None: Final[
+    Loader[None | Sequence[str] | str]
+] = _URILoader(union_of_None_type_or_strtype_or_array_of_strtype, False, False, 0, None)
+union_of_None_type_or_ScatterMethodLoader: Final[Loader[None | ScatterMethod]] = (
+    _UnionLoader(
+        (
+            None_type,
+            ScatterMethodLoader,
+        )
+    )
 )
-Workflow_classLoader: Final = _EnumLoader(("Workflow",), "Workflow_class")
-uri_Workflow_classLoader_False_True_None_None: Final = _URILoader(
-    Workflow_classLoader, False, True, None, None
+uri_union_of_None_type_or_ScatterMethodLoader_False_True_None_None: Final[
+    Loader[None | ScatterMethod]
+] = _URILoader(union_of_None_type_or_ScatterMethodLoader, False, True, None, None)
+Workflow_class: TypeAlias = Literal["Workflow"]
+Workflow_classLoader: Final[Loader[Workflow_class]] = _EnumLoader[Workflow_class](
+    ("Workflow",), "Workflow_class"
 )
-array_of_WorkflowOutputParameterLoader: Final = _ArrayLoader(
-    WorkflowOutputParameterLoader
+uri_Workflow_classLoader_False_True_None_None: Final[Loader[Workflow_class]] = (
+    _URILoader(Workflow_classLoader, False, True, None, None)
 )
-idmap_outputs_array_of_WorkflowOutputParameterLoader: Final = _IdMapLoader(
-    array_of_WorkflowOutputParameterLoader, "id", "type"
+array_of_WorkflowOutputParameterLoader: Final[
+    Loader[Sequence[WorkflowOutputParameter]]
+] = _ArrayLoader(WorkflowOutputParameterLoader)
+idmap_outputs_array_of_WorkflowOutputParameterLoader: Final[
+    Loader[Sequence[WorkflowOutputParameter]]
+] = _IdMapLoader(array_of_WorkflowOutputParameterLoader, "id", "type")
+array_of_WorkflowStepLoader: Final[Loader[Sequence[WorkflowStep]]] = _ArrayLoader(
+    WorkflowStepLoader
 )
-array_of_WorkflowStepLoader: Final = _ArrayLoader(WorkflowStepLoader)
-union_of_array_of_WorkflowStepLoader: Final = _UnionLoader(
-    (array_of_WorkflowStepLoader,)
+union_of_array_of_WorkflowStepLoader: Final[Loader[Sequence[WorkflowStep]]] = (
+    _UnionLoader((array_of_WorkflowStepLoader,))
 )
-idmap_steps_union_of_array_of_WorkflowStepLoader: Final = _IdMapLoader(
-    union_of_array_of_WorkflowStepLoader, "id", "None"
-)
-SubworkflowFeatureRequirement_classLoader: Final = _EnumLoader(
+idmap_steps_union_of_array_of_WorkflowStepLoader: Final[
+    Loader[Sequence[WorkflowStep]]
+] = _IdMapLoader(union_of_array_of_WorkflowStepLoader, "id", "None")
+SubworkflowFeatureRequirement_class: TypeAlias = Literal[
+    "SubworkflowFeatureRequirement"
+]
+SubworkflowFeatureRequirement_classLoader: Final[
+    Loader[SubworkflowFeatureRequirement_class]
+] = _EnumLoader[SubworkflowFeatureRequirement_class](
     ("SubworkflowFeatureRequirement",), "SubworkflowFeatureRequirement_class"
 )
-uri_SubworkflowFeatureRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    SubworkflowFeatureRequirement_classLoader, False, True, None, None
-)
-ScatterFeatureRequirement_classLoader: Final = _EnumLoader(
+uri_SubworkflowFeatureRequirement_classLoader_False_True_None_None: Final[
+    Loader[SubworkflowFeatureRequirement_class]
+] = _URILoader(SubworkflowFeatureRequirement_classLoader, False, True, None, None)
+ScatterFeatureRequirement_class: TypeAlias = Literal["ScatterFeatureRequirement"]
+ScatterFeatureRequirement_classLoader: Final[
+    Loader[ScatterFeatureRequirement_class]
+] = _EnumLoader[ScatterFeatureRequirement_class](
     ("ScatterFeatureRequirement",), "ScatterFeatureRequirement_class"
 )
-uri_ScatterFeatureRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    ScatterFeatureRequirement_classLoader, False, True, None, None
-)
-MultipleInputFeatureRequirement_classLoader: Final = _EnumLoader(
+uri_ScatterFeatureRequirement_classLoader_False_True_None_None: Final[
+    Loader[ScatterFeatureRequirement_class]
+] = _URILoader(ScatterFeatureRequirement_classLoader, False, True, None, None)
+MultipleInputFeatureRequirement_class: TypeAlias = Literal[
+    "MultipleInputFeatureRequirement"
+]
+MultipleInputFeatureRequirement_classLoader: Final[
+    Loader[MultipleInputFeatureRequirement_class]
+] = _EnumLoader[MultipleInputFeatureRequirement_class](
     ("MultipleInputFeatureRequirement",), "MultipleInputFeatureRequirement_class"
 )
-uri_MultipleInputFeatureRequirement_classLoader_False_True_None_None: Final = (
-    _URILoader(MultipleInputFeatureRequirement_classLoader, False, True, None, None)
-)
-StepInputExpressionRequirement_classLoader: Final = _EnumLoader(
+uri_MultipleInputFeatureRequirement_classLoader_False_True_None_None: Final[
+    Loader[MultipleInputFeatureRequirement_class]
+] = _URILoader(MultipleInputFeatureRequirement_classLoader, False, True, None, None)
+StepInputExpressionRequirement_class: TypeAlias = Literal[
+    "StepInputExpressionRequirement"
+]
+StepInputExpressionRequirement_classLoader: Final[
+    Loader[StepInputExpressionRequirement_class]
+] = _EnumLoader[StepInputExpressionRequirement_class](
     ("StepInputExpressionRequirement",), "StepInputExpressionRequirement_class"
 )
-uri_StepInputExpressionRequirement_classLoader_False_True_None_None: Final = _URILoader(
-    StepInputExpressionRequirement_classLoader, False, True, None, None
+uri_StepInputExpressionRequirement_classLoader_False_True_None_None: Final[
+    Loader[StepInputExpressionRequirement_class]
+] = _URILoader(StepInputExpressionRequirement_classLoader, False, True, None, None)
+Operation_class: TypeAlias = Literal["Operation"]
+Operation_classLoader: Final[Loader[Operation_class]] = _EnumLoader[Operation_class](
+    ("Operation",), "Operation_class"
 )
-Operation_classLoader: Final = _EnumLoader(("Operation",), "Operation_class")
-uri_Operation_classLoader_False_True_None_None: Final = _URILoader(
-    Operation_classLoader, False, True, None, None
+uri_Operation_classLoader_False_True_None_None: Final[Loader[Operation_class]] = (
+    _URILoader(Operation_classLoader, False, True, None, None)
 )
-array_of_OperationInputParameterLoader: Final = _ArrayLoader(
-    OperationInputParameterLoader
+array_of_OperationInputParameterLoader: Final[
+    Loader[Sequence[OperationInputParameter]]
+] = _ArrayLoader(OperationInputParameterLoader)
+idmap_inputs_array_of_OperationInputParameterLoader: Final[
+    Loader[Sequence[OperationInputParameter]]
+] = _IdMapLoader(array_of_OperationInputParameterLoader, "id", "type")
+array_of_OperationOutputParameterLoader: Final[
+    Loader[Sequence[OperationOutputParameter]]
+] = _ArrayLoader(OperationOutputParameterLoader)
+idmap_outputs_array_of_OperationOutputParameterLoader: Final[
+    Loader[Sequence[OperationOutputParameter]]
+] = _IdMapLoader(array_of_OperationOutputParameterLoader, "id", "type")
+uri_strtype_False_True_None_None: Final[Loader[str]] = _URILoader(
+    strtype, False, True, None, None
 )
-idmap_inputs_array_of_OperationInputParameterLoader: Final = _IdMapLoader(
-    array_of_OperationInputParameterLoader, "id", "type"
-)
-array_of_OperationOutputParameterLoader: Final = _ArrayLoader(
-    OperationOutputParameterLoader
-)
-idmap_outputs_array_of_OperationOutputParameterLoader: Final = _IdMapLoader(
-    array_of_OperationOutputParameterLoader, "id", "type"
-)
-uri_strtype_False_True_None_None: Final = _URILoader(strtype, False, True, None, None)
-uri_array_of_strtype_False_False_0_None: Final = _URILoader(
+uri_array_of_strtype_False_False_0_None: Final[Loader[Sequence[str]]] = _URILoader(
     array_of_strtype, False, False, 0, None
 )
-union_of_strtype_or_array_of_strtype: Final = _UnionLoader(
+union_of_inttype_or_ExpressionLoader: Final[Loader[i32 | str]] = _UnionLoader(
+    (
+        inttype,
+        ExpressionLoader,
+    )
+)
+union_of_strtype_or_array_of_strtype: Final[Loader[Sequence[str] | str]] = _UnionLoader(
     (
         strtype,
         array_of_strtype,
     )
 )
-union_of_None_type_or_Any_type: Final = _UnionLoader(
+union_of_None_type_or_Any_type: Final[Loader[Any | None]] = _UnionLoader(
     (
         None_type,
         Any_type,
     )
 )
-array_of_LoopInputLoader: Final = _ArrayLoader(LoopInputLoader)
-idmap_loop_array_of_LoopInputLoader: Final = _IdMapLoader(
+array_of_LoopInputLoader: Final[Loader[Sequence[LoopInput]]] = _ArrayLoader(
+    LoopInputLoader
+)
+idmap_loop_array_of_LoopInputLoader: Final[Loader[Sequence[LoopInput]]] = _IdMapLoader(
     array_of_LoopInputLoader, "id", "loopSource"
 )
-LoopOutputModesLoader: Final = _EnumLoader(
+LoopOutputModes: TypeAlias = Literal["last", "all"]
+LoopOutputModesLoader: Final[Loader[LoopOutputModes]] = _EnumLoader[LoopOutputModes](
     (
         "last",
         "all",
     ),
     "LoopOutputModes",
 )
-union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _UnionLoader(
+union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader: Final[
+    Loader[CommandLineTool | ExpressionTool | Operation | ProcessGenerator | Workflow]
+] = _UnionLoader(
     (
         CommandLineToolLoader,
         ExpressionToolLoader,
@@ -28951,14 +31465,27 @@ union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_Oper
         ProcessGeneratorLoader,
     )
 )
-array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _ArrayLoader(
+array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader: Final[
+    Loader[
+        Sequence[
+            CommandLineTool | ExpressionTool | Operation | ProcessGenerator | Workflow
+        ]
+    ]
+] = _ArrayLoader(
     union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader
 )
-union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader_or_array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader: (
-    Final
-) = _UnionLoader(
+union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader_or_array_of_union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_OperationLoader_or_ProcessGeneratorLoader: Final[
+    Loader[
+        CommandLineTool
+        | ExpressionTool
+        | Operation
+        | ProcessGenerator
+        | Sequence[
+            CommandLineTool | ExpressionTool | Operation | ProcessGenerator | Workflow
+        ]
+        | Workflow
+    ]
+] = _UnionLoader(
     (
         CommandLineToolLoader,
         ExpressionToolLoader,
@@ -28971,7 +31498,6 @@ union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_WorkflowLoader_or_Oper
 
 _loaders.update({
     "DocumentedLoader": None,
-    "ProcessRequirementLoader": union_of_InlineJavascriptRequirementLoader_or_SchemaDefRequirementLoader_or_LoadListingRequirementLoader_or_DockerRequirementLoader_or_SoftwareRequirementLoader_or_InitialWorkDirRequirementLoader_or_EnvVarRequirementLoader_or_ShellCommandRequirementLoader_or_ResourceRequirementLoader_or_WorkReuseLoader_or_NetworkAccessLoader_or_InplaceUpdateRequirementLoader_or_ToolTimeLimitLoader_or_SubworkflowFeatureRequirementLoader_or_ScatterFeatureRequirementLoader_or_MultipleInputFeatureRequirementLoader_or_StepInputExpressionRequirementLoader_or_SecretsLoader_or_MPIRequirementLoader_or_CUDARequirementLoader_or_LoopLoader_or_ShmSizeLoader,
     "LabeledLoader": None,
     "IdentifiedLoader": None,
     "IdentifierRequiredLoader": None,
@@ -28984,14 +31510,15 @@ _loaders.update({
     "InputSchemaLoader": None,
     "OutputSchemaLoader": None,
     "InputParameterLoader": union_of_CommandInputParameterLoader_or_WorkflowInputParameterLoader_or_OperationInputParameterLoader,
-    "OutputParameterLoader": union_of_CommandOutputParameterLoader_or_ExpressionToolOutputParameterLoader_or_WorkflowOutputParameterLoader_or_OperationOutputParameterLoader,
-    "ProcessLoader": None,
+    "OutputParameterLoader": union_of_CommandOutputParameterLoader_or_ExpressionToolOutputParameterLoader_or_OperationOutputParameterLoader_or_WorkflowOutputParameterLoader,
+    "ProcessRequirementLoader": union_of_MultipleInputFeatureRequirementLoader_or_ToolTimeLimitLoader_or_MPIRequirementLoader_or_LoadListingRequirementLoader_or_WorkReuseLoader_or_LoopLoader_or_ShellCommandRequirementLoader_or_CUDARequirementLoader_or_InplaceUpdateRequirementLoader_or_InlineJavascriptRequirementLoader_or_NetworkAccessLoader_or_DockerRequirementLoader_or_ShmSizeLoader_or_StepInputExpressionRequirementLoader_or_SoftwareRequirementLoader_or_ResourceRequirementLoader_or_InitialWorkDirRequirementLoader_or_SchemaDefRequirementLoader_or_ScatterFeatureRequirementLoader_or_SecretsLoader_or_SubworkflowFeatureRequirementLoader_or_EnvVarRequirementLoader,
+    "ProcessLoader": union_of_CommandLineToolLoader_or_ExpressionToolLoader_or_ProcessGeneratorLoader_or_WorkflowLoader_or_OperationLoader,
     "CommandInputSchemaLoader": union_of_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader,
     "CommandLineBindableLoader": None,
     "SinkLoader": None,
 })
 
-CWLObjectTypeLoader.add_loaders(
+cast(_UnionLoader[CWLObjectType], CWLObjectTypeLoader).add_loaders(
     (
         booltype,
         inttype,
@@ -29001,6 +31528,53 @@ CWLObjectTypeLoader.add_loaders(
         DirectoryLoader,
         array_of_union_of_None_type_or_CWLObjectTypeLoader,
         map_of_union_of_None_type_or_CWLObjectTypeLoader,
+    )
+)
+cast(_UnionLoader[InputParameterType], InputParameterTypeLoader).add_loaders(
+    (
+        CWLTypeLoader,
+        InputRecordSchemaLoader,
+        InputEnumSchemaLoader,
+        InputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_InputRecordSchemaLoader_or_InputEnumSchemaLoader_or_InputArraySchemaLoader_or_strtype,
+    )
+)
+cast(_UnionLoader[OutputParameterType], OutputParameterTypeLoader).add_loaders(
+    (
+        CWLTypeLoader,
+        OutputRecordSchemaLoader,
+        OutputEnumSchemaLoader,
+        OutputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_OutputRecordSchemaLoader_or_OutputEnumSchemaLoader_or_OutputArraySchemaLoader_or_strtype,
+    )
+)
+cast(
+    _UnionLoader[CommandInputParameterType], CommandInputParameterTypeLoader
+).add_loaders(
+    (
+        CWLTypeLoader,
+        stdinLoader,
+        CommandInputRecordSchemaLoader,
+        CommandInputEnumSchemaLoader,
+        CommandInputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_CommandInputRecordSchemaLoader_or_CommandInputEnumSchemaLoader_or_CommandInputArraySchemaLoader_or_strtype,
+    )
+)
+cast(
+    _UnionLoader[CommandOutputParameterType], CommandOutputParameterTypeLoader
+).add_loaders(
+    (
+        CWLTypeLoader,
+        stdoutLoader,
+        stderrLoader,
+        CommandOutputRecordSchemaLoader,
+        CommandOutputEnumSchemaLoader,
+        CommandOutputArraySchemaLoader,
+        strtype,
+        array_of_union_of_CWLTypeLoader_or_CommandOutputRecordSchemaLoader_or_CommandOutputEnumSchemaLoader_or_CommandOutputArraySchemaLoader_or_strtype,
     )
 )
 

--- a/src/cwl_utils/parser/cwl_v1_2_utils.py
+++ b/src/cwl_utils/parser/cwl_v1_2_utils.py
@@ -1,30 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 import hashlib
 import logging
-from collections import namedtuple
-from collections.abc import MutableMapping, MutableSequence
+from collections.abc import MutableMapping, MutableSequence, Sequence
 from io import StringIO
 from pathlib import Path
-from typing import IO, Any, cast
+from typing import IO, Any, cast, Literal
 from urllib.parse import urldefrag
 
 from schema_salad.exceptions import ValidationException
 from schema_salad.metaschema import ArraySchema, RecordSchema
 from schema_salad.runtime import LoadingOptions, shortname, file_uri, save
 from schema_salad.sourceline import SourceLine, add_lc_filename
-from schema_salad.utils import aslist, json_dumps, yaml_no_ts
+from schema_salad.utils import aslist, json_dumps, yaml_no_ts, flatten
 
 import cwl_utils.parser
 import cwl_utils.parser.cwl_v1_2 as cwl
 import cwl_utils.parser.utils
 from cwl_utils.errors import WorkflowException
+from cwl_utils.types import SrcSink
 from cwl_utils.utils import yaml_dumps
 
 CONTENT_LIMIT: int = 64 * 1024
 
 _logger = logging.getLogger("cwl_utils")
-
-SrcSink = namedtuple("SrcSink", ["src", "sink", "linkMerge", "message"])
 
 
 def _compare_type(type1: Any, type2: Any) -> bool:
@@ -132,12 +130,15 @@ def _inputfile_load(
 
 def check_all_types(
     src_dict: dict[str, Any],
-    sinks: MutableSequence[cwl.WorkflowStepInput | cwl.WorkflowOutputParameter],
+    sinks: Sequence[cwl.WorkflowStepInput | cwl.WorkflowOutputParameter],
     param_to_step: dict[str, cwl.WorkflowStep],
     type_dict: dict[str, Any],
 ) -> dict[str, list[SrcSink]]:
     """Given a list of sinks, check if their types match with the types of their sources."""
-    validation: dict[str, list[SrcSink]] = {"warning": [], "exception": []}
+    validation: dict[str, list[SrcSink]] = {
+        "warning": [],
+        "exception": [],
+    }
     for sink in sinks:
         extra_message = (
             "pickValue is %s" % sink.pickValue if sink.pickValue is not None else None
@@ -304,8 +305,7 @@ def convert_stdstreams_to_files(clt: cwl.CommandLineTool) -> None:
                 )
             else:
                 clt.stdin = (
-                    "$(inputs.%s.path)"
-                    % cast(str, inp.id).rpartition("#")[2].split("/")[-1]
+                    "$(inputs.%s.path)" % inp.id.rpartition("#")[2].split("/")[-1]
                 )
                 inp.type_ = "File"
 
@@ -368,21 +368,36 @@ def load_inputfile_by_yaml(
     return result
 
 
+def to_input_array(type_: cwl.InputParameterType) -> cwl.InputArraySchema:
+    return cwl.InputArraySchema(type_="array", items=type_)
+
+
+def to_output_array(type_: cwl.OutputParameterType) -> cwl.OutputArraySchema:
+    return cwl.OutputArraySchema(type_="array", items=type_)
+
+
 def type_for_step_input(
     step: cwl.WorkflowStep,
     in_: cwl.WorkflowStepInput,
-) -> Any:
+) -> (
+    Literal["Any"]
+    | cwl_utils.parser.InputParameterType
+    | cwl_utils.parser.CommandInputParameterType
+):
     """Determine the type for the given step input."""
     if in_.valueFrom is not None:
         return "Any"
-    step_run = cwl_utils.parser.utils.load_step(step)
-    cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
-    if step_run and step_run.inputs:
+    if step_run := cwl_utils.parser.utils.load_step(step):
+        cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
         for step_input in step_run.inputs:
-            if cast(str, step_input.id).split("#")[-1] == in_.id.split("#")[-1]:
-                input_type = step_input.type_
-                if step.scatter is not None and in_.id in aslist(step.scatter):
-                    input_type = ArraySchema(items=input_type, type_="array")
+            if step_input.id.split("#")[-1] == in_.id.split("#")[-1]:
+                if (input_type := step_input.type_) is None:
+                    raise Exception(f"Step output {step_input.id} has null type")
+                else:
+                    if step.scatter is not None and in_.id in aslist(step.scatter):
+                        input_type = cwl_utils.parser.utils.to_input_array(
+                            input_type, step_run.cwlVersion or "v1.2"
+                        )
                 return input_type
     return "Any"
 
@@ -390,24 +405,33 @@ def type_for_step_input(
 def type_for_step_output(
     step: cwl.WorkflowStep,
     sourcename: str,
-) -> Any:
+) -> (
+    Literal["Any"]
+    | cwl_utils.parser.OutputParameterType
+    | cwl_utils.parser.CommandOutputParameterType
+):
     """Determine the type for the given step output."""
-    step_run = cwl_utils.parser.utils.load_step(step)
-    cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
-    if step_run and step_run.outputs:
+    if step_run := cwl_utils.parser.utils.load_step(step):
+        cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
         for output in step_run.outputs:
             if (
                 output.id.split("#")[-1].split("/")[-1]
                 == sourcename.split("#")[-1].split("/")[-1]
             ):
-                output_type = output.type_
-                if step.scatter is not None:
-                    if step.scatterMethod == "nested_crossproduct":
-                        for _ in range(len(aslist(step.scatter))):
-                            output_type = ArraySchema(items=output_type, type_="array")
-                    else:
-                        output_type = ArraySchema(items=output_type, type_="array")
-                return output_type
+                if (output_type := output.type_) is None:
+                    raise Exception(f"Step output {output.id} has null type")
+                else:
+                    if step.scatter is not None:
+                        if step.scatterMethod == "nested_crossproduct":
+                            for _ in range(len(aslist(step.scatter))):
+                                output_type = cwl_utils.parser.utils.to_output_array(
+                                    output_type, step_run.cwlVersion or "v1.2"
+                                )
+                        else:
+                            output_type = cwl_utils.parser.utils.to_output_array(
+                                output_type, step_run.cwlVersion or "v1.2"
+                            )
+                    return output_type
     raise ValidationException(
         "param {} not found in {}.".format(
             sourcename,
@@ -417,41 +441,45 @@ def type_for_step_output(
 
 
 def type_for_source(
-    process: cwl.CommandLineTool | cwl.Workflow | cwl.ExpressionTool,
-    sourcenames: str | list[str],
-    parent: cwl.Workflow | None = None,
+    process: cwl.CommandLineTool | cwl.Workflow | cwl.ExpressionTool | cwl.Operation,
+    sourcenames: str | Sequence[str],
+    parent: cwl_utils.parser.Workflow | None = None,
     linkMerge: str | None = None,
     pickValue: str | None = None,
-) -> Any:
+    loaded_steps: dict[str, cwl_utils.parser.Process] | None = None,
+) -> cwl_utils.parser.ParameterTypeOrArraySchema:
     """Determine the type for the given sourcenames."""
     scatter_context: list[tuple[int, str] | None] = []
     params = cwl_utils.parser.utils.param_for_source_id(
-        process, sourcenames, parent, scatter_context
+        process, sourcenames, parent, scatter_context, loaded_steps
     )
     if not isinstance(params, MutableSequence):
-        new_type = params.type_
-        if scatter_context[0] is not None:
-            if scatter_context[0][1] == "nested_crossproduct":
-                for _ in range(scatter_context[0][0]):
+        if params.type_ is None:
+            raise Exception(f"Parameter {params.id} has null type")
+        else:
+            new_type: cwl_utils.parser.ParameterTypeOrArraySchema = params.type_
+            if scatter_context[0] is not None:
+                if scatter_context[0][1] == "nested_crossproduct":
+                    for _ in range(scatter_context[0][0]):
+                        new_type = ArraySchema(items=new_type, type_="array")
+                else:
                     new_type = ArraySchema(items=new_type, type_="array")
-            else:
+            if linkMerge == "merge_nested":
                 new_type = ArraySchema(items=new_type, type_="array")
-        if linkMerge == "merge_nested":
-            new_type = ArraySchema(items=new_type, type_="array")
-        elif linkMerge == "merge_flattened":
-            new_type = cwl_utils.parser.utils.merge_flatten_type(new_type)
-        if pickValue is not None:
-            if isinstance(new_type, ArraySchema):
-                if pickValue in ("first_non_null", "the_only_non_null"):
-                    new_type = new_type.items
-        return new_type
-    new_type = []
+            elif linkMerge == "merge_flattened":
+                new_type = cwl_utils.parser.utils.merge_flatten_type(new_type)
+            if pickValue is not None:
+                if isinstance(new_type, ArraySchema):
+                    if pickValue in ("first_non_null", "the_only_non_null"):
+                        new_type = cast(
+                            cwl_utils.parser.ParameterType | ArraySchema, new_type.items
+                        )
+            return new_type
+    new_types: list[cwl_utils.parser.ParameterType | ArraySchema] = []
     for p, sc in zip(params, scatter_context):
-        if isinstance(p, str) and not any(_compare_type(t, p) for t in new_type):
-            cur_type = p
-        elif hasattr(p, "type_") and not any(
-            _compare_type(t, p.type_) for t in new_type
-        ):
+        if isinstance(p, str) and not any(_compare_type(t, p) for t in new_types):
+            cur_type: cwl_utils.parser.ParameterType | ArraySchema | None = p
+        elif p is not None and not any(_compare_type(t, p.type_) for t in new_types):
             cur_type = p.type_
         else:
             cur_type = None
@@ -462,17 +490,27 @@ def type_for_source(
                         cur_type = ArraySchema(items=cur_type, type_="array")
                 else:
                     cur_type = ArraySchema(items=cur_type, type_="array")
-            new_type.append(cur_type)
-    if len(new_type) == 1:
-        new_type = new_type[0]
+            new_types.append(cur_type)
+    if len(new_types) == 1:
+        final_type: cwl_utils.parser.ParameterTypeOrArraySchema = new_types[0]
+    else:
+        final_type = cast(
+            cwl_utils.parser.ParameterTypeOrArraySchema,
+            flatten(new_types),
+        )
     if linkMerge == "merge_nested":
-        new_type = ArraySchema(items=new_type, type_="array")
+        final_type = ArraySchema(items=final_type, type_="array")
     elif linkMerge == "merge_flattened":
-        new_type = cwl_utils.parser.utils.merge_flatten_type(new_type)
+        final_type = cwl_utils.parser.utils.merge_flatten_type(final_type)
     elif isinstance(sourcenames, list) and len(sourcenames) > 1:
-        new_type = ArraySchema(items=new_type, type_="array")
+        final_type = ArraySchema(items=final_type, type_="array")
     if pickValue is not None:
-        if isinstance(new_type, ArraySchema):
+        if isinstance(final_type, ArraySchema):
             if pickValue in ("first_non_null", "the_only_non_null"):
-                new_type = new_type.items
-    return new_type
+                final_type = cast(
+                    cwl_utils.parser.ParameterType
+                    | ArraySchema
+                    | Sequence[ArraySchema],
+                    final_type.items,
+                )
+    return final_type

--- a/src/cwl_utils/parser/latest.py
+++ b/src/cwl_utils/parser/latest.py
@@ -1,3 +1,3 @@
 """Convenience module."""
 
-from .cwl_v1_2 import *  # noqa: F401,F403
+from cwl_utils.parser.cwl_v1_2 import *  # noqa: F401,F403

--- a/src/cwl_utils/parser/utils.py
+++ b/src/cwl_utils/parser/utils.py
@@ -2,18 +2,19 @@
 
 import copy
 import logging
-from collections.abc import MutableSequence
+from collections.abc import MutableSequence, Sequence
 from pathlib import Path
-from typing import Any, cast, Literal
+from typing import Any, cast, Literal, overload, Final
 from urllib.parse import unquote_plus, urlparse
 
 from schema_salad.exceptions import ValidationException
 from schema_salad.metaschema import ArraySchema, RecordSchema
 from schema_salad.runtime import file_uri, shortname, save
 from schema_salad.sourceline import SourceLine, strip_dup_lineno
-from schema_salad.utils import json_dumps, yaml_no_ts
+from schema_salad.utils import json_dumps, yaml_no_ts, flatten
 
 import cwl_utils
+from cwl_utils.errors import WorkflowException
 from cwl_utils.parser import (
     LoadingOptions,
     Process,
@@ -32,9 +33,23 @@ from cwl_utils.parser import (
     CommandOutputParameter,
     WorkflowInputParameter,
     load_document_by_uri,
+    InputParameterType,
+    CommandInputParameterType,
+    InputArraySchema,
+    OutputParameterType,
+    CommandOutputParameterType,
+    OutputArraySchema,
+    CWLVersion,
+    OperationInputParameter,
+    ExpressionToolOutputParameter,
+    WorkflowOutputParameter,
+    OperationOutputParameter,
+    ParameterTypeOrArraySchema,
+    CWLTypeSchema,
+    AbstractProcess,
 )
-from cwl_utils.errors import WorkflowException
-from cwl_utils.utils import yaml_dumps
+from cwl_utils.types import is_sequence, SrcSink
+from cwl_utils.utils import yaml_dumps, get_step_uri
 
 _logger = logging.getLogger("cwl_utils")
 
@@ -53,7 +68,9 @@ def _compare_records(
     for key in sinkfields.keys():
         if (
             not can_assign_src_to_sink(
-                srcfields.get(key, "null"), sinkfields.get(key, "null"), strict
+                cast(CWLTypeSchema, srcfields.get(key, "null")),
+                cast(CWLTypeSchema, sinkfields.get(key, "null")),
+                strict,
             )
             and sinkfields.get(key) is not None
         ):
@@ -76,7 +93,11 @@ def _compare_records(
     return True
 
 
-def can_assign_src_to_sink(src: Any, sink: Any, strict: bool = False) -> bool:
+def can_assign_src_to_sink(
+    src: CWLTypeSchema,
+    sink: CWLTypeSchema,
+    strict: bool = False,
+) -> bool:
     """
     Check for identical type specifications, ignoring extra keys like inputBinding.
 
@@ -90,10 +111,12 @@ def can_assign_src_to_sink(src: Any, sink: Any, strict: bool = False) -> bool:
     if "Any" in (src, sink):
         return True
     if isinstance(src, ArraySchema) and isinstance(sink, ArraySchema):
-        return can_assign_src_to_sink(src.items, sink.items, strict)
+        return can_assign_src_to_sink(
+            cast(CWLTypeSchema, src.items), cast(CWLTypeSchema, sink.items), strict
+        )
     if isinstance(src, RecordSchema) and isinstance(sink, RecordSchema):
         return _compare_records(src, sink, strict)
-    if isinstance(src, MutableSequence):
+    if is_sequence(src):
         if strict:
             for this_src in src:
                 if not can_assign_src_to_sink(this_src, sink):
@@ -103,7 +126,7 @@ def can_assign_src_to_sink(src: Any, sink: Any, strict: bool = False) -> bool:
             if this_src != "null" and can_assign_src_to_sink(this_src, sink):
                 return True
         return False
-    if isinstance(sink, MutableSequence):
+    if is_sequence(sink):
         for this_sink in sink:
             if can_assign_src_to_sink(src, this_sink):
                 return True
@@ -112,8 +135,8 @@ def can_assign_src_to_sink(src: Any, sink: Any, strict: bool = False) -> bool:
 
 
 def check_types(
-    srctype: Any,
-    sinktype: Any,
+    srctype: ParameterTypeOrArraySchema,
+    sinktype: ParameterTypeOrArraySchema,
     linkMerge: str | None,
     valueFrom: str | None = None,
 ) -> str:
@@ -230,24 +253,42 @@ def load_inputfile_by_yaml(
 
 
 def load_step(
-    step: WorkflowStep,
+    step: WorkflowStep, loaded_steps: dict[str, Process] | None = None
 ) -> Process:
     if isinstance(step.run, str):
-        step_run = load_document_by_uri(
-            path=step.loadingOptions.fetcher.urljoin(
-                base_url=cast(str, step.loadingOptions.fileuri),
-                url=step.run,
-            ),
-            loadingOptions=step.loadingOptions,
-        )
-        return cast(Process, step_run)
-    return cast(Process, copy.deepcopy(step.run))
+        uri = get_step_uri(step)
+        if loaded_steps is not None and uri in loaded_steps:
+            return loaded_steps[uri]
+        else:
+            step_run = cast(
+                AbstractProcess,
+                load_document_by_uri(
+                    path=uri,
+                    loadingOptions=step.loadingOptions,
+                ),
+            )
+            if not isinstance(step_run, cwl_utils.parser.Process):
+                raise Exception(
+                    f"Unsupported process type: {step_run.__class__.__name__}"
+                )
+            if loaded_steps is not None:
+                loaded_steps[uri] = step_run
+            return step_run
+    else:
+        step_run = copy.deepcopy(step.run)
+        if not isinstance(step_run, cwl_utils.parser.Process):
+            raise Exception(f"Unsupported process type: {step_run.__class__.__name__}")
+        return step_run
 
 
-def merge_flatten_type(src: Any) -> Any:
+def merge_flatten_type(
+    src: ParameterTypeOrArraySchema,
+) -> ArraySchema | Sequence[ArraySchema]:
     """Return the merge flattened type of the source type."""
-    if isinstance(src, MutableSequence):
-        return [merge_flatten_type(t) for t in src]
+    if is_sequence(src):
+        return cast(
+            Sequence[ArraySchema], flatten([merge_flatten_type(t) for t in src])
+        )
     if isinstance(src, ArraySchema):
         return src
     return ArraySchema(type_="array", items=src)
@@ -255,25 +296,42 @@ def merge_flatten_type(src: Any) -> Any:
 
 def param_for_source_id(
     process: Process,
-    sourcenames: str | list[str],
+    sourcenames: str | Sequence[str],
     parent: Workflow | None = None,
     scatter_context: list[tuple[int, str] | None] | None = None,
+    loaded_steps: dict[str, cwl_utils.parser.Process] | None = None,
 ) -> (
     CommandInputParameter
-    | CommandOutputParameter
+    | OperationInputParameter
     | WorkflowInputParameter
+    | CommandOutputParameter
+    | ExpressionToolOutputParameter
+    | OperationOutputParameter
+    | WorkflowOutputParameter
     | MutableSequence[
-        CommandInputParameter | CommandOutputParameter | WorkflowInputParameter
+        CommandInputParameter
+        | OperationInputParameter
+        | WorkflowInputParameter
+        | CommandOutputParameter
+        | ExpressionToolOutputParameter
+        | OperationOutputParameter
+        | WorkflowOutputParameter
     ]
 ):
     """Find the process input parameter that matches one of the given sourcenames."""
     if isinstance(sourcenames, str):
         sourcenames = [sourcenames]
     params: MutableSequence[
-        CommandInputParameter | CommandOutputParameter | WorkflowInputParameter
+        CommandInputParameter
+        | OperationInputParameter
+        | WorkflowInputParameter
+        | CommandOutputParameter
+        | ExpressionToolOutputParameter
+        | OperationOutputParameter
+        | WorkflowOutputParameter
     ] = []
     for sourcename in sourcenames:
-        if not isinstance(process, Workflow):
+        if isinstance(process, Workflow):
             for param in process.inputs:
                 if param.id.split("#")[-1] == sourcename.split("#")[-1]:
                     params.append(param)
@@ -295,7 +353,7 @@ def param_for_source_id(
                         == step.id.split("#")[-1]
                         and step.out
                     ):
-                        step_run = cwl_utils.parser.utils.load_step(step)
+                        step_run = cwl_utils.parser.utils.load_step(step, loaded_steps)
                         cwl_utils.parser.utils.convert_stdstreams_to_files(step_run)
                         for outp in step.out:
                             outp_id = outp if isinstance(outp, str) else outp.id
@@ -347,22 +405,26 @@ def param_for_source_id(
 
 def static_checker(workflow: Workflow) -> None:
     """Check if all source and sink types of a workflow are compatible before run time."""
-    step_inputs = []
+    step_inputs: Final[list[WorkflowStepInput]] = []
     step_outputs = []
-    type_dict = {}
+    type_dict: dict[
+        str, Literal["Any"] | cwl_utils.parser.ParameterType | ArraySchema
+    ] = {}
     param_to_step = {}
     for step in workflow.steps:
         if step.in_ is not None:
             step_inputs.extend(step.in_)
             param_to_step.update({s.id: step for s in step.in_})
-            type_dict.update(
-                {
-                    cast(str, s.id): type_for_step_input(
-                        step, s, cast(str, workflow.cwlVersion)
+            match workflow.cwlVersion:
+                case "v1.0" | "v1.1" | "v1.2":
+                    type_dict.update(
+                        {
+                            s.id: type_for_step_input(step, s, workflow.cwlVersion)
+                            for s in step.in_
+                        }
                     )
-                    for s in step.in_
-                }
-            )
+                case _:
+                    raise Exception(f"Unsupported CWL version: {workflow.cwlVersion}")
         if step.out is not None:
             # FIXME: the correct behaviour here would be to create WorkflowStepOutput directly at load time
             match workflow.cwlVersion:
@@ -382,7 +444,7 @@ def static_checker(workflow: Workflow) -> None:
                         for s in step.out
                     ]
                 case _:
-                    raise Exception(f"Unsupported CWL version {workflow.cwlVersion}")
+                    raise Exception(f"Unsupported CWL version: {workflow.cwlVersion}")
             step_outputs.extend(step_outs)
             param_to_step.update({s.id: step for s in step_outs})
             type_dict.update(
@@ -395,37 +457,57 @@ def static_checker(workflow: Workflow) -> None:
         **{param.id: param for param in workflow.inputs},
         **{param.id: param for param in step_outputs},
     }
+    if any(param.type_ is None for param in workflow.inputs) or any(
+        param.type_ is None for param in workflow.outputs
+    ):
+        raise Exception("Parameters with null type are not supported")
     type_dict = {
         **type_dict,
-        **{param.id: param.type_ for param in workflow.inputs},
-        **{param.id: param.type_ for param in workflow.outputs},
+        **{
+            param.id: param.type_
+            for param in workflow.inputs
+            if param.type_ is not None
+        },
+        **{
+            param.id: param.type_
+            for param in workflow.outputs
+            if param.type_ is not None
+        },
     }
 
-    step_inputs_val: dict[str, Any]
-    workflow_outputs_val: dict[str, Any]
+    step_inputs_val: dict[str, list[SrcSink]]
+    workflow_outputs_val: dict[str, list[SrcSink]]
     match workflow.cwlVersion:
         case "v1.0":
             step_inputs_val = cwl_v1_0_utils.check_all_types(
-                src_dict, step_inputs, type_dict
+                src_dict, cast(list[cwl_v1_0.WorkflowStepInput], step_inputs), type_dict
             )
             workflow_outputs_val = cwl_v1_0_utils.check_all_types(
                 src_dict, workflow.outputs, type_dict
             )
         case "v1.1":
             step_inputs_val = cwl_v1_1_utils.check_all_types(
-                src_dict, step_inputs, type_dict
+                src_dict, cast(list[cwl_v1_1.WorkflowStepInput], step_inputs), type_dict
             )
             workflow_outputs_val = cwl_v1_1_utils.check_all_types(
                 src_dict, workflow.outputs, type_dict
             )
         case "v1.2":
             step_inputs_val = cwl_v1_2_utils.check_all_types(
-                src_dict, step_inputs, param_to_step, type_dict
+                src_dict,
+                cast(list[cwl_v1_2.WorkflowStepInput], step_inputs),
+                cast(dict[str, cwl_v1_2.WorkflowStep], param_to_step),
+                type_dict,
             )
             workflow_outputs_val = cwl_v1_2_utils.check_all_types(
-                src_dict, workflow.outputs, param_to_step, type_dict
+                src_dict,
+                workflow.outputs,
+                cast(dict[str, cwl_v1_2.WorkflowStep], param_to_step),
+                type_dict,
             )
-        case _ as cwlVersion:
+        case None:
+            raise ValidationException("could not get the cwlVersion")
+        case cwlVersion:
             raise Exception(f"Unsupported CWL version {cwlVersion}")
 
     warnings = step_inputs_val["warning"] + workflow_outputs_val["warning"]
@@ -495,12 +577,10 @@ def static_checker(workflow: Workflow) -> None:
         exception_msgs.append(msg)
 
     for sink in step_inputs:
+        sink_type = type_dict[sink.id]
         if (
-            "null" != type_dict[sink.id]
-            and not (
-                isinstance(type_dict[sink.id], MutableSequence)
-                and "null" in type_dict[sink.id]
-            )
+            "null" != sink_type
+            and not (is_sequence(sink_type) and "null" in sink_type)
             and getattr(sink, "source", None) is None
             and getattr(sink, "default", None) is None
             and getattr(sink, "valueFrom", None) is None
@@ -520,62 +600,135 @@ def static_checker(workflow: Workflow) -> None:
         raise ValidationException(all_exception_msg)
 
 
+@overload
+def to_input_array(
+    type_: InputParameterType | CommandInputParameterType, cwlVersion: Literal["v1.0"]
+) -> cwl_v1_0.InputArraySchema: ...
+
+
+@overload
+def to_input_array(
+    type_: InputParameterType | CommandInputParameterType, cwlVersion: Literal["v1.1"]
+) -> cwl_v1_1.InputArraySchema: ...
+
+
+@overload
+def to_input_array(
+    type_: InputParameterType | CommandInputParameterType, cwlVersion: Literal["v1.2"]
+) -> cwl_v1_2.InputArraySchema: ...
+
+
+def to_input_array(
+    type_: InputParameterType | CommandInputParameterType,
+    cwlVersion: CWLVersion,
+) -> InputArraySchema:
+    match cwlVersion:
+        case "v1.0":
+            return cwl_v1_0_utils.to_input_array(
+                cast(
+                    cwl_v1_0.InputParameterType | cwl_v1_0.CommandInputParameterType,
+                    type_,
+                )
+            )
+        case "v1.1":
+            return cwl_v1_1_utils.to_input_array(
+                cast(
+                    cwl_v1_1.InputParameterType | cwl_v1_1.CommandInputParameterType,
+                    type_,
+                )
+            )
+        case "v1.2":
+            return cwl_v1_2_utils.to_input_array(
+                cast(
+                    cwl_v1_2.InputParameterType | cwl_v1_2.CommandInputParameterType,
+                    type_,
+                )
+            )
+
+
+@overload
+def to_output_array(
+    type_: OutputParameterType | CommandOutputParameterType, cwlVersion: Literal["v1.0"]
+) -> cwl_v1_0.OutputArraySchema: ...
+
+
+@overload
+def to_output_array(
+    type_: OutputParameterType | CommandOutputParameterType, cwlVersion: Literal["v1.1"]
+) -> cwl_v1_1.OutputArraySchema: ...
+
+
+@overload
+def to_output_array(
+    type_: OutputParameterType | CommandOutputParameterType, cwlVersion: Literal["v1.2"]
+) -> cwl_v1_2.OutputArraySchema: ...
+
+
+def to_output_array(
+    type_: OutputParameterType | CommandOutputParameterType,
+    cwlVersion: CWLVersion,
+) -> OutputArraySchema:
+    match cwlVersion:
+        case "v1.0":
+            return cwl_v1_0_utils.to_output_array(
+                cast(
+                    cwl_v1_0.OutputParameterType | cwl_v1_0.CommandOutputParameterType,
+                    type_,
+                )
+            )
+        case "v1.1":
+            return cwl_v1_1_utils.to_output_array(
+                cast(
+                    cwl_v1_1.OutputParameterType | cwl_v1_1.CommandOutputParameterType,
+                    type_,
+                )
+            )
+        case "v1.2":
+            return cwl_v1_2_utils.to_output_array(
+                cast(
+                    cwl_v1_2.OutputParameterType | cwl_v1_2.CommandOutputParameterType,
+                    type_,
+                )
+            )
+
+
 def type_for_source(
     process: Process,
-    cwlVersion: Literal["v1.0", "v1.1", "v1.2"],
-    sourcenames: str | list[str],
+    cwlVersion: CWLVersion,
+    sourcenames: str | Sequence[str],
     parent: Workflow | None = None,
     linkMerge: str | None = None,
     pickValue: str | None = None,
-) -> Any:
+    loaded_steps: dict[str, cwl_utils.parser.Process] | None = None,
+) -> cwl_utils.parser.ParameterTypeOrArraySchema:
     """Determine the type for the given sourcenames."""
     match process.cwlVersion or cwlVersion:
         case "v1.0":
             return cwl_v1_0_utils.type_for_source(
-                cast(
-                    cwl_v1_0.CommandLineTool
-                    | cwl_v1_0.Workflow
-                    | cwl_v1_0.ExpressionTool,
-                    process,
-                ),
-                sourcenames,
-                cast(cwl_v1_0.Workflow | None, parent),
-                linkMerge,
+                process, sourcenames, parent, linkMerge, loaded_steps
             )
         case "v1.1":
             return cwl_v1_1_utils.type_for_source(
-                cast(
-                    cwl_v1_1.CommandLineTool
-                    | cwl_v1_1.Workflow
-                    | cwl_v1_1.ExpressionTool,
-                    process,
-                ),
-                sourcenames,
-                cast(cwl_v1_1.Workflow | None, parent),
-                linkMerge,
+                process, sourcenames, parent, linkMerge, loaded_steps
             )
         case "v1.2":
             return cwl_v1_2_utils.type_for_source(
-                cast(
-                    cwl_v1_2.CommandLineTool
-                    | cwl_v1_2.Workflow
-                    | cwl_v1_2.ExpressionTool,
-                    process,
-                ),
-                sourcenames,
-                cast(cwl_v1_2.Workflow | None, parent),
-                linkMerge,
-                pickValue,
+                process, sourcenames, parent, linkMerge, pickValue, loaded_steps
             )
-        case _ as cwlVersion:
+        case cwlVersion:
             raise ValidationException(
                 f"Version error. Did not recognise {cwlVersion} as a CWL version"
             )
 
 
 def type_for_step_input(
-    step: WorkflowStep, in_: WorkflowStepInput, cwlVersion: str
-) -> Any:
+    step: WorkflowStep, in_: WorkflowStepInput, cwlVersion: CWLVersion
+) -> (
+    Literal["Any"]
+    | cwl_utils.parser.InputParameterType
+    | cwl_utils.parser.CommandInputParameterType
+    | ArraySchema
+):
     """Determine the type for the given step output."""
     match cwlVersion:
         case "v1.0":
@@ -592,7 +745,14 @@ def type_for_step_input(
             )
 
 
-def type_for_step_output(step: WorkflowStep, sourcename: str, cwlVersion: str) -> Any:
+def type_for_step_output(
+    step: WorkflowStep, sourcename: str, cwlVersion: CWLVersion
+) -> (
+    Literal["Any"]
+    | cwl_utils.parser.OutputParameterType
+    | cwl_utils.parser.CommandOutputParameterType
+    | ArraySchema
+):
     """Determine the type for the given step output."""
     match cwlVersion:
         case "v1.0":

--- a/src/cwl_utils/tests/test_parser_utils.py
+++ b/src/cwl_utils/tests/test_parser_utils.py
@@ -200,6 +200,9 @@ def test_v1_0_stdout_to_file() -> None:
     )
     cwl_utils.parser.cwl_v1_0_utils.convert_stdstreams_to_files(clt)
     assert clt.stdout is not None
+    assert isinstance(
+        clt.outputs[0].outputBinding, cwl_utils.parser.cwl_v1_0.CommandOutputBinding
+    )
     assert clt.stdout == clt.outputs[0].outputBinding.glob
 
 
@@ -232,6 +235,9 @@ def test_v1_0_stdout_to_file_preserve_original() -> None:
     )
     cwl_utils.parser.cwl_v1_0_utils.convert_stdstreams_to_files(clt)
     assert clt.stdout == "original.txt"
+    assert isinstance(
+        clt.outputs[0].outputBinding, cwl_utils.parser.cwl_v1_0.CommandOutputBinding
+    )
     assert clt.stdout == clt.outputs[0].outputBinding.glob
 
 
@@ -245,6 +251,9 @@ def test_v1_0_stderr_to_file() -> None:
     )
     cwl_utils.parser.cwl_v1_0_utils.convert_stdstreams_to_files(clt)
     assert clt.stderr is not None
+    assert isinstance(
+        clt.outputs[0].outputBinding, cwl_utils.parser.cwl_v1_0.CommandOutputBinding
+    )
     assert clt.stderr == clt.outputs[0].outputBinding.glob
 
 
@@ -277,6 +286,9 @@ def test_v1_0_stderr_to_file_preserve_original() -> None:
     )
     cwl_utils.parser.cwl_v1_0_utils.convert_stdstreams_to_files(clt)
     assert clt.stderr == "original.txt"
+    assert isinstance(
+        clt.outputs[0].outputBinding, cwl_utils.parser.cwl_v1_0.CommandOutputBinding
+    )
     assert clt.stderr == clt.outputs[0].outputBinding.glob
 
 
@@ -518,6 +530,7 @@ def test_v1_1_stdout_to_file() -> None:
     )
     cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
     assert clt.stdout is not None
+    assert clt.outputs[0].outputBinding is not None
     assert clt.stdout == clt.outputs[0].outputBinding.glob
 
 
@@ -550,6 +563,7 @@ def test_v1_1_stdout_to_file_preserve_original() -> None:
     )
     cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
     assert clt.stdout == "original.txt"
+    assert clt.outputs[0].outputBinding is not None
     assert clt.stdout == clt.outputs[0].outputBinding.glob
 
 
@@ -563,6 +577,7 @@ def test_v1_1_stderr_to_file() -> None:
     )
     cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
     assert clt.stderr is not None
+    assert clt.outputs[0].outputBinding is not None
     assert clt.stderr == clt.outputs[0].outputBinding.glob
 
 
@@ -595,6 +610,7 @@ def test_v1_1_stderr_to_file_preserve_original() -> None:
     )
     cwl_utils.parser.cwl_v1_1_utils.convert_stdstreams_to_files(clt)
     assert clt.stderr == "original.txt"
+    assert clt.outputs[0].outputBinding is not None
     assert clt.stderr == clt.outputs[0].outputBinding.glob
 
 
@@ -879,6 +895,7 @@ def test_v1_2_stdout_to_file() -> None:
     )
     cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
     assert clt.stdout is not None
+    assert clt.outputs[0].outputBinding is not None
     assert clt.stdout == clt.outputs[0].outputBinding.glob
 
 
@@ -911,6 +928,7 @@ def test_v1_2_stdout_to_file_preserve_original() -> None:
     )
     cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
     assert clt.stdout == "original.txt"
+    assert clt.outputs[0].outputBinding is not None
     assert clt.stdout == clt.outputs[0].outputBinding.glob
 
 
@@ -924,6 +942,7 @@ def test_v1_2_stderr_to_file() -> None:
     )
     cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
     assert clt.stderr is not None
+    assert clt.outputs[0].outputBinding is not None
     assert clt.stderr == clt.outputs[0].outputBinding.glob
 
 
@@ -956,6 +975,7 @@ def test_v1_2_stderr_to_file_preserve_original() -> None:
     )
     cwl_utils.parser.cwl_v1_2_utils.convert_stdstreams_to_files(clt)
     assert clt.stderr == "original.txt"
+    assert clt.outputs[0].outputBinding is not None
     assert clt.stderr == clt.outputs[0].outputBinding.glob
 
 

--- a/src/cwl_utils/tests/test_subscope.py
+++ b/src/cwl_utils/tests/test_subscope.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Test that scoping of identifiers in Workflow.steps[].run is correct."""
 
-from cwl_utils.parser import Workflow, load_document_by_uri
+from cwl_utils.parser import Workflow, load_document_by_uri, Process
 
 from .util import get_path
 
@@ -10,6 +10,7 @@ def test_workflow_step_process_scope_v1_0() -> None:
     """CWL v1.0 IDs under Workflow.steps[].run should not be scoped in the "run" scope."""
     uri = get_path("testdata/workflow_input_format_expr.cwl").as_uri()
     cwl_obj: Workflow = load_document_by_uri(uri)
+    assert isinstance(cwl_obj.steps[0].run, Process)
     assert cwl_obj.steps[0].run.inputs[0].id.endswith("#format_extract/target")
 
 
@@ -17,6 +18,7 @@ def test_workflow_step_process_scope_v1_1() -> None:
     """CWL v1.1 IDs under Workflow.steps[].run should be scoped in the "run" scope."""
     uri = get_path("testdata/workflow_input_format_expr_v1_1.cwl").as_uri()
     cwl_obj: Workflow = load_document_by_uri(uri)
+    assert isinstance(cwl_obj.steps[0].run, Process)
     assert cwl_obj.steps[0].run.inputs[0].id.endswith("#format_extract/run/target")
 
 
@@ -24,4 +26,5 @@ def test_workflow_step_process_scope_v1_2() -> None:
     """CWL v1.2 IDs under Workflow.steps[].run should be scoped in the "run" scope."""
     uri = get_path("testdata/workflow_input_format_expr_v1_2.cwl").as_uri()
     cwl_obj: Workflow = load_document_by_uri(uri)
+    assert isinstance(cwl_obj.steps[0].run, Process)
     assert cwl_obj.steps[0].run.inputs[0].id.endswith("#format_extract/run/target")

--- a/src/cwl_utils/types.py
+++ b/src/cwl_utils/types.py
@@ -3,7 +3,8 @@
 """Shared Python type definitions for commons JSON like CWL objects."""
 
 import sys
-from collections.abc import Mapping, MutableMapping, MutableSequence
+from collections import namedtuple
+from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
 from typing import Any, Literal, TypeAlias, TypedDict, TypeGuard
 
 if sys.version_info >= (3, 13):
@@ -79,6 +80,7 @@ CWLOutputType: TypeAlias = (
 )
 CWLObjectType: TypeAlias = MutableMapping[str, CWLOutputType | None]
 SinkType: TypeAlias = CWLOutputType | CWLObjectType
+SrcSink = namedtuple("SrcSink", ["src", "sink", "linkMerge", "message"])
 
 
 class CWLRuntimeParameterContext(TypedDict, total=False):
@@ -161,3 +163,7 @@ def is_file_or_directory(
     value: Any,
 ) -> TypeIs[CWLFileType | CWLDirectoryType]:
     return isinstance(value, Mapping) and value.get("class") in ("File", "Directory")
+
+
+def is_sequence(thing: object) -> TypeIs[Sequence[Any]]:
+    return isinstance(thing, Sequence) and not isinstance(thing, str | bytes)

--- a/src/cwl_utils/utils.py
+++ b/src/cwl_utils/utils.py
@@ -7,11 +7,11 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import MutableMapping, MutableSequence
+from collections.abc import MutableMapping, MutableSequence, Sequence
 from copy import deepcopy
 from importlib.resources import files
 from io import StringIO
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from ruamel.yaml.main import YAML
@@ -22,7 +22,7 @@ from cwl_utils.errors import MissingKeyField
 from cwl_utils.loghandler import _logger
 
 # Type hinting
-from cwl_utils.parser import cwl_v1_0, cwl_v1_1, cwl_v1_2
+from cwl_utils.parser import cwl_v1_0, cwl_v1_1, cwl_v1_2, WorkflowStep
 
 # Load as 1.2 files
 from cwl_utils.parser.cwl_v1_2 import InputArraySchema as InputArraySchemaV1_2
@@ -415,11 +415,15 @@ def sanitise_schema_field(
         case {"type": {"type": "enum", **rest}}:
             schema_field_item["type"] = InputEnumSchemaV1_2(
                 type_="enum",
-                symbols=rest.get("symbols", ""),
+                symbols=cast(Sequence[str], rest.get("symbols", [])),
             )
         case {"type": {"type": "array", **rest}}:
             schema_field_item["type"] = InputArraySchemaV1_2(
-                type_="array", items=rest.get("items", "")
+                type_="array",
+                items=cast(
+                    cwl_v1_2.InputParameterType,
+                    rest.get("items", ""),
+                ),
             )
         case {"type": {"$import": _}}:
             pass  # Leave import as is
@@ -452,6 +456,17 @@ def is_local_uri(uri: str) -> bool:
     if is_uri(uri) and urlparse(uri).scheme == "file":
         return True
     return False
+
+
+def get_step_uri(step: WorkflowStep) -> str:
+    if not isinstance(step.run, str):
+        raise Exception(
+            f"Impossible to retrieve URI for step {step.id}: it embeds a process"
+        )
+    return step.loadingOptions.fetcher.urljoin(
+        base_url=cast(str, step.loadingOptions.fileuri),
+        url=step.run,
+    )
 
 
 def get_value_from_uri(uri: str) -> str:


### PR DESCRIPTION
Regenerate the v1.0, v1.1, and v1.2 CWL parsers using the latest Schema SALAD version, which adds type annotations to classes, loaders, and fields (`FieldType`, `EnumFieldType`, generic `Loader[FieldType]`, etc.).

Adjust all downstream machinery to resolve the resulting type errors:

- Update type aliases in `cwl_utils.parser` (`PrimitiveType`, `InputParameterType`, `OutputParameterType`, `CommandInputParameterType`, `CommandOutputParameterType`, `EnvironmentDef`, `CWLVersion`, `CWLTypeSchema`, `ParameterType`, `ParameterTypeOrArraySchema`)
- Harden `cwl_utils.types` with `is_sequence()` and the `SrcSink` namedtuple
- Fix expression refactorors, `inputs_schema_gen` (anonymous array schemas, `Sequence` doc values, `SchemaDefRequirement` cast), docker/cite extraction, and `cwl_utils.utils`
- Adjust tests according to the new typing utilities