### PR TITLE
Make `type_for_source` require an explicit `cwlVersion`

### DIFF
--- a/src/cwl_utils/parser/utils.py
+++ b/src/cwl_utils/parser/utils.py
@@ -4,7 +4,7 @@ import copy
 import logging
 from collections.abc import MutableSequence
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, cast, Literal
 from urllib.parse import unquote_plus, urlparse
 
 from schema_salad.exceptions import ValidationException
@@ -522,13 +522,14 @@ def static_checker(workflow: Workflow) -> None:
 
 def type_for_source(
     process: Process,
+    cwlVersion: Literal["v1.0", "v1.1", "v1.2"],
     sourcenames: str | list[str],
     parent: Workflow | None = None,
     linkMerge: str | None = None,
     pickValue: str | None = None,
 ) -> Any:
     """Determine the type for the given sourcenames."""
-    match process.cwlVersion:
+    match process.cwlVersion or cwlVersion:
         case "v1.0":
             return cwl_v1_0_utils.type_for_source(
                 cast(
@@ -566,8 +567,6 @@ def type_for_source(
                 linkMerge,
                 pickValue,
             )
-        case None:
-            raise ValidationException("could not get the cwlVersion")
         case _ as cwlVersion:
             raise ValidationException(
                 f"Version error. Did not recognise {cwlVersion} as a CWL version"

--- a/src/cwl_utils/tests/test_parser_utils.py
+++ b/src/cwl_utils/tests/test_parser_utils.py
@@ -295,6 +295,7 @@ def test_v1_0_type_compare_record() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert cwl_utils.parser.cwl_v1_0_utils._compare_type(source_type, source_type)
@@ -305,7 +306,9 @@ def test_v1_0_type_for_source() -> None:
     uri = get_path("testdata/step_valuefrom5_wf_v1_0.cwl").as_uri()
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
-        cwl_obj, cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file"
+        cwl_obj,
+        cwl_obj.cwlVersion,
+        cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file",
     )
     assert source_type == "File"
 
@@ -315,7 +318,9 @@ def test_v1_0_type_for_source_with_id() -> None:
     uri = get_path("testdata/step_valuefrom5_wf_with_id_v1_0.cwl").as_uri()
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
-        cwl_obj, cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file"
+        cwl_obj,
+        cwl_obj.cwlVersion,
+        cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file",
     )
     assert source_type == "File"
 
@@ -325,7 +330,7 @@ def test_v1_0_type_for_stdout() -> None:
     uri = get_path("testdata/stdout-wf_v1_0.cwl").as_uri()
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
-        cwl_obj, cwl_obj.outputs[0].outputSource
+        cwl_obj, cwl_obj.cwlVersion, cwl_obj.outputs[0].outputSource
     )
     assert source_type == "File"
 
@@ -336,6 +341,7 @@ def test_v1_0_type_output_source_record() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, RecordSchema)
@@ -351,6 +357,7 @@ def test_v1_0_type_for_output_source_with_single_scatter_step() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, ArraySchema)
@@ -363,6 +370,7 @@ def test_v1_0_type_for_output_source_with_nested_crossproduct_scatter_step() -> 
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, ArraySchema)
@@ -375,7 +383,9 @@ def test_v1_0_type_for_output_source_with_flat_crossproduct_scatter_step() -> No
     uri = get_path("testdata/scatter-wf3_v1_0.cwl").as_uri()
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
-        process=cwl_obj, sourcenames=cwl_obj.outputs[0].outputSource
+        process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
+        sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, ArraySchema)
     assert source_type.items == "string"
@@ -387,6 +397,7 @@ def test_v1_0_type_for_source_with_multiple_entries_merge_nested() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -401,6 +412,7 @@ def test_v1_0_type_for_source_with_multiple_entries_merge_flattened() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -414,6 +426,7 @@ def test_v1_0_type_for_source_with_single_entry_merge_nested() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -428,6 +441,7 @@ def test_v1_0_type_for_source_with_single_entry_merge_flattened() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -642,6 +656,7 @@ def test_v1_1_type_compare_record() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert cwl_utils.parser.cwl_v1_1_utils._compare_type(source_type, source_type)
@@ -652,7 +667,9 @@ def test_v1_1_type_for_source() -> None:
     uri = get_path("testdata/step_valuefrom5_wf_v1_1.cwl").as_uri()
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
-        cwl_obj, cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file"
+        cwl_obj,
+        cwl_obj.cwlVersion,
+        cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file",
     )
     assert source_type == "File"
 
@@ -662,7 +679,9 @@ def test_v1_1_type_for_source_with_id() -> None:
     uri = get_path("testdata/step_valuefrom5_wf_with_id_v1_1.cwl").as_uri()
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
-        cwl_obj, cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file"
+        cwl_obj,
+        cwl_obj.cwlVersion,
+        cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file",
     )
     assert source_type == "File"
 
@@ -672,7 +691,7 @@ def test_v1_1_type_for_stdout() -> None:
     uri = get_path("testdata/stdout-wf_v1_1.cwl").as_uri()
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
-        cwl_obj, cwl_obj.outputs[0].outputSource
+        cwl_obj, cwl_obj.cwlVersion, cwl_obj.outputs[0].outputSource
     )
     assert source_type == "File"
 
@@ -683,6 +702,7 @@ def test_v1_1_type_output_source_record() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, RecordSchema)
@@ -698,6 +718,7 @@ def test_v1_1_type_for_output_source_with_single_scatter_step() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, ArraySchema)
@@ -710,6 +731,7 @@ def test_v1_1_type_for_output_source_with_nested_crossproduct_scatter_step() -> 
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, ArraySchema)
@@ -723,6 +745,7 @@ def test_v1_1_type_for_output_source_with_flat_crossproduct_scatter_step() -> No
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, ArraySchema)
@@ -735,6 +758,7 @@ def test_v1_1_type_for_source_with_multiple_entries_merge_nested() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -749,6 +773,7 @@ def test_v1_1_type_for_source_with_multiple_entries_merge_flattened() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -762,6 +787,7 @@ def test_v1_1_type_for_source_with_single_entry_merge_nested() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -776,6 +802,7 @@ def test_v1_1_type_for_source_with_single_entry_merge_flattened() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -990,6 +1017,7 @@ def test_v1_2_type_compare_record() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert cwl_utils.parser.cwl_v1_2_utils._compare_type(source_type, source_type)
@@ -1000,7 +1028,9 @@ def test_v1_2_type_for_source() -> None:
     uri = get_path("testdata/step_valuefrom5_wf_v1_2.cwl").as_uri()
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
-        cwl_obj, cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file"
+        cwl_obj,
+        cwl_obj.cwlVersion,
+        cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file",
     )
     assert source_type == "File"
 
@@ -1010,7 +1040,9 @@ def test_v1_2_type_for_source_with_id() -> None:
     uri = get_path("testdata/step_valuefrom5_wf_with_id_v1_2.cwl").as_uri()
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
-        cwl_obj, cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file"
+        cwl_obj,
+        cwl_obj.cwlVersion,
+        cwl_obj.loadingOptions.fileuri + "#step1/echo_out_file",
     )
     assert source_type == "File"
 
@@ -1020,7 +1052,7 @@ def test_v1_2_type_for_stdout() -> None:
     uri = get_path("testdata/stdout-wf_v1_2.cwl").as_uri()
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
-        cwl_obj, cwl_obj.outputs[0].outputSource
+        cwl_obj, cwl_obj.cwlVersion, cwl_obj.outputs[0].outputSource
     )
     assert source_type == "File"
 
@@ -1031,6 +1063,7 @@ def test_v1_2_type_output_source_record() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, RecordSchema)
@@ -1046,6 +1079,7 @@ def test_v1_2_type_for_output_source_with_single_scatter_step() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, ArraySchema)
@@ -1058,6 +1092,7 @@ def test_v1_2_type_for_output_source_with_nested_crossproduct_scatter_step() -> 
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, ArraySchema)
@@ -1071,6 +1106,7 @@ def test_v1_2_type_for_output_source_with_flat_crossproduct_scatter_step() -> No
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
     )
     assert isinstance(source_type, ArraySchema)
@@ -1083,6 +1119,7 @@ def test_v1_2_type_for_source_with_multiple_entries_merge_nested() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -1097,6 +1134,7 @@ def test_v1_2_type_for_source_with_multiple_entries_merge_flattened() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -1110,6 +1148,7 @@ def test_v1_2_type_for_source_with_single_entry_merge_nested() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -1124,6 +1163,7 @@ def test_v1_2_type_for_source_with_single_entry_merge_flattened() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.steps[0].in_[0].source,
         linkMerge=cwl_obj.steps[0].in_[0].linkMerge,
     )
@@ -1137,6 +1177,7 @@ def test_v1_2_type_for_source_with_multiple_entries_first_non_null() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
         pickValue=cwl_obj.outputs[0].pickValue,
     )
@@ -1149,6 +1190,7 @@ def test_v1_2_type_for_source_with_multiple_entries_the_only_non_null() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
         pickValue=cwl_obj.outputs[0].pickValue,
     )
@@ -1161,6 +1203,7 @@ def test_v1_2_type_for_source_with_multiple_entries_all_non_null() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
         pickValue=cwl_obj.outputs[0].pickValue,
     )
@@ -1174,6 +1217,7 @@ def test_v1_2_type_for_source_with_single_entry_first_non_null() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
         pickValue=cwl_obj.outputs[0].pickValue,
     )
@@ -1186,6 +1230,7 @@ def test_v1_2_type_for_source_with_single_entry_the_only_non_null() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
         pickValue=cwl_obj.outputs[0].pickValue,
     )
@@ -1198,6 +1243,7 @@ def test_v1_2_type_for_source_with_single_entry_all_non_null() -> None:
     cwl_obj = load_document_by_uri(uri)
     source_type = cwl_utils.parser.utils.type_for_source(
         process=cwl_obj,
+        cwlVersion=cwl_obj.cwlVersion,
         sourcenames=cwl_obj.outputs[0].outputSource,
         pickValue=cwl_obj.outputs[0].pickValue,
     )


### PR DESCRIPTION
Change `type_for_source` to take a `cwlVersion` argument instead of relying on `process.cwlVersion`, which may be `None`. This lets callers pass the version explicitly and removes the `ValidationException` branch for a missing version.

Update tests to pass `cwl_obj.cwlVersion` to `type_for_source`.